### PR TITLE
Dependabot Bumps

### DIFF
--- a/source/dotnet/IntegrationTests.Core/IntegrationTests.Core.csproj
+++ b/source/dotnet/IntegrationTests.Core/IntegrationTests.Core.csproj
@@ -22,8 +22,8 @@ limitations under the License.
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="2.3.3" />
-        <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="2.3.3" />
+        <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="2.3.4" />
+        <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="2.3.4" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="Moq" Version="4.18.1" />

--- a/source/dotnet/IntegrationTests.Core/IntegrationTests.Core.csproj
+++ b/source/dotnet/IntegrationTests.Core/IntegrationTests.Core.csproj
@@ -32,7 +32,7 @@ limitations under the License.
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/source/dotnet/IntegrationTests/IntegrationTests.csproj
+++ b/source/dotnet/IntegrationTests/IntegrationTests.csproj
@@ -31,7 +31,7 @@ limitations under the License.
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/source/dotnet/Tests/Tests.csproj
+++ b/source/dotnet/Tests/Tests.csproj
@@ -30,7 +30,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="2.3.3" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="2.3.4" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Bumps the following packages:

- [Energinet.DataHub.Core.TestCommon](https://github.com/Energinet-DataHub/geh-core) from 2.3.3 to 2.3.4.
- [Energinet.DataHub.Core.FunctionApp.TestCommon](https://github.com/Energinet-DataHub/geh-core) from 2.3.3 to 2.3.4.
- [coverlet.collector](https://github.com/coverlet-coverage/coverlet) from 3.1.0 to 3.1.2.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #56 #52 
