### PR TITLE
refac: meteringpointId -> gsrnNumber

### DIFF
--- a/source/dotnet/IntegrationEventListener/MeteringPoints/MeteringPointCreatedDto.cs
+++ b/source/dotnet/IntegrationEventListener/MeteringPoints/MeteringPointCreatedDto.cs
@@ -17,7 +17,7 @@ using NodaTime;
 namespace Energinet.DataHub.Wholesale.IntegrationEventListener.MeteringPoints;
 
 public record MeteringPointCreatedDto(
-    string MeteringPointId,
+    string GsrnNumber,
     Guid GridAreaLinkId,
     SettlementMethod? SettlementMethod,
     ConnectionState ConnectionState,

--- a/source/dotnet/Tests/IntegrationEventListener/MeteringPointCreatedDtoFactoryTests.cs
+++ b/source/dotnet/Tests/IntegrationEventListener/MeteringPointCreatedDtoFactoryTests.cs
@@ -101,7 +101,7 @@ namespace Energinet.DataHub.Wholesale.Tests.IntegrationEventListener
 
             // Assert
             actual.Should().NotContainNullsOrEmptyEnumerables();
-            actual.MeteringPointId.Should().Be(meteringPointCreatedEvent.GsrnNumber);
+            actual.GsrnNumber.Should().Be(meteringPointCreatedEvent.GsrnNumber);
             actual.EffectiveDate.Should().Be(meteringPointCreatedEvent.EffectiveDate.ToInstant());
             actual.GridAreaLinkId.Should().Be(meteringPointCreatedEvent.GridAreaCode);
             actual.SettlementMethod.Should().Be(SettlementMethod.Flex);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Using the GsrnNumber as the MeteringpointId is confusing. Not only is the meteringpointId exposed as another value, but it also represents the actual Id given to the entity in the metering point domain. Not the actual ID for the metering point.

* #76 
