### PR TITLE
fix: Remove wrong/irrelevant secondary sorting of time series points

### DIFF
--- a/source/databricks/package/balance_fixing_total_production.py
+++ b/source/databricks/package/balance_fixing_total_production.py
@@ -213,7 +213,7 @@ def _get_enriched_time_series_points_df(
 
     # Only use latest registered points
     window = Window.partitionBy("GsrnNumber", "time").orderBy(
-        col("RegistrationDateTime").desc(), col("storedTime").desc()
+        col("RegistrationDateTime").desc()
     )
     # If we end up with more than one point for the same Meteringpoint and "time".
     # We only need the latest point, this is essential to handle updates of points.

--- a/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_enriched_time_series_points_df.py
+++ b/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_enriched_time_series_points_df.py
@@ -253,13 +253,10 @@ time_2 = "2022-06-10T13:09:15.000Z"
 
 
 @pytest.mark.parametrize(
-    "registration_date_time_1, registration_date_time_2, stored_time_1, stored_time_2, expected_quantity",
+    "registration_date_time_1, registration_date_time_2, expected_quantity",
     [
-        (time_1, time_2, time_1, time_1, point_2_quantity),
-        (time_2, time_1, time_1, time_1, point_1_quantity),
-        (time_1, time_1, time_1, time_2, point_2_quantity),
-        (time_1, time_1, time_2, time_1, point_1_quantity),
-        (time_1, time_2, time_2, time_1, point_2_quantity),
+        (time_1, time_2, point_2_quantity),
+        (time_2, time_1, point_1_quantity),
     ],
 )
 def test__given_two_points_with_same_gsrn_and_time__only_uses_the_one_with_the_latest_stored_time(
@@ -268,8 +265,6 @@ def test__given_two_points_with_same_gsrn_and_time__only_uses_the_one_with_the_l
     timestamp_factory,
     registration_date_time_1,
     registration_date_time_2,
-    stored_time_1,
-    stored_time_2,
     expected_quantity,
 ):
     """Test that _get_enriched_time_series_points_df gets a two time_series_points,
@@ -279,8 +274,6 @@ def test__given_two_points_with_same_gsrn_and_time__only_uses_the_one_with_the_l
     raw_time_series_points = raw_time_series_points_with_same_gsrn_and_time_factory(
         registration_date_time_1=registration_date_time_1,
         registration_date_time_2=registration_date_time_2,
-        stored_time_1=stored_time_1,
-        stored_time_2=stored_time_2,
     )
     metering_point_period_df = metering_point_period_df_factory()
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

According to SME time series with the same registration time as earlier received time series must be rejected by validation. Thus wholesale does not need to anticipate anything else than the registration date time already being both unique and decisive.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #32
