### PR TITLE
fix: Balancefixing window connection state fix energysupplierchanged

### DIFF
--- a/source/databricks/package/balance_fixing_total_production.py
+++ b/source/databricks/package/balance_fixing_total_production.py
@@ -263,7 +263,9 @@ def _get_metering_point_periods_df(
             )
             .when(
                 col("MessageType") == ENERGY_SUPPLIER_CHANGED_MESSAGE_TYPE,
-                lit(ConnectionState.connected.value),
+                coalesce(
+                    col("ConnectionState"), last("ConnectionState", True).over(window)
+                ),
             ),
         )
         .withColumn(

--- a/source/databricks/package/balance_fixing_total_production.py
+++ b/source/databricks/package/balance_fixing_total_production.py
@@ -261,8 +261,7 @@ def _get_metering_point_periods_df(
                 col("MessageType") == METERING_POINT_CONNECTED_MESSAGE_TYPE,
                 lit(ConnectionState.connected.value),
             )
-            .when(
-                col("MessageType") == ENERGY_SUPPLIER_CHANGED_MESSAGE_TYPE,
+            .otherwise(
                 coalesce(
                     col("ConnectionState"), last("ConnectionState", True).over(window)
                 ),

--- a/source/databricks/package/balance_fixing_total_production.py
+++ b/source/databricks/package/balance_fixing_total_production.py
@@ -256,8 +256,13 @@ def _get_metering_point_periods_df(
             when(
                 col("MessageType") == METERING_POINT_CREATED_MESSAGE_TYPE,
                 lit(ConnectionState.new.value),
-            ).when(
+            )
+            .when(
                 col("MessageType") == METERING_POINT_CONNECTED_MESSAGE_TYPE,
+                lit(ConnectionState.connected.value),
+            )
+            .when(
+                col("MessageType") == ENERGY_SUPPLIER_CHANGED_MESSAGE_TYPE,
                 lit(ConnectionState.connected.value),
             ),
         )


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

The connection state was unhandled in the case of the period created from the `EnergySupplierChanged` event. 

This PR will make sure periods that area created from that event have the last known connection state from the events with the same `MeteringpointId`

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #201 
