### PR TITLE
bug: eventsstreaming is missing log-level argument

### DIFF
--- a/source/databricks/package/integration_events_persister_streaming.py
+++ b/source/databricks/package/integration_events_persister_streaming.py
@@ -29,7 +29,7 @@ def _get_valid_args_or_throw(command_line_args: list[str]):
     p.add("--event-hub-connectionstring", type=str, required=True)
     p.add("--integration-events-path", type=str, required=True)
     p.add("--integration-events-checkpoint-path", type=str, required=True)
-    p.add("--log-level", type=valid_log_level, help="debug|information")
+    p.add("--log-level", type=valid_log_level, help="debug|information", required=True)
 
     args, unknown_args = p.parse_known_args(args=command_line_args)
     if len(unknown_args):

--- a/source/databricks/package/integration_events_persister_streaming.py
+++ b/source/databricks/package/integration_events_persister_streaming.py
@@ -14,6 +14,7 @@
 
 import sys
 from package import integration_events_persister, initialize_spark, log, db_logging
+from package.args_helper import valid_date, valid_list, valid_log_level
 from package.datamigration import islocked
 import configargparse
 
@@ -28,6 +29,7 @@ def _get_valid_args_or_throw(command_line_args: list[str]):
     p.add("--event-hub-connectionstring", type=str, required=True)
     p.add("--integration-events-path", type=str, required=True)
     p.add("--integration-events-checkpoint-path", type=str, required=True)
+    p.add("--log-level", type=valid_log_level, help="debug|information")
 
     args, unknown_args = p.parse_known_args(args=command_line_args)
     if len(unknown_args):

--- a/source/databricks/tests/integration/integration_events_persister/test_integration_events_persister.py
+++ b/source/databricks/tests/integration/integration_events_persister/test_integration_events_persister.py
@@ -77,6 +77,8 @@ valid_command_line_args = [
     "any-path",
     "--integration-events-checkpoint-path",
     "any-checkpoint-path",
+    "--log-level",
+    "information",
 ]
 
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Streaming cloud not be started due to missing argument. The argument was passed in [this pr](https://github.com/Energinet-DataHub/dh3-infrastructure/pull/33)

This PR will parse the argument and mark is as required. (The required flag is missing from the calculator job, ill create another PR to update it)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #508 
