### PR TITLE
Refac: Rename BatchGridAreaDto to GridAreaDto

### DIFF
--- a/source/dotnet/Contracts/BatchDtoV2.cs
+++ b/source/dotnet/Contracts/BatchDtoV2.cs
@@ -17,4 +17,4 @@ namespace Energinet.DataHub.Wholesale.Application.Batches;
 /// <summary>
 /// An immutable batch.
 /// </summary>
-public sealed record BatchDtoV2(Guid BatchNumber, DateTimeOffset PeriodStart, DateTimeOffset PeriodEnd, DateTimeOffset? ExecutionTimeStart, DateTimeOffset? ExecutionTimeEnd, BatchState ExecutionState, bool IsBasisDataDownloadAvailable, GridAreaDto[] BatchGridAreas);
+public sealed record BatchDtoV2(Guid BatchNumber, DateTimeOffset PeriodStart, DateTimeOffset PeriodEnd, DateTimeOffset? ExecutionTimeStart, DateTimeOffset? ExecutionTimeEnd, BatchState ExecutionState, bool IsBasisDataDownloadAvailable, GridAreaDto[] GridAreas);

--- a/source/dotnet/Contracts/BatchDtoV2.cs
+++ b/source/dotnet/Contracts/BatchDtoV2.cs
@@ -17,4 +17,4 @@ namespace Energinet.DataHub.Wholesale.Application.Batches;
 /// <summary>
 /// An immutable batch.
 /// </summary>
-public sealed record BatchDtoV2(Guid BatchNumber, DateTimeOffset PeriodStart, DateTimeOffset PeriodEnd, DateTimeOffset? ExecutionTimeStart, DateTimeOffset? ExecutionTimeEnd, BatchState ExecutionState, bool IsBasisDataDownloadAvailable, BatchGridAreaDto[] BatchGridAreas);
+public sealed record BatchDtoV2(Guid BatchNumber, DateTimeOffset PeriodStart, DateTimeOffset PeriodEnd, DateTimeOffset? ExecutionTimeStart, DateTimeOffset? ExecutionTimeEnd, BatchState ExecutionState, bool IsBasisDataDownloadAvailable, GridAreaDto[] BatchGridAreas);

--- a/source/dotnet/Contracts/GridAreaDto.cs
+++ b/source/dotnet/Contracts/GridAreaDto.cs
@@ -17,4 +17,4 @@ namespace Energinet.DataHub.Wholesale.Application.Batches;
 /// <summary>
 /// An immutable batch.
 /// </summary>
-public sealed record BatchGridAreaDto(string GridAreaCode);
+public sealed record GridAreaDto(string GridAreaCode);

--- a/source/dotnet/Contracts/GridAreaDto.cs
+++ b/source/dotnet/Contracts/GridAreaDto.cs
@@ -14,7 +14,4 @@
 
 namespace Energinet.DataHub.Wholesale.Application.Batches;
 
-/// <summary>
-/// An immutable batch.
-/// </summary>
 public sealed record GridAreaDto(string GridAreaCode);

--- a/source/dotnet/Packages/Client/Client.csproj
+++ b/source/dotnet/Packages/Client/Client.csproj
@@ -72,9 +72,6 @@ limitations under the License.
     <Compile Include="..\..\Contracts\BatchDtoV2.cs">
       <Link>Dtos\BatchDtoV2.cs</Link>
     </Compile>
-    <Compile Include="..\..\Contracts\BatchGridAreaDto.cs">
-      <Link>Dtos\BatchGridAreaDto.cs</Link>
-    </Compile>
     <Compile Include="..\..\Contracts\BatchRequestDto.cs">
       <Link>Dtos\BatchRequestDto.cs</Link>
     </Compile>
@@ -83,6 +80,9 @@ limitations under the License.
     </Compile>
     <Compile Include="..\..\Contracts\BatchState.cs">
       <Link>Model\BatchState.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Contracts\GridAreaDto.cs">
+      <Link>Dtos\GridAreaDto.cs</Link>
     </Compile>
     <Compile Include="..\..\Contracts\WholesaleProcessType.cs">
       <Link>Model\WholesaleProcessType.cs</Link>

--- a/source/dotnet/Services/Application/Application.csproj
+++ b/source/dotnet/Services/Application/Application.csproj
@@ -33,14 +33,14 @@ limitations under the License.
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\Contracts\BatchGridAreaDto.cs">
-      <Link>Batches\BatchGridAreaDto.cs</Link>
-    </Compile>
     <Compile Include="..\..\Contracts\BatchRequestDto.cs">
       <Link>Batches\BatchRequestDto.cs</Link>
     </Compile>
     <Compile Include="..\..\Contracts\BatchSearchDto.cs">
       <Link>Batches\BatchSearchDto.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Contracts\GridAreaDto.cs">
+      <Link>Batches\GridAreaDto.cs</Link>
     </Compile>
     <Compile Include="..\..\Contracts\WholesaleProcessType.cs">
       <Link>Processes\WholesaleProcessType.cs</Link>

--- a/source/dotnet/Services/Application/Batches/BatchDto.cs
+++ b/source/dotnet/Services/Application/Batches/BatchDto.cs
@@ -19,4 +19,4 @@ namespace Energinet.DataHub.Wholesale.Application.Batches;
 /// <summary>
 /// An immutable batch.
 /// </summary>
-public sealed record BatchDto(long? RunId, Guid BatchId, DateTimeOffset PeriodStart, DateTimeOffset PeriodEnd, DateTimeOffset? ExecutionTimeStart, DateTimeOffset? ExecutionTimeEnd, BatchState ExecutionState, bool IsBasisDataDownloadAvailable, BatchGridAreaDto[] BatchGridAreas);
+public sealed record BatchDto(long? RunId, Guid BatchId, DateTimeOffset PeriodStart, DateTimeOffset PeriodEnd, DateTimeOffset? ExecutionTimeStart, DateTimeOffset? ExecutionTimeEnd, BatchState ExecutionState, bool IsBasisDataDownloadAvailable, GridAreaDto[] BatchGridAreas);

--- a/source/dotnet/Services/Application/Batches/BatchDto.cs
+++ b/source/dotnet/Services/Application/Batches/BatchDto.cs
@@ -19,4 +19,4 @@ namespace Energinet.DataHub.Wholesale.Application.Batches;
 /// <summary>
 /// An immutable batch.
 /// </summary>
-public sealed record BatchDto(long? RunId, Guid BatchId, DateTimeOffset PeriodStart, DateTimeOffset PeriodEnd, DateTimeOffset? ExecutionTimeStart, DateTimeOffset? ExecutionTimeEnd, BatchState ExecutionState, bool IsBasisDataDownloadAvailable, GridAreaDto[] BatchGridAreas);
+public sealed record BatchDto(long? RunId, Guid BatchId, DateTimeOffset PeriodStart, DateTimeOffset PeriodEnd, DateTimeOffset? ExecutionTimeStart, DateTimeOffset? ExecutionTimeEnd, BatchState ExecutionState, bool IsBasisDataDownloadAvailable, GridAreaDto[] GridAreas);

--- a/source/dotnet/Services/Application/Batches/BatchDtoMapper.cs
+++ b/source/dotnet/Services/Application/Batches/BatchDtoMapper.cs
@@ -47,8 +47,8 @@ public class BatchDtoMapper : IBatchDtoMapper
         };
     }
 
-    private static BatchGridAreaDto[] MapGridAreas(IReadOnlyCollection<GridAreaCode> gridAreaCodes)
+    private static GridAreaDto[] MapGridAreas(IReadOnlyCollection<GridAreaCode> gridAreaCodes)
     {
-        return gridAreaCodes.Select(gridArea => new BatchGridAreaDto(gridArea.Code)).ToArray();
+        return gridAreaCodes.Select(gridArea => new GridAreaDto(gridArea.Code)).ToArray();
     }
 }

--- a/source/dotnet/Services/WebApi/Controllers/V2/BatchDtoV2Mapper.cs
+++ b/source/dotnet/Services/WebApi/Controllers/V2/BatchDtoV2Mapper.cs
@@ -28,6 +28,6 @@ public class BatchDtoV2Mapper : IBatchDtoV2Mapper
             batchDto.ExecutionTimeEnd,
             batchDto.ExecutionState,
             batchDto.IsBasisDataDownloadAvailable,
-            batchDto.BatchGridAreas);
+            batchDto.GridAreas);
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

This PR renames BatchGridAreaDto to GridAreaDto to better reflect that it is a grid area object and not a specific grid area on a batch object.

The next PR will create a new dto with the name BatchGridAreaDto that contains a batch with a specific grid area and its processes.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #317 
