### PR TITLE
bug: read result path with code value

### DIFF
--- a/source/dotnet/Services/Infrastructure/BasisData/BatchFileManager.cs
+++ b/source/dotnet/Services/Infrastructure/BasisData/BatchFileManager.cs
@@ -129,7 +129,7 @@ public class BatchFileManager : IBatchFileManager
 
     // TODO BJARKE: The directory paths must match the directory used by Databricks (see calculator.py).
     private (string Directory, string Extension, string ZipEntryPath) GetResultDirectory(Guid batchId, GridAreaCode gridAreaCode)
-        => ($"results/batch_id={batchId}/grid_area={gridAreaCode}/", ".json", $"{gridAreaCode}/Result.json");
+        => ($"results/batch_id={batchId}/grid_area={gridAreaCode.Code}/", ".json", $"{gridAreaCode}/Result.json");
 
     private (string Directory, string Extension, string ZipEntryPath) GetTimeSeriesHourBasisDataDirectory(Guid batchId, GridAreaCode gridAreaCode)
         => ($"results/basis-data/batch_id={batchId}/time-series-hour/grid_area={gridAreaCode}/",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

`PeekEndpoint` failed with a 404 after inspecting the URI used to get the result

https://stdatalakesharedresu001.dfs.core.windows.net/processes?resource=filesystem&directory=results%2Fbatch_id%3D195e433b-a751-49b2-8a32-3f3a90687d65%2Fgrid_area%3DGridAreaCode%20%7B%20Code%20%3D%20806%20%7D&recursive=false&upn=false

The path using the GridAreaCode appears to be missing the class instead of the code value

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #17 
