### PR TITLE
fix: calculator start must be parameterless

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   wheel_ci:
     uses:  Energinet-DataHub/.github/.github/workflows/python-wheel-ci.yml@v8
     with:
-      PYHTON_VERSION: '3.8.6'
+      PYHTON_VERSION: '3.9.7'
       ARCHITECTURE: 'x64'
       WHEEL_WORKING_DIRECTORY: './source/databricks'
       ARTIFACT_NAME: 'wheel'

--- a/source/databricks/package/balance_fixing_total_production.py
+++ b/source/databricks/package/balance_fixing_total_production.py
@@ -61,7 +61,7 @@ from package.schemas import (
 from package.db_logging import debug
 from datetime import datetime, timedelta, tzinfo, date
 import time
-from zoneinfo import ZoneInfo
+from backports.zoneinfo import ZoneInfo
 from pytz import timezone
 import pytz
 

--- a/source/databricks/package/balance_fixing_total_production.py
+++ b/source/databricks/package/balance_fixing_total_production.py
@@ -61,7 +61,6 @@ from package.schemas import (
 from package.db_logging import debug
 from datetime import datetime, timedelta, tzinfo, date
 import time
-from backports.zoneinfo import ZoneInfo
 from pytz import timezone
 import pytz
 

--- a/source/databricks/package/calculator_job.py
+++ b/source/databricks/package/calculator_job.py
@@ -116,7 +116,17 @@ def write_time_series_basis_data_to_csv(
     )
 
 
-def start(spark: SparkSession, args):
+def start():
+    args = _get_valid_args_or_throw()
+    log(f"Job arguments: {str(args)}")
+    db_logging.loglevel = args.log_level
+    if args.only_validate_args:
+        exit(0)
+
+    spark = initialize_spark(
+        args.data_storage_account_name, args.data_storage_account_key
+    )
+
     # Merge schema is expensive according to the Spark documentation.
     # Might be a candidate for future performance optimization initiatives.
     # Only events stored before the snapshot_datetime are needed.
@@ -175,14 +185,4 @@ def start(spark: SparkSession, args):
 
 
 if __name__ == "__main__":
-    args = _get_valid_args_or_throw()
-    log(f"Job arguments: {str(args)}")
-    db_logging.loglevel = args.log_level
-    if args.only_validate_args:
-        exit(0)
-
-    spark = initialize_spark(
-        args.data_storage_account_name, args.data_storage_account_key
-    )
-
-    start(spark, args)
+    start()

--- a/source/databricks/package/calculator_job.py
+++ b/source/databricks/package/calculator_job.py
@@ -116,17 +116,7 @@ def write_time_series_basis_data_to_csv(
     )
 
 
-def start():
-    args = _get_valid_args_or_throw()
-    log(f"Job arguments: {str(args)}")
-    db_logging.loglevel = args.log_level
-    if args.only_validate_args:
-        exit(0)
-
-    spark = initialize_spark(
-        args.data_storage_account_name, args.data_storage_account_key
-    )
-
+def start(spark: SparkSession, args):
     # Merge schema is expensive according to the Spark documentation.
     # Might be a candidate for future performance optimization initiatives.
     # Only events stored before the snapshot_datetime are needed.
@@ -185,4 +175,14 @@ def start():
 
 
 if __name__ == "__main__":
-    start()
+    args = _get_valid_args_or_throw()
+    log(f"Job arguments: {str(args)}")
+    db_logging.loglevel = args.log_level
+    if args.only_validate_args:
+        exit(0)
+
+    spark = initialize_spark(
+        args.data_storage_account_name, args.data_storage_account_key
+    )
+
+    start(spark, args)

--- a/source/databricks/package/calculator_job.py
+++ b/source/databricks/package/calculator_job.py
@@ -116,7 +116,7 @@ def write_time_series_basis_data_to_csv(
     )
 
 
-def start(spark: SparkSession, args):
+def internal_start(spark: SparkSession, args):
     # Merge schema is expensive according to the Spark documentation.
     # Might be a candidate for future performance optimization initiatives.
     # Only events stored before the snapshot_datetime are needed.
@@ -174,7 +174,7 @@ def start(spark: SparkSession, args):
     )
 
 
-if __name__ == "__main__":
+def start():
     args = _get_valid_args_or_throw()
     log(f"Job arguments: {str(args)}")
     db_logging.loglevel = args.log_level
@@ -185,4 +185,8 @@ if __name__ == "__main__":
         args.data_storage_account_name, args.data_storage_account_key
     )
 
-    start(spark, args)
+    internal_start(spark, args)
+
+
+if __name__ == "__main__":
+    start()

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -97,29 +97,98 @@ def test_calculator_job_accepts_parameters_from_process_manager(
     assert exit_code == 0, "Calculator job failed to accept provided input arguments"
 
 
-def test__result_is_generated_for_requested_grid_areas(
-    spark, test_data_job_parameters, data_lake_path, source_path
+def test_calculator_job_input_and_output_integration_test(
+    spark,
+    json_test_files,
+    databricks_path,
+    data_lake_path,
+    source_path,
+    find_first_file,
 ):
+    """This a massive test that tests multiple aspects of the job.
+    It ain't pretty but most of the aspects need to be tested in conjunction
+    with a successful execution in order to be (relatively) sure
+    that they provide the desired guarantees.
+    We haven't split this test into multiple tests, which would have to all
+    run the very slow process of starting spark instance over again
+    each time the external process is executed.
+    """
+
+    # Reads integration_events json file into dataframe and writes it to parquet
+    spark.read.json(f"{json_test_files}/integration_events.json").withColumn(
+        "body", col("body").cast("binary")
+    ).write.mode("overwrite").parquet(
+        f"{data_lake_path}/parquet_test_files/integration_events"
+    )
+
+    # Schema should match published_time_series_points_schema in time series
+    published_time_series_points_schema = StructType(
+        [
+            StructField("GsrnNumber", StringType(), True),
+            StructField("TransactionId", StringType(), True),
+            StructField("Quantity", DecimalType(18, 3), True),
+            StructField("Quality", LongType(), True),
+            StructField("Resolution", LongType(), True),
+            StructField("RegistrationDateTime", TimestampType(), True),
+            StructField("storedTime", TimestampType(), False),
+            StructField("time", TimestampType(), True),
+            StructField("year", IntegerType(), True),
+            StructField("month", IntegerType(), True),
+            StructField("day", IntegerType(), True),
+        ]
+    )
+
+    # Reads time_series_points json file into dataframe with published_time_series_points_schema and writes it to parquet
+    spark.read.schema(published_time_series_points_schema).json(
+        f"{json_test_files}/time_series_points.json"
+    ).write.mode("overwrite").parquet(
+        f"{data_lake_path}/parquet_test_files/time_series_points"
+    )
+
+    # Arrange
+    python_parameters = [
+        "python",
+        f"{databricks_path}/package/calculator_job.py",
+        "--data-storage-account-name",
+        "foo",
+        "--data-storage-account-key",
+        "foo",
+        "--integration-events-path",
+        f"{data_lake_path}/parquet_test_files/integration_events",
+        "--time-series-points-path",
+        f"{data_lake_path}/parquet_test_files/time_series_points",
+        "--process-results-path",
+        f"{data_lake_path}/results",
+        "--batch-id",
+        "1",
+        "--batch-grid-areas",
+        "[805, 806]",
+        "--batch-snapshot-datetime",
+        "2022-09-02T21:59:00Z",
+        "--batch-period-start-datetime",
+        "2022-04-01T22:00:00Z",
+        "--batch-period-end-datetime",
+        "2022-09-01T22:00:00Z",
+        "--time-zone",
+        "Europe/Copenhagen",
+    ]
+
+    # Reads time_series_points from parquet into dataframe
+    input_time_series_points = spark.read.parquet(
+        f"{data_lake_path}/parquet_test_files/time_series_points"
+    )
+
     # Act
-    start_calculator(spark, test_data_job_parameters)
+    exitcode = subprocess.call(python_parameters)
 
     # Assert
+    assert exitcode == 0
     result_805 = spark.read.json(f"{data_lake_path}/results/batch_id=1/grid_area=805")
     result_806 = spark.read.json(f"{data_lake_path}/results/batch_id=1/grid_area=806")
     assert result_805.count() >= 1, "Calculator job failed to write files"
     assert result_806.count() >= 1, "Calculator job failed to write files"
 
-
-def test__published_time_series_points_contract_matches_schema_from_input_time_series_points(
-    spark, test_data_job_parameters, data_lake_path, source_path
-):
-    # Act
-    start_calculator(spark, test_data_job_parameters)
-
-    # Assert
-    input_time_series_points = spark.read.parquet(
-        f"{data_lake_path}/parquet_test_files/time_series_points"
-    )
+    # Asserts that the published-time-series-points contract matches the schema from input_time_series_points.
     # When asserting both that the calculator creates output and it does it with input data that matches
     # the time series points contract from the time-series domain (in the same test), then we can infer that the
     # calculator works with the format of the data published from the time-series domain.
@@ -128,55 +197,23 @@ def test__published_time_series_points_contract_matches_schema_from_input_time_s
         input_time_series_points.schema,
     )
 
-
-def test__calculator_result_schema_must_match_contract_with_dotnet(
-    spark, test_data_job_parameters, data_lake_path, source_path
-):
-    # Act
-    start_calculator(spark, test_data_job_parameters)
-
-    # Assert
-    result_805 = spark.read.json(f"{data_lake_path}/results/batch_id=1/grid_area=805")
+    # Assert: Calculator result schema must match contract with .NET
     assert_contract_matches_schema(
         f"{source_path}/contracts/calculator-result.json",
         result_805.schema,
     )
 
-
-def test__quantity_is_with_precision_3(
-    spark, test_data_job_parameters, data_lake_path, find_first_file
-):
-    # Act
-    start_calculator(spark, test_data_job_parameters)
-
     # Assert: Quantity output is a string encoded decimal with precision 3 (number of digits after delimiter)
     # Note that any change or violation may impact consumers that expects exactly this precision from the result
-    result_805 = spark.read.json(f"{data_lake_path}/results/batch_id=1/grid_area=805")
     import re
 
     assert re.search(r"^\d+\.\d{3}$", result_805.first().quantity)
-
-
-def test__result_file_is_created(
-    spark, test_data_job_parameters, data_lake_path, find_first_file
-):
-    # Act
-    start_calculator(spark, test_data_job_parameters)
 
     # Assert: Relative path of result file must match expectation of .NET
     # IMPORTANT: If the expected result path changes it probably requires .NET changes too
     expected_result_path = f"{data_lake_path}/results/batch_id=1/grid_area=805"
     actual_result_file = find_first_file(expected_result_path, "part-*.json")
     assert actual_result_file is not None
-
-
-def test__creates_hour_csv_with_expected_columns_names(
-    spark, test_data_job_parameters, data_lake_path
-):
-    # Act
-    start_calculator(spark, test_data_job_parameters)
-
-    # Assert
     actual = spark.read.option("header", "true").csv(
         f"{data_lake_path}/results/basis-data/batch_id=1/time-series-hour/grid_area=805"
     )
@@ -188,14 +225,6 @@ def test__creates_hour_csv_with_expected_columns_names(
         *[f"ENERGYQUANTITY{i+1}" for i in range(24)],
     ]
 
-
-def test__creates_quarter_csv_with_expected_columns_names(
-    spark, test_data_job_parameters, data_lake_path
-):
-    # Act
-    start_calculator(spark, test_data_job_parameters)
-
-    # Assert
     actual = spark.read.option("header", "true").csv(
         f"{data_lake_path}/results/basis-data/batch_id=1/time-series-quarter/grid_area=805"
     )
@@ -207,12 +236,6 @@ def test__creates_quarter_csv_with_expected_columns_names(
         *[f"ENERGYQUANTITY{i+1}" for i in range(96)],
     ]
 
-
-def test__creates_csv_per_grid_area(spark, test_data_job_parameters, data_lake_path):
-    # Act
-    start_calculator(spark, test_data_job_parameters)
-
-    # Assert
     basis_data_805 = spark.read.option("header", "true").csv(
         f"{data_lake_path}/results/basis-data/batch_id=1/time-series-quarter/grid_area=805"
     )

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -97,98 +97,29 @@ def test_calculator_job_accepts_parameters_from_process_manager(
     assert exit_code == 0, "Calculator job failed to accept provided input arguments"
 
 
-def test_calculator_job_input_and_output_integration_test(
-    spark,
-    json_test_files,
-    databricks_path,
-    data_lake_path,
-    source_path,
-    find_first_file,
+def test__result_is_generated_for_requested_grid_areas(
+    spark, test_data_job_parameters, data_lake_path, source_path
 ):
-    """This a massive test that tests multiple aspects of the job.
-    It ain't pretty but most of the aspects need to be tested in conjunction
-    with a successful execution in order to be (relatively) sure
-    that they provide the desired guarantees.
-    We haven't split this test into multiple tests, which would have to all
-    run the very slow process of starting spark instance over again
-    each time the external process is executed.
-    """
-
-    # Reads integration_events json file into dataframe and writes it to parquet
-    spark.read.json(f"{json_test_files}/integration_events.json").withColumn(
-        "body", col("body").cast("binary")
-    ).write.mode("overwrite").parquet(
-        f"{data_lake_path}/parquet_test_files/integration_events"
-    )
-
-    # Schema should match published_time_series_points_schema in time series
-    published_time_series_points_schema = StructType(
-        [
-            StructField("GsrnNumber", StringType(), True),
-            StructField("TransactionId", StringType(), True),
-            StructField("Quantity", DecimalType(18, 3), True),
-            StructField("Quality", LongType(), True),
-            StructField("Resolution", LongType(), True),
-            StructField("RegistrationDateTime", TimestampType(), True),
-            StructField("storedTime", TimestampType(), False),
-            StructField("time", TimestampType(), True),
-            StructField("year", IntegerType(), True),
-            StructField("month", IntegerType(), True),
-            StructField("day", IntegerType(), True),
-        ]
-    )
-
-    # Reads time_series_points json file into dataframe with published_time_series_points_schema and writes it to parquet
-    spark.read.schema(published_time_series_points_schema).json(
-        f"{json_test_files}/time_series_points.json"
-    ).write.mode("overwrite").parquet(
-        f"{data_lake_path}/parquet_test_files/time_series_points"
-    )
-
-    # Arrange
-    python_parameters = [
-        "python",
-        f"{databricks_path}/package/calculator_job.py",
-        "--data-storage-account-name",
-        "foo",
-        "--data-storage-account-key",
-        "foo",
-        "--integration-events-path",
-        f"{data_lake_path}/parquet_test_files/integration_events",
-        "--time-series-points-path",
-        f"{data_lake_path}/parquet_test_files/time_series_points",
-        "--process-results-path",
-        f"{data_lake_path}/results",
-        "--batch-id",
-        "1",
-        "--batch-grid-areas",
-        "[805, 806]",
-        "--batch-snapshot-datetime",
-        "2022-09-02T21:59:00Z",
-        "--batch-period-start-datetime",
-        "2022-04-01T22:00:00Z",
-        "--batch-period-end-datetime",
-        "2022-09-01T22:00:00Z",
-        "--time-zone",
-        "Europe/Copenhagen",
-    ]
-
-    # Reads time_series_points from parquet into dataframe
-    input_time_series_points = spark.read.parquet(
-        f"{data_lake_path}/parquet_test_files/time_series_points"
-    )
-
     # Act
-    exitcode = subprocess.call(python_parameters)
+    start_calculator(spark, test_data_job_parameters)
 
     # Assert
-    assert exitcode == 0
     result_805 = spark.read.json(f"{data_lake_path}/results/batch_id=1/grid_area=805")
     result_806 = spark.read.json(f"{data_lake_path}/results/batch_id=1/grid_area=806")
     assert result_805.count() >= 1, "Calculator job failed to write files"
     assert result_806.count() >= 1, "Calculator job failed to write files"
 
-    # Asserts that the published-time-series-points contract matches the schema from input_time_series_points.
+
+def test__published_time_series_points_contract_matches_schema_from_input_time_series_points(
+    spark, test_data_job_parameters, data_lake_path, source_path
+):
+    # Act
+    start_calculator(spark, test_data_job_parameters)
+
+    # Assert
+    input_time_series_points = spark.read.parquet(
+        f"{data_lake_path}/parquet_test_files/time_series_points"
+    )
     # When asserting both that the calculator creates output and it does it with input data that matches
     # the time series points contract from the time-series domain (in the same test), then we can infer that the
     # calculator works with the format of the data published from the time-series domain.
@@ -197,23 +128,55 @@ def test_calculator_job_input_and_output_integration_test(
         input_time_series_points.schema,
     )
 
-    # Assert: Calculator result schema must match contract with .NET
+
+def test__calculator_result_schema_must_match_contract_with_dotnet(
+    spark, test_data_job_parameters, data_lake_path, source_path
+):
+    # Act
+    start_calculator(spark, test_data_job_parameters)
+
+    # Assert
+    result_805 = spark.read.json(f"{data_lake_path}/results/batch_id=1/grid_area=805")
     assert_contract_matches_schema(
         f"{source_path}/contracts/calculator-result.json",
         result_805.schema,
     )
 
+
+def test__quantity_is_with_precision_3(
+    spark, test_data_job_parameters, data_lake_path, find_first_file
+):
+    # Act
+    start_calculator(spark, test_data_job_parameters)
+
     # Assert: Quantity output is a string encoded decimal with precision 3 (number of digits after delimiter)
     # Note that any change or violation may impact consumers that expects exactly this precision from the result
+    result_805 = spark.read.json(f"{data_lake_path}/results/batch_id=1/grid_area=805")
     import re
 
     assert re.search(r"^\d+\.\d{3}$", result_805.first().quantity)
+
+
+def test__result_file_is_created(
+    spark, test_data_job_parameters, data_lake_path, find_first_file
+):
+    # Act
+    start_calculator(spark, test_data_job_parameters)
 
     # Assert: Relative path of result file must match expectation of .NET
     # IMPORTANT: If the expected result path changes it probably requires .NET changes too
     expected_result_path = f"{data_lake_path}/results/batch_id=1/grid_area=805"
     actual_result_file = find_first_file(expected_result_path, "part-*.json")
     assert actual_result_file is not None
+
+
+def test__creates_hour_csv_with_expected_columns_names(
+    spark, test_data_job_parameters, data_lake_path
+):
+    # Act
+    start_calculator(spark, test_data_job_parameters)
+
+    # Assert
     actual = spark.read.option("header", "true").csv(
         f"{data_lake_path}/results/basis-data/batch_id=1/time-series-hour/grid_area=805"
     )
@@ -225,6 +188,14 @@ def test_calculator_job_input_and_output_integration_test(
         *[f"ENERGYQUANTITY{i+1}" for i in range(24)],
     ]
 
+
+def test__creates_quarter_csv_with_expected_columns_names(
+    spark, test_data_job_parameters, data_lake_path
+):
+    # Act
+    start_calculator(spark, test_data_job_parameters)
+
+    # Assert
     actual = spark.read.option("header", "true").csv(
         f"{data_lake_path}/results/basis-data/batch_id=1/time-series-quarter/grid_area=805"
     )
@@ -236,6 +207,12 @@ def test_calculator_job_input_and_output_integration_test(
         *[f"ENERGYQUANTITY{i+1}" for i in range(96)],
     ]
 
+
+def test__creates_csv_per_grid_area(spark, test_data_job_parameters, data_lake_path):
+    # Act
+    start_calculator(spark, test_data_job_parameters)
+
+    # Assert
     basis_data_805 = spark.read.option("header", "true").csv(
         f"{data_lake_path}/results/basis-data/batch_id=1/time-series-quarter/grid_area=805"
     )

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -27,7 +27,7 @@ from pyspark.sql.types import (
     LongType,
 )
 from tests.contract_utils import assert_contract_matches_schema
-from package.calculator_job import start as start_calculator
+from package.calculator_job import internal_start as start_calculator
 
 
 def _get_process_manager_parameters(filename):


### PR DESCRIPTION
The entry point for the calculator_job start() must be parameterless for it to be called trough the wheel. 

zoneinfo was not in use so it is no longer imported