### PR TITLE
refac: AccountpointId -> MeteringPointId

### DIFF
--- a/source/dotnet/Services/IntegrationEventListener/MarketParticipant/EnergySupplierChangedDto.cs
+++ b/source/dotnet/Services/IntegrationEventListener/MarketParticipant/EnergySupplierChangedDto.cs
@@ -19,7 +19,7 @@ namespace Energinet.DataHub.Wholesale.IntegrationEventListener.MarketParticipant
 /// <summary>
 /// Wholesales internal representation of the data on the EnergySupplierChanged event exposed by the market participant domain
 /// </summary>
-/// <param name="AccountingpointId">Unique metering point identification</param>
+/// <param name="MeteringPointId">Unique metering point identification (AccountingpointId from MarketParticipant domain)</param>
 /// <param name="GsrnNumber">metering point identification</param>
 /// <param name="EnergySupplierGln">Unique Energy Supplier identification</param>
 /// <param name="EffectiveDate">Date which the change of supplier goes into effect</param>
@@ -28,7 +28,7 @@ namespace Energinet.DataHub.Wholesale.IntegrationEventListener.MarketParticipant
 /// <param name="MessageType">The type of message the dto represents</param>
 /// <param name="OperationTime">The point in time when the sending domain published the event</param>
 public sealed record EnergySupplierChangedDto(
-        string AccountingpointId,
+        string MeteringPointId,
         string GsrnNumber,
         string EnergySupplierGln,
         Instant EffectiveDate,

--- a/source/dotnet/Services/Tests/IntegrationEventListener/MarketParticipant/EnergySupplierChangedDtoFactoryTests.cs
+++ b/source/dotnet/Services/Tests/IntegrationEventListener/MarketParticipant/EnergySupplierChangedDtoFactoryTests.cs
@@ -66,7 +66,7 @@ public class EnergySupplierChangedDtoFactoryTests
 
         // Assert
         actual.Should().NotContainNullsOrEmptyEnumerables();
-        actual.AccountingpointId.Should().Be(accountingpointId);
+        actual.MeteringPointId.Should().Be(accountingpointId);
         actual.GsrnNumber.Should().Be(gsrnNumber);
         actual.EnergySupplierGln.Should().Be(energySupplierGln);
         actual.Id.Should().Be(id);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Market participant representation of the unique identifier for the metering point is called AccountpointId, for Wholesale perspective, this becomes unnecessary when we wish to window our metering points downstream.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #201 
