### PR TITLE
use elastic pool

### DIFF
--- a/build/infrastructure/main/kv-shared-resources-sql.tf
+++ b/build/infrastructure/main/kv-shared-resources-sql.tf
@@ -31,3 +31,8 @@ data "azurerm_key_vault_secret" "mssql_data_url" {
   name         = "mssql-data-url"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }
+
+data "azurerm_key_vault_secret" "mssql_data_elastic_pool_id" {
+  name         = "mssql-data-elastic-pool-id"
+  key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
+}

--- a/build/infrastructure/main/mssql-database.tf
+++ b/build/infrastructure/main/mssql-database.tf
@@ -18,7 +18,7 @@ data "azurerm_mssql_server" "mssqlsrv" {
 }
 
 module "mssqldb_wholesale" {
-  source                      = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/mssql-database?ref=7.1.0"
+  source                      = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/mssql-database?ref=v9"
 
   name                        = "data"
   project_name                = var.domain_name_short
@@ -27,6 +27,8 @@ module "mssqldb_wholesale" {
   server_id                   = data.azurerm_mssql_server.mssqlsrv.id
   log_analytics_workspace_id  = data.azurerm_key_vault_secret.log_shared_id.value
   sql_server_name             = data.azurerm_mssql_server.mssqlsrv.name
+  sku_name                    = "ElasticPool"
+  elastic_pool_id             = data.azurerm_key_vault_secret.mssql_data_elastic_pooling_id.value
   
   tags                        = azurerm_resource_group.this.tags
 }

--- a/build/infrastructure/main/mssql-database.tf
+++ b/build/infrastructure/main/mssql-database.tf
@@ -27,7 +27,6 @@ module "mssqldb_wholesale" {
   server_id                   = data.azurerm_mssql_server.mssqlsrv.id
   log_analytics_workspace_id  = data.azurerm_key_vault_secret.log_shared_id.value
   sql_server_name             = data.azurerm_mssql_server.mssqlsrv.name
-  sku_name                    = "ElasticPool"
   elastic_pool_id             = data.azurerm_key_vault_secret.mssql_data_elastic_pooling_id.value
   
   tags                        = azurerm_resource_group.this.tags

--- a/build/infrastructure/main/mssql-database.tf
+++ b/build/infrastructure/main/mssql-database.tf
@@ -27,7 +27,7 @@ module "mssqldb_wholesale" {
   server_id                   = data.azurerm_mssql_server.mssqlsrv.id
   log_analytics_workspace_id  = data.azurerm_key_vault_secret.log_shared_id.value
   sql_server_name             = data.azurerm_mssql_server.mssqlsrv.name
-  elastic_pool_id             = data.azurerm_key_vault_secret.mssql_data_elastic_pooling_id.value
+  elastic_pool_id             = data.azurerm_key_vault_secret.mssql_data_elastic_pool_id.value
   
   tags                        = azurerm_resource_group.this.tags
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
Move the SQL database into the SQL Server elastic pool.

This will not require backup, as no data is lost