### PR TITLE
Test user authentication

### DIFF
--- a/source/dotnet/IntegrationTests.Core/Fixtures/WebApi/WholesaleWebApiFixture.cs
+++ b/source/dotnet/IntegrationTests.Core/Fixtures/WebApi/WholesaleWebApiFixture.cs
@@ -52,6 +52,7 @@ namespace Energinet.DataHub.Wholesale.IntegrationTests.Core.Fixtures.WebApi
 
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.FrontEndOpenIdUrl, AuthorizationConfiguration.FrontendOpenIdUrl);
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.FrontEndServiceAppId, AuthorizationConfiguration.FrontendAppId);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Testing");
             await Task.CompletedTask;
         }
 

--- a/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
+++ b/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
@@ -50,7 +50,7 @@ public class BearerTokenTests :
     public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
-    public async Task Request_missing_bearer_token_returns_401_Unauthorized()
+    public async Task Request_WhenMissingBearerToken_Returns401Unauthorized()
     {
         // Arrange
         using var client = _factory.CreateClient();
@@ -65,7 +65,7 @@ public class BearerTokenTests :
     }
 
     [Fact]
-    public async Task Request_with_invalid_bearer_token_returns_401_Unauthorized()
+    public async Task Request_WhenInvalidBearerToken_Returns401Unauthorized()
     {
         // Arrange
         using var client = _factory.CreateClient();
@@ -80,7 +80,7 @@ public class BearerTokenTests :
     }
 
     [Fact]
-    public async Task Request_with_valid_bearer_token_does_not_return_401_Unauthorized()
+    public async Task Request_WhenValidBearerToken_DoesNotReturn401Unauthorized()
     {
         // Arrange
         using var client = _factory.CreateClient();

--- a/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
+++ b/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
@@ -1,0 +1,83 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using Energinet.DataHub.Wholesale.IntegrationTests.Core.Fixtures.WebApi;
+using Energinet.DataHub.Wholesale.IntegrationTests.Core.TestCommon.WebApi;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+namespace Energinet.DataHub.Wholesale.IntegrationTests.WebApi;
+
+[IntegrationTest]
+[Collection(nameof(BearerTokenTests))]
+public class BearerTokenTests :
+    WebApiTestBase<WholesaleWebApiFixture>,
+    IClassFixture<WholesaleWebApiFixture>,
+    IClassFixture<WebApiFactory>,
+    IAsyncLifetime
+{
+    private const string BaseUrl = "/v1/batch";
+    private const bool SuppliedJwtTokenIsValid = true;
+    private const bool SuppliedJwtTokenIsInValid = false;
+    private const string JwtBearerHttpHeader = "Authorization";
+    private const string JwtBearerToken = "Bearer xxx";
+
+    private readonly WebApiFactory _factory;
+
+    public BearerTokenTests(
+        WholesaleWebApiFixture wholesaleWebApiFixture,
+        WebApiFactory factory,
+        ITestOutputHelper testOutputHelper)
+        : base(wholesaleWebApiFixture, testOutputHelper)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Request_missing_bearer_token_returns_401_Unauthorized()
+    {
+        // Arrange
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Remove("Authorization");
+        _factory.ReconfigureJwtTokenValidatorMock(SuppliedJwtTokenIsValid);
+
+        // Act
+        var response = await client.GetAsync(BaseUrl);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Request_with_invalid_bearer_token_returns_401_Unauthorized()
+    {
+        // Arrange
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add(JwtBearerHttpHeader, JwtBearerToken);
+        _factory.ReconfigureJwtTokenValidatorMock(SuppliedJwtTokenIsInValid);
+
+        // Act
+        var response = await client.GetAsync(BaseUrl);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
+++ b/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
@@ -30,7 +30,7 @@ public class BearerTokenTests :
 {
     private const string BaseUrl = "/v1/batch";
     private const bool SuppliedJwtTokenIsValid = true;
-    private const bool SuppliedJwtTokenIsInValid = false;
+    private const bool SuppliedJwtTokenIsInvalid = false;
     private const string JwtBearerHttpHeader = "Authorization";
     private const string JwtBearerToken = "Bearer xxx";
 
@@ -70,7 +70,7 @@ public class BearerTokenTests :
         // Arrange
         using var client = _factory.CreateClient();
         client.DefaultRequestHeaders.Add(JwtBearerHttpHeader, JwtBearerToken);
-        _factory.ReconfigureJwtTokenValidatorMock(SuppliedJwtTokenIsInValid);
+        _factory.ReconfigureJwtTokenValidatorMock(SuppliedJwtTokenIsInvalid);
 
         // Act
         var response = await client.GetAsync(BaseUrl);

--- a/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
+++ b/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
@@ -78,4 +78,19 @@ public class BearerTokenTests :
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
+
+    [Fact]
+    public async Task Request_with_valid_bearer_token_does_not_return_401_Unauthorized()
+    {
+        // Arrange
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add(JwtBearerHttpHeader, JwtBearerToken);
+        _factory.ReconfigureJwtTokenValidatorMock(SuppliedJwtTokenIsValid);
+
+        // Act
+        var response = await client.GetAsync(BaseUrl);
+
+        // Assert
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+    }
 }

--- a/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
+++ b/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
@@ -18,11 +18,9 @@ using Energinet.DataHub.Wholesale.IntegrationTests.Core.TestCommon.WebApi;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Categories;
 
 namespace Energinet.DataHub.Wholesale.IntegrationTests.WebApi;
 
-[IntegrationTest]
 [Collection(nameof(BearerTokenTests))]
 public class BearerTokenTests :
     WebApiTestBase<WholesaleWebApiFixture>,

--- a/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
+++ b/source/dotnet/IntegrationTests/WebApi/BearerTokenTests.cs
@@ -54,7 +54,7 @@ public class BearerTokenTests :
     {
         // Arrange
         using var client = _factory.CreateClient();
-        client.DefaultRequestHeaders.Remove("Authorization");
+        client.DefaultRequestHeaders.Remove(JwtBearerHttpHeader);
         _factory.ReconfigureJwtTokenValidatorMock(SuppliedJwtTokenIsValid);
 
         // Act

--- a/source/dotnet/IntegrationTests/WebApi/V1/BatchControllerTests.cs
+++ b/source/dotnet/IntegrationTests/WebApi/V1/BatchControllerTests.cs
@@ -71,13 +71,4 @@ public class BatchControllerTests :
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
-
-    [Fact]
-    public async Task Request_missing_bearer_token_returns_401_Unauthorized()
-    {
-        _client.DefaultRequestHeaders.Remove("Authorization");
-        var response = await _client.GetAsync(BaseUrl);
-
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
-    }
 }

--- a/source/dotnet/IntegrationTests/WebApi/V1/BatchControllerTests.cs
+++ b/source/dotnet/IntegrationTests/WebApi/V1/BatchControllerTests.cs
@@ -71,4 +71,13 @@ public class BatchControllerTests :
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
+
+    [Fact]
+    public async Task Request_missing_bearer_token_returns_401_Unauthorized()
+    {
+        _client.DefaultRequestHeaders.Remove("Authorization");
+        var response = await _client.GetAsync(BaseUrl);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
 }


### PR DESCRIPTION
## Description

Add test cases to verify that a token is validated when a request is processed.

The reason for changing the `ASPNETCORE_ENVIRONMENT` environmental variable is that it alters the code path in `Startup.cs`. With a value of `Testing` we skip the _Developer experience_ and match that of production.

``` csharp
if (env.IsDevelopment()) <- this prevents us from adding the middleware
{
   app.UseDeveloperExceptionPage();
   app.UseSwagger();
   app.UseSwaggerUI();
}
else
{
   // This middleware has to be configured after 'UseRouting' for 'AllowAnonymousAttribute' to work.
   // We dont want JwtToken when running locally
   app.UseMiddleware<JwtTokenMiddleware>();
}
```
