### PR TITLE
fix: Try to improve database outtage related errors

### DIFF
--- a/source/dotnet/IntegrationTests/Fixture/Database/SenderDatabaseManager.cs
+++ b/source/dotnet/IntegrationTests/Fixture/Database/SenderDatabaseManager.cs
@@ -30,7 +30,11 @@ public class SenderDatabaseManager : SqlServerDatabaseManager<DatabaseContext>
     public override DatabaseContext CreateDbContext()
     {
         var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>()
-            .UseSqlServer(ConnectionString, options => options.UseNodaTime());
+            .UseSqlServer(ConnectionString, options =>
+            {
+                options.UseNodaTime();
+                options.EnableRetryOnFailure();
+            });
 
         return new DatabaseContext(optionsBuilder.Options);
     }

--- a/source/dotnet/IntegrationTests/Fixture/Database/WholesaleDatabaseManager.cs
+++ b/source/dotnet/IntegrationTests/Fixture/Database/WholesaleDatabaseManager.cs
@@ -30,7 +30,11 @@ public class WholesaleDatabaseManager : SqlServerDatabaseManager<DatabaseContext
     public override DatabaseContext CreateDbContext()
     {
         var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>()
-            .UseSqlServer(ConnectionString, options => options.UseNodaTime());
+            .UseSqlServer(ConnectionString, options =>
+            {
+                options.UseNodaTime();
+                options.EnableRetryOnFailure();
+            });
 
         return new DatabaseContext(optionsBuilder.Options);
     }

--- a/source/dotnet/ProcessManager/Program.cs
+++ b/source/dotnet/ProcessManager/Program.cs
@@ -102,7 +102,11 @@ public class Program
         var connectionString =
             EnvironmentVariableHelper.GetEnvVariable(EnvironmentSettingNames.DatabaseConnectionString);
         serviceCollection.AddDbContext<DatabaseContext>(options =>
-            options.UseSqlServer(connectionString, o => o.UseNodaTime()));
+            options.UseSqlServer(connectionString, o =>
+            {
+                o.UseNodaTime();
+                o.EnableRetryOnFailure();
+            }));
 
         var serviceBusConnectionString =
             EnvironmentVariableHelper.GetEnvVariable(EnvironmentSettingNames.ServiceBusSendConnectionString);

--- a/source/dotnet/Sender/Program.cs
+++ b/source/dotnet/Sender/Program.cs
@@ -91,7 +91,11 @@ public static class Program
         var connectionString =
             EnvironmentVariableHelper.GetEnvVariable(EnvironmentSettingNames.DatabaseConnectionString);
         serviceCollection.AddDbContext<DatabaseContext>(options =>
-            options.UseSqlServer(connectionString, o => o.UseNodaTime()));
+            options.UseSqlServer(connectionString, o =>
+            {
+                o.UseNodaTime();
+                o.EnableRetryOnFailure();
+            }));
 
         serviceCollection.AddScoped<ICalculatedResultReader, CalculatedResultsReader>();
     }

--- a/source/dotnet/WebApi/Configuration/ServiceCollectionExtensions.cs
+++ b/source/dotnet/WebApi/Configuration/ServiceCollectionExtensions.cs
@@ -57,7 +57,11 @@ internal static class ServiceCollectionExtensions
             throw new ArgumentNullException(EnvironmentSettingNames.DbConnectionString, "does not exist in configuration settings");
 
         services.AddDbContext<DatabaseContext>(
-            options => options.UseSqlServer(connectionString, o => o.UseNodaTime()));
+            options => options.UseSqlServer(connectionString, o =>
+            {
+                o.UseNodaTime();
+                o.EnableRetryOnFailure();
+            }));
 
         services.AddScoped<IDatabaseContext, DatabaseContext>();
         services.AddScoped<IUnitOfWork, UnitOfWork>();


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Try to improve database recilliency with Entity Framework. See
- [this documentation](https://docs.microsoft.com/en-us/ef/core/miscellaneous/connection-resiliency)
- [this error](https://portal.azure.com/#view/AppInsightsExtension/DetailsV2Blade/ComponentId~/%7B%22SubscriptionId%22%3A%220f12dae0-3f9d-46ae-93a7-7091ff0b950d%22%2C%22ResourceGroup%22%3A%22rg-DataHub-SharedResouces-B-002%22%2C%22Name%22%3A%22appi-shared-sharedres-b-002%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252F0f12dae0-3f9d-46ae-93a7-7091ff0b950d%252FresourceGroups%252Frg-DataHub-SharedResouces-B-002%252Fproviders%252FMicrosoft.Insights%252Fcomponents%252Fappi-shared-sharedres-b-002%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel~/%7B%22eventId%22%3A%2225573f97-16fd-11ed-90e0-000d3aaba7b4%22%2C%22timestamp%22%3A%222022-08-08T09%3A32%3A19.296Z%22%2C%22cacheId%22%3A%2201973dd8-b080-45e7-83fc-29e0a03ed926%22%2C%22eventTable%22%3A%22exceptions%22%2C%22timeContext%22%3A%7B%22durationMs%22%3A86400000%2C%22endTime%22%3A%222022-08-08T10%3A30%3A41.363Z%22%7D%7D)
![image](https://user-images.githubusercontent.com/11583438/183400868-a4d8bdc5-17cd-4aa3-92af-961b5d01814f.png)



<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
