### PR TITLE
feat: Restart cancelled runs.

### DIFF
--- a/source/dotnet/Application/Batches/BatchApplicationService.cs
+++ b/source/dotnet/Application/Batches/BatchApplicationService.cs
@@ -84,7 +84,7 @@ public class BatchApplicationService : IBatchApplicationService
             else if (state == JobState.Canceled)
             {
                 // The process manager will automatically pick up the batch and (re)try execution when the status is reset to pending
-                batch.ResetStatus();
+                batch.ResetStatusToPending();
             }
         }
 

--- a/source/dotnet/Application/Batches/BatchApplicationService.cs
+++ b/source/dotnet/Application/Batches/BatchApplicationService.cs
@@ -83,6 +83,7 @@ public class BatchApplicationService : IBatchApplicationService
             }
             else if (state == JobState.Canceled)
             {
+                // The process manager will automatically pick up the batch and (re)try execution when the status is reset to pending
                 batch.ResetStatus();
             }
         }

--- a/source/dotnet/Application/Batches/BatchApplicationService.cs
+++ b/source/dotnet/Application/Batches/BatchApplicationService.cs
@@ -54,7 +54,7 @@ public class BatchApplicationService : IBatchApplicationService
         foreach (var batch in batches)
         {
             var jobRunId = await _jobRunner.SubmitJobAsync(batch).ConfigureAwait(false);
-            batch.SetExecuting(jobRunId);
+            batch.MarkAsExecuting(jobRunId);
             await _unitOfWork.CommitAsync().ConfigureAwait(false);
         }
     }
@@ -78,7 +78,7 @@ public class BatchApplicationService : IBatchApplicationService
 
             if (state == JobState.Completed)
             {
-                batch.Complete();
+                batch.MarkAsCompleted();
                 completedBatches.Add(batch);
             }
             else if (state == JobState.Canceled)

--- a/source/dotnet/Application/Batches/BatchApplicationService.cs
+++ b/source/dotnet/Application/Batches/BatchApplicationService.cs
@@ -83,7 +83,7 @@ public class BatchApplicationService : IBatchApplicationService
             }
             else if (state == JobState.Canceled)
             {
-                batch.Restart();
+                batch.ResetStatus();
             }
         }
 

--- a/source/dotnet/Application/Batches/BatchApplicationService.cs
+++ b/source/dotnet/Application/Batches/BatchApplicationService.cs
@@ -81,6 +81,10 @@ public class BatchApplicationService : IBatchApplicationService
                 batch.Complete();
                 completedBatches.Add(batch);
             }
+            else if (state == JobState.Canceled)
+            {
+                batch.Restart();
+            }
         }
 
         var completedProcesses = CreateProcessCompletedEvents(completedBatches);

--- a/source/dotnet/Domain/BatchAggregate/Batch.cs
+++ b/source/dotnet/Domain/BatchAggregate/Batch.cs
@@ -52,6 +52,15 @@ public class Batch
 
     public JobRunId? RunId { get; private set; }
 
+    public void Restart()
+    {
+        if (ExecutionState == BatchExecutionState.Completed)
+            throw new InvalidOperationException("Batch cannot be restarted because it has completed.");
+
+        ExecutionState = BatchExecutionState.Pending;
+        RunId = null;
+    }
+
     public void Complete()
     {
         if (ExecutionState != BatchExecutionState.Executing)

--- a/source/dotnet/Domain/BatchAggregate/Batch.cs
+++ b/source/dotnet/Domain/BatchAggregate/Batch.cs
@@ -52,8 +52,7 @@ public class Batch
 
     public JobRunId? RunId { get; private set; }
 
-    /// <summary>Reset the status to <see cref="BatchExecutionState.Pending" />.</summary>
-    public void ResetStatus()
+    public void ResetStatusToPending()
     {
         if (ExecutionState == BatchExecutionState.Completed)
             throw new InvalidOperationException("Cannot reset status of a completed batch.");

--- a/source/dotnet/Domain/BatchAggregate/Batch.cs
+++ b/source/dotnet/Domain/BatchAggregate/Batch.cs
@@ -52,6 +52,7 @@ public class Batch
 
     public JobRunId? RunId { get; private set; }
 
+    /// <summary>Reset the status to <see cref="BatchExecutionState.Pending" />.</summary>
     public void ResetStatus()
     {
         if (ExecutionState == BatchExecutionState.Completed)

--- a/source/dotnet/Domain/BatchAggregate/Batch.cs
+++ b/source/dotnet/Domain/BatchAggregate/Batch.cs
@@ -52,16 +52,16 @@ public class Batch
 
     public JobRunId? RunId { get; private set; }
 
-    public void Restart()
+    public void ResetStatus()
     {
         if (ExecutionState == BatchExecutionState.Completed)
-            throw new InvalidOperationException("Batch cannot be restarted because it has completed.");
+            throw new InvalidOperationException("Cannot reset status of a completed batch.");
 
         ExecutionState = BatchExecutionState.Pending;
         RunId = null;
     }
 
-    public void Complete()
+    public void MarkAsCompleted()
     {
         if (ExecutionState != BatchExecutionState.Executing)
             throw new InvalidOperationException("Batch cannot be completed because it is not in state executing.");
@@ -69,7 +69,7 @@ public class Batch
         ExecutionState = BatchExecutionState.Completed;
     }
 
-    public void SetExecuting(JobRunId jobRunId)
+    public void MarkAsExecuting(JobRunId jobRunId)
     {
         ArgumentNullException.ThrowIfNull(jobRunId);
 

--- a/source/dotnet/Tests/Domain/BatchAggregate/BatchTests.cs
+++ b/source/dotnet/Tests/Domain/BatchAggregate/BatchTests.cs
@@ -50,71 +50,71 @@ public class BatchTests
     }
 
     [Fact]
-    public void Complete_WhenPending_ThrowsInvalidOperationException()
+    public void MarkAsCompleted_WhenPending_ThrowsInvalidOperationException()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Pending).Build();
-        Assert.Throws<InvalidOperationException>(() => sut.Complete());
+        Assert.Throws<InvalidOperationException>(() => sut.MarkAsCompleted());
     }
 
     [Fact]
-    public void Complete_WhenComplete_ThrowsInvalidOperationException()
+    public void MarkAsCompleted_WhenComplete_ThrowsInvalidOperationException()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Completed).Build();
-        Assert.Throws<InvalidOperationException>(() => sut.Complete());
+        Assert.Throws<InvalidOperationException>(() => sut.MarkAsCompleted());
     }
 
     [Fact]
-    public void Complete_WhenExecuting_CompletesBatch()
+    public void MarkAsCompleted_WhenExecuting_CompletesBatch()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Executing).Build();
-        sut.Complete();
+        sut.MarkAsCompleted();
         sut.ExecutionState.Should().Be(BatchExecutionState.Completed);
     }
 
     [Fact]
-    public void SetExecuting_WhenExecuting_ThrowsInvalidOperationException()
+    public void MarkAsExecuting_WhenExecuting_ThrowsInvalidOperationException()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Executing).Build();
-        Assert.Throws<InvalidOperationException>(() => sut.SetExecuting(_fakeJobRunId));
+        Assert.Throws<InvalidOperationException>(() => sut.MarkAsExecuting(_fakeJobRunId));
     }
 
     [Fact]
-    public void SetExecuting_WhenComplete_ThrowsInvalidOperationException()
+    public void MarkAsExecuting_WhenComplete_ThrowsInvalidOperationException()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Completed).Build();
-        Assert.Throws<InvalidOperationException>(() => sut.SetExecuting(_fakeJobRunId));
+        Assert.Throws<InvalidOperationException>(() => sut.MarkAsExecuting(_fakeJobRunId));
     }
 
     [Fact]
-    public void SetExecuting_WhenPending_ExecutesBatch()
+    public void MarkAsExecuting_WhenPending_ExecutesBatch()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Pending).Build();
-        sut.SetExecuting(_fakeJobRunId);
+        sut.MarkAsExecuting(_fakeJobRunId);
         sut.ExecutionState.Should().Be(BatchExecutionState.Executing);
     }
 
     [Fact]
-    public void Restart_WhenPending_KeepsPendingState()
+    public void ResetStatus_WhenPending_KeepsPendingState()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Pending).Build();
-        sut.Restart();
+        sut.ResetStatus();
         sut.ExecutionState.Should().Be(BatchExecutionState.Pending);
     }
 
     [Fact]
-    public void Restart_WhenExecuting_ShouldRevertToPending()
+    public void ResetStatus_WhenExecuting_ShouldRevertToPending()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Pending).Build();
-        sut.SetExecuting(_fakeJobRunId);
-        sut.Restart();
+        sut.MarkAsExecuting(_fakeJobRunId);
+        sut.ResetStatus();
         sut.ExecutionState.Should().Be(BatchExecutionState.Pending);
         sut.RunId.Should().BeNull();
     }
 
     [Fact]
-    public void Restart_WhenComplete_ThrowsInvalidOperationException()
+    public void ResetStatus_WhenComplete_ThrowsInvalidOperationException()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Completed).Build();
-        Assert.Throws<InvalidOperationException>(() => sut.Restart());
+        Assert.Throws<InvalidOperationException>(() => sut.ResetStatus());
     }
 }

--- a/source/dotnet/Tests/Domain/BatchAggregate/BatchTests.cs
+++ b/source/dotnet/Tests/Domain/BatchAggregate/BatchTests.cs
@@ -92,4 +92,29 @@ public class BatchTests
         sut.SetExecuting(_fakeJobRunId);
         sut.ExecutionState.Should().Be(BatchExecutionState.Executing);
     }
+
+    [Fact]
+    public void Restart_WhenPending_KeepsPendingState()
+    {
+        var sut = new BatchBuilder().WithState(BatchExecutionState.Pending).Build();
+        sut.Restart();
+        sut.ExecutionState.Should().Be(BatchExecutionState.Pending);
+    }
+
+    [Fact]
+    public void Restart_WhenExecuting_ShouldRevertToPending()
+    {
+        var sut = new BatchBuilder().WithState(BatchExecutionState.Pending).Build();
+        sut.SetExecuting(_fakeJobRunId);
+        sut.Restart();
+        sut.ExecutionState.Should().Be(BatchExecutionState.Pending);
+        sut.RunId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Restart_WhenComplete_ThrowsInvalidOperationException()
+    {
+        var sut = new BatchBuilder().WithState(BatchExecutionState.Completed).Build();
+        Assert.Throws<InvalidOperationException>(() => sut.Restart());
+    }
 }

--- a/source/dotnet/Tests/Domain/BatchAggregate/BatchTests.cs
+++ b/source/dotnet/Tests/Domain/BatchAggregate/BatchTests.cs
@@ -94,27 +94,27 @@ public class BatchTests
     }
 
     [Fact]
-    public void ResetStatus_WhenPending_KeepsPendingState()
+    public void ResetStatusToPending_WhenPending_KeepsPendingState()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Pending).Build();
-        sut.ResetStatus();
+        sut.ResetStatusToPending();
         sut.ExecutionState.Should().Be(BatchExecutionState.Pending);
     }
 
     [Fact]
-    public void ResetStatus_WhenExecuting_ShouldRevertToPending()
+    public void ResetStatusToPending_WhenExecuting_ShouldRevertToPending()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Pending).Build();
         sut.MarkAsExecuting(_fakeJobRunId);
-        sut.ResetStatus();
+        sut.ResetStatusToPending();
         sut.ExecutionState.Should().Be(BatchExecutionState.Pending);
         sut.RunId.Should().BeNull();
     }
 
     [Fact]
-    public void ResetStatus_WhenComplete_ThrowsInvalidOperationException()
+    public void ResetStatusToPending_WhenComplete_ThrowsInvalidOperationException()
     {
         var sut = new BatchBuilder().WithState(BatchExecutionState.Completed).Build();
-        Assert.Throws<InvalidOperationException>(() => sut.ResetStatus());
+        Assert.Throws<InvalidOperationException>(() => sut.ResetStatusToPending());
     }
 }


### PR DESCRIPTION
There does not appear to be a way to restart jobs without triggering a new run (and a new JobRunId). A batch must therefore be made aware of the new JobRunId after a restart. 

Alternatively, separating the cluster from job creation in TF may prevent the jobs from shutting down. However, the documentation says: "We strongly suggest to use new_cluster for greater reliability."

#159 