### PR TITLE
add stored time

### DIFF
--- a/source/databricks/package/integration_events_persister.py
+++ b/source/databricks/package/integration_events_persister.py
@@ -17,7 +17,7 @@ import sys
 sys.path.append(r"/workspaces/opengeh-wholesale/source/databricks")
 
 from pyspark.sql import DataFrame
-from pyspark.sql.functions import year, month, dayofmonth, col, from_json
+from pyspark.sql.functions import year, month, dayofmonth, col, from_json, current_timestamp
 
 
 # integration_events_persister
@@ -29,9 +29,10 @@ def integration_events_persister(
 
     events = (
         streamingDf
-        .withColumn("year", year(col("enqueuedTime")))
-        .withColumn("month", month(col("enqueuedTime")))
-        .withColumn("day", dayofmonth(col("enqueuedTime")))
+        .withColumn("storedTime", current_timestamp())
+        .withColumn("year", year(col("storedTime")))
+        .withColumn("month", month(col("storedTime")))
+        .withColumn("day", dayofmonth(col("storedTime")))
     )
 
     (


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description
Adding storedTime of when data was stored in the parquet table. This is used for partitioning. And for filtering on time when we want to know how data looked at a specific time in history

## References
* #32
