### PR TITLE
SQL database - use new TF module to use IAM

### DIFF
--- a/.github/actions/publish-release-contents/action.yml
+++ b/.github/actions/publish-release-contents/action.yml
@@ -29,7 +29,8 @@ runs:
       run: |
         mkdir ${{ inputs.RELEASE_FOLDER_PATH }}
         mkdir ${{ inputs.RELEASE_FOLDER_PATH }}/infrastructure
-        cp -fR ${{ inputs.REPO_FOLDER_PATH }}/build/infrastructure/main ${{ inputs.RELEASE_FOLDER_PATH }}/infrastructure 2>/dev/null || :
+        cp -fR ${{ inputs.REPO_FOLDER_PATH }}/build/infrastructure/main ${{ inputs.RELEASE_FOLDER_PATH }}/infrastructure/main 2>/dev/null || :
+        cp -fR ${{ inputs.REPO_FOLDER_PATH }}/build/infrastructure/env ${{ inputs.RELEASE_FOLDER_PATH }}/infrastructure/env 2>/dev/null || :
 
     - name: Publish jobs to release folder
       shell: bash

--- a/build/infrastructure/env/t-001/mssql-database_override.tf
+++ b/build/infrastructure/env/t-001/mssql-database_override.tf
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-output ms_wholesale_connection_string {
-  description = "Connection string of the wholesale database created in the shared server"
-  value       = local.DB_CONNECTION_STRING_SQL_AUTH
-  sensitive   = true
+module "mssqldb_wholesale" {
+  developer_ad_group_name     = var.developer_ad_group_name
 }

--- a/build/infrastructure/env/u-001/mssql-database_override.tf
+++ b/build/infrastructure/env/u-001/mssql-database_override.tf
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-output ms_wholesale_connection_string {
-  description = "Connection string of the wholesale database created in the shared server"
-  value       = local.DB_CONNECTION_STRING_SQL_AUTH
-  sensitive   = true
+module "mssqldb_wholesale" {
+  developer_ad_group_name     = var.developer_ad_group_name
 }

--- a/build/infrastructure/env/u-002/mssql-database_override.tf
+++ b/build/infrastructure/env/u-002/mssql-database_override.tf
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-output ms_wholesale_connection_string {
-  description = "Connection string of the wholesale database created in the shared server"
-  value       = local.DB_CONNECTION_STRING_SQL_AUTH
-  sensitive   = true
+module "mssqldb_wholesale" {
+  developer_ad_group_name     = var.developer_ad_group_name
 }

--- a/build/infrastructure/main/locals.tf
+++ b/build/infrastructure/main/locals.tf
@@ -16,5 +16,6 @@ locals {
     PROCESSES_CONTAINER_NAME                 = "processes"
     INTERGRATION_EVENTS_CONTAINER_NAME       = "integration-events"
     COMPLETED_PROCESS_SUBSCRIPTION           = "completed-process-sub-sender"
-    DB_CONNECTION_STRING                     = "Server=tcp:${data.azurerm_key_vault_secret.mssql_data_url.value},1433;Initial Catalog=${module.mssqldb_wholesale.name};Persist Security Info=False;User ID=${data.azurerm_key_vault_secret.mssql_data_admin_name.value};Password=${data.azurerm_key_vault_secret.mssql_data_admin_password.value};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=120;"
+    DB_CONNECTION_STRING_SQL_AUTH            = "Server=tcp:${data.azurerm_key_vault_secret.mssql_data_url.value},1433;Initial Catalog=${module.mssqldb_wholesale.name};Persist Security Info=False;User ID=${data.azurerm_key_vault_secret.mssql_data_admin_name.value};Password=${data.azurerm_key_vault_secret.mssql_data_admin_password.value};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=120;"
+    DB_CONNECTION_STRING                     = "Server=tcp:${data.azurerm_key_vault_secret.mssql_data_url.value},1433;Database=${module.mssqldb_wholesale.name};Persist Security Info=False;Authentication=Active Directory Managed Identity;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=120;"
 }

--- a/build/infrastructure/main/mssql-database.tf
+++ b/build/infrastructure/main/mssql-database.tf
@@ -18,7 +18,7 @@ data "azurerm_mssql_server" "mssqlsrv" {
 }
 
 module "mssqldb_wholesale" {
-  source                      = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/mssql-database?ref=7.0.0"
+  source                      = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/mssql-database?ref=7.1.0"
 
   name                        = "data"
   project_name                = var.domain_name_short
@@ -26,6 +26,7 @@ module "mssqldb_wholesale" {
   environment_instance        = var.environment_instance
   server_id                   = data.azurerm_mssql_server.mssqlsrv.id
   log_analytics_workspace_id  = data.azurerm_key_vault_secret.log_shared_id.value
+  sql_server_name             = data.azurerm_mssql_server.mssqlsrv.name
   
   tags                        = azurerm_resource_group.this.tags
 }

--- a/build/infrastructure/main/mssqldb-applicationaccess.tf
+++ b/build/infrastructure/main/mssqldb-applicationaccess.tf
@@ -1,0 +1,30 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+module "mssql_database_application_access" {
+  source                  = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/mssql-database-application-access?ref=7.1.0"
+
+  sql_server_name         = data.azurerm_mssql_server.mssqlsrv.name
+  database_name           = module.mssqldb_wholesale.name
+  application_hosts_names = [
+                              module.func_sender.name,
+                              module.func_processmanager.name,
+                              module.app_wholesale_api.name,
+                            ]
+
+  depends_on              = [
+                              module.func_sender.name,
+                              module.func_processmanager.name,
+                              module.app_wholesale_api.name,
+                            ]
+}

--- a/build/infrastructure/main/variables.tf
+++ b/build/infrastructure/main/variables.tf
@@ -48,3 +48,9 @@ variable enable_health_check_alerts {
   type          = bool
   description   = "Specify if health check alerts for Azure Functions and App Services should be enabled."
 }
+
+variable developer_ad_group_name {
+  type          = string
+  description   = "(Optional) Name of the AD group containing developers to have read access to SQL database."
+  default       = ""
+}


### PR DESCRIPTION
Enable Identity based Access Management on the SQL database used by the domain.
The application hosts (web apps and function apps) are assigned as reader and writes on the database, and the developer group is assigned as readers.
A SQL authentication connection string still exists as this is currently needed to perform data migrations.