### PR TITLE
fix: Update market participant package to fix receival of events

### DIFF
--- a/source/dotnet/IntegrationEventListener/IntegrationEventListener.csproj
+++ b/source/dotnet/IntegrationEventListener/IntegrationEventListener.csproj
@@ -35,7 +35,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="6.0.4" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="4.0.2" />
-    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0" />
+    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.4.1" />
     <PackageReference Include="Energinet.DataHub.MeteringPoints.IntegrationEvents" Version="1.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Error in b-002 [here](https://portal.azure.com/#view/AppInsightsExtension/DetailsV2Blade/ComponentId~/%7B%22SubscriptionId%22%3A%220f12dae0-3f9d-46ae-93a7-7091ff0b950d%22%2C%22ResourceGroup%22%3A%22rg-DataHub-SharedResouces-B-002%22%2C%22Name%22%3A%22appi-shared-sharedres-b-002%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252F0f12dae0-3f9d-46ae-93a7-7091ff0b950d%252FresourceGroups%252Frg-DataHub-SharedResouces-B-002%252Fproviders%252FMicrosoft.Insights%252Fcomponents%252Fappi-shared-sharedres-b-002%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel~/%7B%22eventId%22%3A%22828e83ab-17c5-11ed-90e0-000d3aac8608%22%2C%22timestamp%22%3A%222022-08-09T09%3A26%3A59.127Z%22%2C%22cacheId%22%3A%2212f52e07-6fa6-48e1-97c7-f73c58afc587%22%2C%22eventTable%22%3A%22exceptions%22%2C%22timeContext%22%3A%7B%22durationMs%22%3A86400000%2C%22endTime%22%3A%222022-08-10T08%3A11%3A17.761Z%22%7D%7D).

![image](https://user-images.githubusercontent.com/11583438/183854126-81e08377-4ac3-4058-83e7-e406f6d57fb2.png)

The anticipation is that the NuGet package is outdated and thus fails to parse new events. This PR updates to the latest version of the NuGet package.

I have reached out to @FirestarJes  of team Titans to ask for a more helpful error message. Perhaps we also need a project-level talk about how to prevent this kind of problem in the future.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #205
