### PR TITLE
fix: Order metering point events by effective date

### DIFF
--- a/source/databricks/package/balance_fixing_total_production.py
+++ b/source/databricks/package/balance_fixing_total_production.py
@@ -147,7 +147,7 @@ def _get_metering_point_periods_df(
         )
     )
 
-    window = Window.partitionBy("MeteringPointId").orderBy("OperationTime")
+    window = Window.partitionBy("MeteringPointId").orderBy("EffectiveDate")
 
     metering_point_periods_df = metering_point_events_df.withColumn(
         "toEffectiveDate",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

According to team Batman the correct ordering for replay of metering point created and connected events are by effective date.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #32
