### PR TITLE
refac: allow missing files when zipping

### DIFF
--- a/source/dotnet/Services/Infrastructure/BasisData/BatchFileManager.cs
+++ b/source/dotnet/Services/Infrastructure/BasisData/BatchFileManager.cs
@@ -110,6 +110,7 @@ public class BatchFileManager : IBatchFileManager
         {
             var (directory, extension, entryPath) = fileIdentifierProvider(batchId, gridAreaCode);
             var processDataFile = await GetDataLakeFileClientAsync(directory, extension).ConfigureAwait(false);
+            if (processDataFile == null) continue;
             var response = await processDataFile.ReadAsync().ConfigureAwait(false);
             processDataFilesUrls.Add((response.Value.Content, entryPath));
         }
@@ -122,13 +123,13 @@ public class BatchFileManager : IBatchFileManager
     /// </summary>
     /// <param name="directory"></param>
     /// <param name="extension"></param>
-    /// <returns>The first file with matching file extension.</returns>
-    private async Task<DataLakeFileClient> GetDataLakeFileClientAsync(string directory, string extension)
+    /// <returns>The first file with matching file extension. If no directory was found, return null</returns>
+    private async Task<DataLakeFileClient?> GetDataLakeFileClientAsync(string directory, string extension)
     {
         var directoryClient = _dataLakeFileSystemClient.GetDirectoryClient(directory);
         var directoryExists = await directoryClient.ExistsAsync().ConfigureAwait(false);
         if (!directoryExists.Value)
-            throw new Exception($"Calculation storage directory '{directory}' does not exist");
+            return null;
 
         await foreach (var pathItem in directoryClient.GetPathsAsync())
         {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

There is the possibility that aggregation is run over a period with no quarterly or hourly metering points. In that case we should no longer fail the zip process, but instead create the zip file with the remaining files.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #201
