### PR TITLE
fix: calculator used in production

### DIFF
--- a/source/databricks/package/__init__.py
+++ b/source/databricks/package/__init__.py
@@ -15,3 +15,4 @@
 from .spark_initializor import initialize_spark
 from .integration_events_persister import integration_events_persister
 from .balance_fixing_total_production import calculate_balance_fixing_total_production
+from .calculator import calculator

--- a/source/databricks/package/calculator_job.py
+++ b/source/databricks/package/calculator_job.py
@@ -33,6 +33,4 @@ def start():
         args.data_storage_account_name, args.data_storage_account_key
     )
 
-    calculator(
-        spark, args.process_results_path, args.batch_id
-    )
+    calculator(spark, args.process_results_path, args.batch_id)

--- a/source/databricks/tests/integration/calculator/test_calculator.py
+++ b/source/databricks/tests/integration/calculator/test_calculator.py
@@ -16,7 +16,7 @@ import os
 import shutil
 import subprocess
 import pytest
-from package import initialize_spark
+from package import initialize_spark, calculator
 from pyspark.sql.functions import col
 
 spark = initialize_spark("foo", "bar")
@@ -132,3 +132,19 @@ def test_calculator_job_creates_files_for_each_gridarea(
     result_806 = spark.read.json(f"{delta_lake_path}/result/batch-id=1/grid-area=806")
     assert result_805.count() >= 1, "Calculator job failed to write files"
     assert result_806.count() >= 1, "Calculator job failed to write files"
+
+
+def test_calculator_creates_file(
+    spark, delta_lake_path, find_first_file, json_lines_reader
+):
+    batchId = 1234
+    process_results_path = f"{delta_lake_path}/results"
+
+    calculator(spark, process_results_path, batchId)
+
+    jsonFile = find_first_file(
+        f"{delta_lake_path}/results/batch_id={batchId}/grid_area=805", "part-*.json"
+    )
+
+    result = json_lines_reader(jsonFile)
+    assert len(result) > 0, "Could not verify created json file."


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

The calculator used in production was no longer exposed in `__init__`. Resulting in a `TypeError: 'module' object is not callable` error. 

this PR will reintroduce it, along with a test that verifies that the `calculator` can run.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #32 
