### PR TITLE
bug: max_retries not applying

### DIFF
--- a/build/infrastructure/main/dbwj-calculator.tf
+++ b/build/infrastructure/main/dbwj-calculator.tf
@@ -14,12 +14,12 @@
 
 resource "databricks_job" "calculator_job" {
   name = "CalculatorJob"
-  max_retries = -1
   max_concurrent_runs = 100
   always_running = false
 
   task {
     task_key = "unique_job_${uuid()}"
+    max_retries = 0
 
     new_cluster {
       spark_version           = data.databricks_spark_version.latest_lts.id

--- a/build/infrastructure/main/dbwj-integrationeventspersister.tf
+++ b/build/infrastructure/main/dbwj-integrationeventspersister.tf
@@ -14,13 +14,14 @@
 
 resource "databricks_job" "integration_events_persister_streaming_job" {
   name = "IntegrationEventsPersisterStreamingJob"
-  max_retries = -1
   max_concurrent_runs = 1   
   always_running = true
 
   task {
     # The job must be recreated with each deployment and this is achieved using a unique resource id.
     task_key = "unique_job_${uuid()}"
+
+    max_retries = -1
 
     new_cluster {
       spark_version           = data.databricks_spark_version.latest_lts.id

--- a/build/infrastructure/main/dbwj-integrationeventspersister.tf
+++ b/build/infrastructure/main/dbwj-integrationeventspersister.tf
@@ -20,7 +20,6 @@ resource "databricks_job" "integration_events_persister_streaming_job" {
   task {
     # The job must be recreated with each deployment and this is achieved using a unique resource id.
     task_key = "unique_job_${uuid()}"
-
     max_retries = -1
 
     new_cluster {


### PR DESCRIPTION
```max_retries``` does not apply to the runs when not placed inside the ```tasks``` section. I cannot find documentation mentioning this, but it appears to work now.

```max_concurrent_runs``` and ```always_running``` are not affected.