### PR TITLE
feat: Masterbasisdata dates changes

### DIFF
--- a/source/databricks/package/balance_fixing_total_production.py
+++ b/source/databricks/package/balance_fixing_total_production.py
@@ -101,7 +101,9 @@ def calculate_balance_fixing_total_production(
         enriched_time_series_point_df, time_zone
     )
 
-    master_basis_data_df = _get_master_basis_data(metering_point_period_df)
+    master_basis_data_df = _get_master_basis_data(
+        metering_point_period_df, period_start_datetime, period_end_datetime
+    )
 
     result_df = _get_result_df(enriched_time_series_point_df)
 

--- a/source/databricks/package/balance_fixing_total_production.py
+++ b/source/databricks/package/balance_fixing_total_production.py
@@ -450,8 +450,24 @@ def _get_enriched_time_series_points_df(
     return enriched_points_for_each_metering_point_df
 
 
-def _get_master_basis_data(metering_point_df):
+def _get_master_basis_data(
+    metering_point_df, period_start_datetime, period_end_datetime
+):
     productionType = MeteringPointType.production.value
+
+    metering_point_df = metering_point_df.withColumn(
+        "EffectiveDate",
+        when(
+            col("EffectiveDate") < period_start_datetime, period_start_datetime
+        ).otherwise(col("EffectiveDate")),
+    )
+
+    metering_point_df = metering_point_df.withColumn(
+        "toEffectiveDate",
+        when(
+            col("toEffectiveDate") > period_end_datetime, period_end_datetime
+        ).otherwise(col("toEffectiveDate")),
+    )
 
     return metering_point_df.withColumn(
         "TYPEOFMP", when(col("MeteringPointType") == productionType, "E18")

--- a/source/databricks/package/balance_fixing_total_production.py
+++ b/source/databricks/package/balance_fixing_total_production.py
@@ -454,34 +454,34 @@ def _get_master_basis_data(
     metering_point_df, period_start_datetime, period_end_datetime
 ):
     productionType = MeteringPointType.production.value
-
-    metering_point_df = metering_point_df.withColumn(
-        "EffectiveDate",
-        when(
-            col("EffectiveDate") < period_start_datetime, period_start_datetime
-        ).otherwise(col("EffectiveDate")),
-    )
-
-    metering_point_df = metering_point_df.withColumn(
-        "toEffectiveDate",
-        when(
-            col("toEffectiveDate") > period_end_datetime, period_end_datetime
-        ).otherwise(col("toEffectiveDate")),
-    )
-
-    return metering_point_df.withColumn(
-        "TYPEOFMP", when(col("MeteringPointType") == productionType, "E18")
-    ).select(
-        col("GridAreaCode"),  # column is only used for partitioning
-        col("GsrnNumber").alias("METERINGPOINTID"),
-        col("EffectiveDate").alias("VALIDFROM"),
-        col("toEffectiveDate").alias("VALIDTO"),
-        col("GridAreaCode").alias("GRIDAREA"),
-        col("ToGridAreaCode").alias("TOGRIDAREA"),
-        col("FromGridAreaCode").alias("FROMGRIDAREA"),
-        col("TYPEOFMP"),
-        col("SettlementMethod").alias("SETTLEMENTMETHOD"),
-        col("EnergySupplierGln").alias(("ENERGYSUPPLIERID")),
+    return (
+        metering_point_df.withColumn(
+            "TYPEOFMP", when(col("MeteringPointType") == productionType, "E18")
+        )
+        .withColumn(
+            "EffectiveDate",
+            when(
+                col("EffectiveDate") < period_start_datetime, period_start_datetime
+            ).otherwise(col("EffectiveDate")),
+        )
+        .withColumn(
+            "toEffectiveDate",
+            when(
+                col("toEffectiveDate") > period_end_datetime, period_end_datetime
+            ).otherwise(col("toEffectiveDate")),
+        )
+        .select(
+            col("GridAreaCode"),  # column is only used for partitioning
+            col("GsrnNumber").alias("METERINGPOINTID"),
+            col("EffectiveDate").alias("VALIDFROM"),
+            col("toEffectiveDate").alias("VALIDTO"),
+            col("GridAreaCode").alias("GRIDAREA"),
+            col("ToGridAreaCode").alias("TOGRIDAREA"),
+            col("FromGridAreaCode").alias("FROMGRIDAREA"),
+            col("TYPEOFMP"),
+            col("SettlementMethod").alias("SETTLEMENTMETHOD"),
+            col("EnergySupplierGln").alias(("ENERGYSUPPLIERID")),
+        )
     )
 
 

--- a/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_master_basis_data.py
+++ b/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_master_basis_data.py
@@ -179,7 +179,7 @@ def test__both_hour_and_quarterly_resolution_data_are_in_basis_data(
     assert master_basis_data.count() == expected_number_of_metering_points
 
 
-def test__effective_date_must_not_be_behind_than_period_start(
+def test__effective_date_must_not_be_earlier_than_period_start(
     metering_point_period_df_factory, timestamp_factory
 ):
     expected_vaild_from = "2022-06-09T12:09:15.000Z"
@@ -196,7 +196,7 @@ def test__effective_date_must_not_be_behind_than_period_start(
     assert actual.VALIDFROM == expected_vaild_from
 
 
-def test__to_effective_date_must_not_be_over_period_end(
+def test__to_effective_date_must_not_be_after_period_end(
     metering_point_period_df_factory, timestamp_factory
 ):
     expected_vaild_to = "2022-06-010T12:09:15.000Z"

--- a/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_master_basis_data.py
+++ b/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_master_basis_data.py
@@ -69,7 +69,6 @@ def metering_point_period_df_factory(spark, timestamp_factory):
 def test__get_master_basis_data_has_expected_columns(
     metering_point_period_df_factory, timestamp_factory
 ):
-
     metering_point_period_df = metering_point_period_df_factory().union(
         metering_point_period_df_factory(
             effective_date=timestamp_factory("2022-06-10T22:00:00.000Z"),
@@ -167,3 +166,37 @@ def test__both_hour_and_quarterly_resolution_data_are_in_basis_data(
 
     # Assert
     assert master_basis_data.count() == expected_number_of_metering_points
+
+
+def test__effective_date_must_not_be_behind_than_period_start(
+    metering_point_period_df_factory, timestamp_factory
+):
+    expected_vaild_from = "2022-06-09T12:09:15.000Z"
+    metering_point_period_df = metering_point_period_df_factory(gsrn_number="1")
+
+    master_basis_data = _get_master_basis_data(
+        metering_point_period_df,
+        expected_vaild_from,
+        "2022-06-010T12:09:15.000Z",
+    )
+
+    # Assert
+    actual = master_basis_data.first()
+    assert actual.VALIDFROM == expected_vaild_from
+
+
+def test__to_effective_date_must_not_be_over_period_end(
+    metering_point_period_df_factory, timestamp_factory
+):
+    expected_vaild_to = "2022-06-010T12:09:15.000Z"
+    metering_point_period_df = metering_point_period_df_factory(gsrn_number="1")
+
+    master_basis_data = _get_master_basis_data(
+        metering_point_period_df,
+        "2022-06-09T12:09:15.000Z",
+        expected_vaild_to,
+    )
+
+    # Assert
+    actual = master_basis_data.first()
+    assert actual.VALIDTO == expected_vaild_to

--- a/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_master_basis_data.py
+++ b/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_master_basis_data.py
@@ -34,6 +34,9 @@ from pyspark.sql.types import (
     StructType,
 )
 
+period_start = "2022-06-08T12:09:15.000Z"
+period_end = "2022-06-010T12:09:15.000Z"
+
 
 @pytest.fixture(scope="module")
 def metering_point_period_df_factory(spark, timestamp_factory):
@@ -75,7 +78,9 @@ def test__get_master_basis_data_has_expected_columns(
             to_effective_date=timestamp_factory("2022-06-12T22:00:00.000Z"),
         )
     )
-    master_basis_data = _get_master_basis_data(metering_point_period_df)
+    master_basis_data = _get_master_basis_data(
+        metering_point_period_df, period_start, period_end
+    )
 
     # Assert
     assert master_basis_data.columns == [
@@ -102,7 +107,9 @@ def test__each_meteringpoint_has_a_row(
         .union(metering_point_period_df_factory(gsrn_number="3"))
     )
 
-    master_basis_data = _get_master_basis_data(metering_point_period_df)
+    master_basis_data = _get_master_basis_data(
+        metering_point_period_df, period_start, period_end
+    )
 
     # Assert
     assert master_basis_data.count() == expected_number_of_metering_points
@@ -114,7 +121,7 @@ def test__columns_have_expected_values(
     expected_gsrn_number = "the-gsrn-number"
     expected_grid_area_code = "some-grid-area-code"
     expected_effective_date = timestamp_factory("2022-06-08T12:09:15.000Z")
-    expected_to_effective_date = timestamp_factory("2022-06-10T22:00:00.000Z")
+    expected_to_effective_date = timestamp_factory("2022-06-10T09:15:00.000Z")
     expected_meteringpoint_type = "E18"
     expected_from_grid_area_code = "some-from-grid-area-code"
     expected_to_grid_area_code = "some-to-grid-area-code"
@@ -133,15 +140,17 @@ def test__columns_have_expected_values(
         energy_supplier_gln=expected_energy_supplier_gln,
     )
 
-    master_basis_data_df = _get_master_basis_data(metering_point_period_df)
+    master_basis_data_df = _get_master_basis_data(
+        metering_point_period_df, period_start, period_end
+    )
 
     # Assert
     actual = master_basis_data_df.first()
 
     assert actual.GridAreaCode == expected_grid_area_code
     assert actual.METERINGPOINTID == expected_gsrn_number
-    assert actual.VALIDFROM == expected_effective_date
-    assert actual.VALIDTO == expected_to_effective_date
+    assert actual.VALIDFROM == str(expected_effective_date)
+    assert actual.VALIDTO == str(expected_to_effective_date)
     assert actual.GRIDAREA == expected_grid_area_code
     assert actual.TOGRIDAREA == expected_to_grid_area_code
     assert actual.FROMGRIDAREA == expected_from_grid_area_code
@@ -162,7 +171,9 @@ def test__both_hour_and_quarterly_resolution_data_are_in_basis_data(
         )
     )
 
-    master_basis_data = _get_master_basis_data(metering_point_period_df)
+    master_basis_data = _get_master_basis_data(
+        metering_point_period_df, period_start, period_end
+    )
 
     # Assert
     assert master_basis_data.count() == expected_number_of_metering_points

--- a/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_master_basis_data.py
+++ b/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_master_basis_data.py
@@ -34,8 +34,8 @@ from pyspark.sql.types import (
     StructType,
 )
 
-period_start = "2022-06-08T12:09:15.000Z"
-period_end = "2022-06-010T12:09:15.000Z"
+period_start = "2022-06-08T12:22:00.000Z"
+period_end = "2022-06-010T12:22:00.000Z"
 
 
 @pytest.fixture(scope="module")
@@ -43,7 +43,7 @@ def metering_point_period_df_factory(spark, timestamp_factory):
     def factory(
         gsrn_number="the-gsrn-number",
         grid_area_code="some-grid-area-code",
-        effective_date: datetime = timestamp_factory("2022-06-08T12:09:15.000Z"),
+        effective_date: datetime = timestamp_factory("2022-06-08T22:00:00.000Z"),
         to_effective_date: datetime = timestamp_factory("2022-06-10T22:00:00.000Z"),
         meteringpoint_type=MeteringPointType.production.value,
         from_grid_area_code="some-from-grid-area-code",
@@ -120,8 +120,8 @@ def test__columns_have_expected_values(
 ):
     expected_gsrn_number = "the-gsrn-number"
     expected_grid_area_code = "some-grid-area-code"
-    expected_effective_date = timestamp_factory("2022-06-08T12:09:15.000Z")
-    expected_to_effective_date = timestamp_factory("2022-06-10T09:15:00.000Z")
+    expected_effective_date = timestamp_factory("2022-06-08T22:00:00.000Z")
+    expected_to_effective_date = timestamp_factory("2022-06-09T22:00:00.000Z")
     expected_meteringpoint_type = "E18"
     expected_from_grid_area_code = "some-from-grid-area-code"
     expected_to_grid_area_code = "some-to-grid-area-code"


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

When master basis data was created, the fields `VALIDFROM` and `VALIDTO` was populated from the metering points `effectiveDate` and the `toEffectiveDate`. Which was incorrect in some cases. 

Metering points with an `effectiveDate` before the requested aggregation start period should have the period start as `VALIDOFROM`.

Metering points with an `toEffectiveDate` after the requested aggregation end period should have the period end as `VALIDOTO`.

There is a picture on the referenced story to better illustrate the requested changes.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #201 
