### PR TITLE
Update kv secret name to match new name in "shared resources"

### DIFF
--- a/build/infrastructure/main/func-integrationeventlistener.tf
+++ b/build/infrastructure/main/func-integrationeventlistener.tf
@@ -42,7 +42,7 @@ module "func_integrationeventlistener" {
     METERING_POINT_CREATED_TOPIC_NAME                     = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sbt-metering-point-created-name)"
     METERING_POINT_CONNECTED_SUBSCRIPTION_NAME            = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sbs-metering-point-connected-to-wholesale-name)"
     METERING_POINT_CONNECTED_TOPIC_NAME                   = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sbt-metering-point-connected-name)"
-    MARKET_PARTICIPANT_CHANGED_SUBSCRIPTION_NAME          = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sbs-market-participant-changed-to-aggregations-name)"
+    MARKET_PARTICIPANT_CHANGED_SUBSCRIPTION_NAME          = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sbs-market-participant-changed-to-wholesale-name)"
     MARKET_PARTICIPANT_CHANGED_TOPIC_NAME                 = "@Microsoft.KeyVault(VaultName=${var.shared_resources_keyvault_name};SecretName=sbt-market-participant-changed-name)"
   }
 


### PR DESCRIPTION
## Description

Name of KV secret was changed in "shared resources" by this PR: https://github.com/Energinet-DataHub/geh-shared-resources/pull/232

Current PR ensures we use the new KV secret name.
