### PR TITLE
fix: use storage url (and not storage name) to initialize DataLakeServiceClient

### DIFF
--- a/source/databricks/package/datamigration/data_lake_file_manager.py
+++ b/source/databricks/package/datamigration/data_lake_file_manager.py
@@ -18,6 +18,10 @@ from io import StringIO
 import csv
 
 
+def get_storage_account_url(storage_account_name: str) -> str:
+    return f"https://{storage_account_name}.dfs.core.windows.net"
+
+
 class DataLakeFileManager:
     def __init__(
         self,
@@ -25,8 +29,9 @@ class DataLakeFileManager:
         data_storage_account_key: str,
         container_name: str,
     ):
+        data_storage_account_url = get_storage_account_url(data_storage_account_name)
         self.file_system_client = DataLakeServiceClient(
-            data_storage_account_name, data_storage_account_key
+            data_storage_account_url, data_storage_account_key
         ).get_file_system_client(container_name)
 
     def download_file(self, file_name: str) -> bytes:


### PR DESCRIPTION
…viceClient

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
