### PR TITLE
feat: Enable triggering NuGet prerelease

### DIFF
--- a/.github/workflows/packages-publish.yml
+++ b/.github/workflows/packages-publish.yml
@@ -1,0 +1,36 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish NuGet packages
+
+on:
+  # Build, test, pack and publish release packages
+  # Only executed if packages content or build scripts has changed; not if solution file, documentation or tests has changed
+  push:
+    branches:
+      - main
+    paths:
+      - source/dotnet/Packages/Client/**
+      - .github/workflows/packages-publish.yml
+  # Build, test, pack
+  # Executed if package folder or build scripts has changed; including if documentation or tests has changed
+  pull_request:
+    branches:
+      - main
+    paths:
+      - source/dotnet/Packages/**
+      - .github/workflows/app-common-bundle-publish.yml
+  # Build, test, pack and publish prerelease packages
+  # Executed if manually triggered
+  workflow_dispatch: {}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Needed in order to test prerelease of NuGet package in [this PR](#359).

Pre-release of NuGet packages from PRs require the workflow with the dispatch trigger to exist in main. The remainder of the workflow will be added in the other PR.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #17
