### PR TITLE
Fail fast

### DIFF
--- a/source/dotnet/WebApi/Configuration/ServiceCollectionExtensions.cs
+++ b/source/dotnet/WebApi/Configuration/ServiceCollectionExtensions.cs
@@ -39,16 +39,14 @@ internal static class ServiceCollectionExtensions
         serviceCollection.AddScoped<IJwtTokenValidator, JwtTokenValidator>();
         serviceCollection.AddScoped<IClaimsPrincipalAccessor, ClaimsPrincipalAccessor>();
         serviceCollection.AddScoped<ClaimsPrincipalContext>();
-        serviceCollection.AddScoped(_ =>
-        {
-            var address = Environment.GetEnvironmentVariable(EnvironmentSettingNames.FrontEndOpenIdUrl) ??
-                          throw new Exception(
-                              $"Function app is missing required environment variable '{EnvironmentSettingNames.FrontEndOpenIdUrl}'");
-            var audience = Environment.GetEnvironmentVariable(EnvironmentSettingNames.FrontEndServiceAppId) ??
-                           throw new Exception(
-                               $"Function app is missing required environment variable '{EnvironmentSettingNames.FrontEndServiceAppId}'");
-            return new OpenIdSettings(address, audience);
-        });
+
+        var address = Environment.GetEnvironmentVariable(EnvironmentSettingNames.FrontEndOpenIdUrl) ??
+                      throw new Exception(
+                          $"Function app is missing required environment variable '{EnvironmentSettingNames.FrontEndOpenIdUrl}'");
+        var audience = Environment.GetEnvironmentVariable(EnvironmentSettingNames.FrontEndServiceAppId) ??
+                       throw new Exception(
+                           $"Function app is missing required environment variable '{EnvironmentSettingNames.FrontEndServiceAppId}'");
+        serviceCollection.AddScoped(_ => new OpenIdSettings(address, audience));
     }
 
     public static void AddCommandStack(this IServiceCollection services, IConfiguration configuration)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Make the web API fail on startup instead of waiting for the first request requiring authentication when settings are missing.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #33
