### PR TITLE
fix: revert to read db connectionstring from configuration

### DIFF
--- a/source/dotnet/Services/IntegrationTests/Hosts/WebApiIntegrationTestHost.cs
+++ b/source/dotnet/Services/IntegrationTests/Hosts/WebApiIntegrationTestHost.cs
@@ -60,7 +60,7 @@ public sealed class WebApiIntegrationTestHost : IDisposable
         Environment.SetEnvironmentVariable(EnvironmentSettingNames.AppInsightsInstrumentationKey, anyValue);
         Environment.SetEnvironmentVariable(EnvironmentSettingNames.FrontEndServiceAppId, anyValue);
         Environment.SetEnvironmentVariable(EnvironmentSettingNames.FrontEndOpenIdUrl, anyValue);
-        Environment.SetEnvironmentVariable(EnvironmentSettingNames.DbConnectionString, "UseDevelopmentStorage=true");
+        Environment.SetEnvironmentVariable($"CONNECTIONSTRINGS:{EnvironmentSettingNames.DbConnectionString}", "UseDevelopmentStorage=true");
     }
 
     private static void ConfigureServices(IServiceCollection serviceCollection)

--- a/source/dotnet/Services/IntegrationTests/WebApi/WebApiTests.cs
+++ b/source/dotnet/Services/IntegrationTests/WebApi/WebApiTests.cs
@@ -23,7 +23,7 @@ namespace Energinet.DataHub.Wholesale.IntegrationTests.WebApi;
 [Collection(nameof(WebApiIntegrationTestHost))]
 public class WebApiTests
 {
-    [Fact(Skip = "No way to reconfigure the db connection string used in IConfiguration")]
+    [Fact]
     public async Task ServiceCollection_CanResolveBatchControllerV1()
     {
         // Arrange
@@ -35,7 +35,7 @@ public class WebApiTests
         scope.ServiceProvider.GetRequiredService<BatchControllerV1>();
     }
 
-    [Fact(Skip = "No way to reconfigure the db connection string used in IConfiguration")]
+    [Fact]
     public async Task ServiceCollection_CanResolveBatchControllerV2()
     {
         // Arrange

--- a/source/dotnet/Services/IntegrationTests/WebApi/WebApiTests.cs
+++ b/source/dotnet/Services/IntegrationTests/WebApi/WebApiTests.cs
@@ -23,7 +23,7 @@ namespace Energinet.DataHub.Wholesale.IntegrationTests.WebApi;
 [Collection(nameof(WebApiIntegrationTestHost))]
 public class WebApiTests
 {
-    [Fact]
+    [Fact(Skip = "No way to reconfigure the db connection string used in IConfiguration")]
     public async Task ServiceCollection_CanResolveBatchControllerV1()
     {
         // Arrange
@@ -35,7 +35,7 @@ public class WebApiTests
         scope.ServiceProvider.GetRequiredService<BatchControllerV1>();
     }
 
-    [Fact]
+    [Fact(Skip = "No way to reconfigure the db connection string used in IConfiguration")]
     public async Task ServiceCollection_CanResolveBatchControllerV2()
     {
         // Arrange

--- a/source/dotnet/Services/WebApi/Configuration/ServiceCollectionExtensions.cs
+++ b/source/dotnet/Services/WebApi/Configuration/ServiceCollectionExtensions.cs
@@ -66,9 +66,9 @@ internal static class ServiceCollectionExtensions
         serviceCollection.AddScoped<JwtTokenMiddleware>();
     }
 
-    public static void AddCommandStack(this IServiceCollection services)
+    public static void AddCommandStack(this IServiceCollection services, IConfiguration configuration)
     {
-        var connectionString = EnvironmentVariableHelper.GetEnvVariable(EnvironmentSettingNames.DbConnectionString);
+        var connectionString = configuration.GetConnectionString(EnvironmentSettingNames.DbConnectionString);
         if (connectionString == null)
             throw new ArgumentNullException(EnvironmentSettingNames.DbConnectionString, "does not exist in configuration settings");
 

--- a/source/dotnet/Services/WebApi/Startup.cs
+++ b/source/dotnet/Services/WebApi/Startup.cs
@@ -50,7 +50,7 @@ public class Startup
             config.ReportApiVersions = true;
         });
 
-        services.AddCommandStack();
+        services.AddCommandStack(Configuration);
         services.AddApplicationInsightsTelemetry();
 
         ConfigureHealthChecks(services);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #17
