### PR TITLE
refac:Replace Jedi with Pylance

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
 		},
 		"python.formatting.provider": "black",
 		"python.defaultInterpreterPath": "/opt/conda/bin/python",
-		"python.languageServer": "Jedi",
+		"python.languageServer": "Pylance",
 		"markdownlint.config": {
 			"MD007": {
 				"indent": 4


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Changes the python language server from Jedi to Pylance.
Pylance is a more advanced language server than Jedi and provides a lot more help when coding, this includes the ability to see if a import is used or not

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
