### PR TITLE
fix: TYPEOFMP in masterdata

### DIFF
--- a/source/databricks/package/balance_fixing_total_production.py
+++ b/source/databricks/package/balance_fixing_total_production.py
@@ -419,12 +419,8 @@ def _get_output_master_basis_data_df(
     period_start_datetime: datetime,
     period_end_datetime: datetime,
 ) -> DataFrame:
-    productionType = MeteringPointType.production.value
     return (
         metering_point_df.withColumn(
-            "TYPEOFMP", when(col("MeteringPointType") == productionType, "E18")
-        )
-        .withColumn(
             "EffectiveDate",
             when(
                 col("EffectiveDate") < period_start_datetime, period_start_datetime
@@ -444,7 +440,7 @@ def _get_output_master_basis_data_df(
             col("GridAreaCode").alias("GRIDAREA"),
             col("ToGridAreaCode").alias("TOGRIDAREA"),
             col("FromGridAreaCode").alias("FROMGRIDAREA"),
-            col("TYPEOFMP"),
+            col("MeteringPointType").alias("TYPEOFMP"),
             col("SettlementMethod").alias("SETTLEMENTMETHOD"),
             col("EnergySupplierId").alias(("ENERGYSUPPLIERID")),
         )

--- a/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_output_master_basis_data_df.py
+++ b/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_output_master_basis_data_df.py
@@ -116,7 +116,7 @@ def test__columns_have_expected_values(
         grid_area_code=expected_grid_area_code,
         effective_date=expected_effective_date,
         to_effective_date=expected_to_effective_date,
-        meteringpoint_type="E18",
+        meteringpoint_type=NewMeteringPointType.production.value,
         from_grid_area=expected_from_grid_area,
         to_grid_area=expected_to_grid_area,
         settlement_method=expected_settlement_method,

--- a/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_output_master_basis_data_df.py
+++ b/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_output_master_basis_data_df.py
@@ -116,7 +116,7 @@ def test__columns_have_expected_values(
         grid_area_code=expected_grid_area_code,
         effective_date=expected_effective_date,
         to_effective_date=expected_to_effective_date,
-        meteringpoint_type=MeteringPointType.production.value,
+        meteringpoint_type="E18",
         from_grid_area=expected_from_grid_area,
         to_grid_area=expected_to_grid_area,
         settlement_method=expected_settlement_method,

--- a/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_output_master_basis_data_df.py
+++ b/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_output_master_basis_data_df.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from package.codelists import MeteringPointType, MeteringPointResolution
+from package.codelists import NewMeteringPointType, MeteringPointResolution
 from package.balance_fixing_total_production import _get_output_master_basis_data_df
 from datetime import datetime
 
@@ -28,7 +28,7 @@ def metering_point_period_df_factory(spark, timestamp_factory):
         grid_area_code="some-grid-area",
         effective_date: datetime = timestamp_factory("2022-06-08T22:00:00.000Z"),
         to_effective_date: datetime = timestamp_factory("2022-06-10T22:00:00.000Z"),
-        meteringpoint_type=MeteringPointType.production.value,
+        meteringpoint_type=NewMeteringPointType.production.value,
         from_grid_area="some-from-grid-area",
         to_grid_area="some-to-grid-area",
         settlement_method="some-settlement-method",

--- a/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_output_master_basis_data_df.py
+++ b/source/databricks/tests/integration/calculator/balance_fixing_total_production/test_get_output_master_basis_data_df.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from package.codelists import NewMeteringPointType, MeteringPointResolution
+from package.codelists import NewMeteringPointType, NewMeteringPointResolution
 from package.balance_fixing_total_production import _get_output_master_basis_data_df
 from datetime import datetime
 
@@ -32,7 +32,7 @@ def metering_point_period_df_factory(spark, timestamp_factory):
         from_grid_area="some-from-grid-area",
         to_grid_area="some-to-grid-area",
         settlement_method="some-settlement-method",
-        resolution=MeteringPointResolution.hour.value,
+        resolution=NewMeteringPointResolution.hour.value,
         energy_supplier_id="some-energy-supplier-id",
     ):
         row = {
@@ -147,10 +147,10 @@ def test__both_hour_and_quarterly_resolution_data_are_in_basis_data(
 ):
     expected_number_of_metering_points = 2
     metering_point_period_df = metering_point_period_df_factory(
-        meteringpoint_id="1", resolution=MeteringPointResolution.quarterly.value
+        meteringpoint_id="1", resolution=NewMeteringPointResolution.quarterly.value
     ).union(
         metering_point_period_df_factory(
-            meteringpoint_id="2", resolution=MeteringPointResolution.hour.value
+            meteringpoint_id="2", resolution=NewMeteringPointResolution.hour.value
         )
     )
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

We were missing the field `TYPEOFMP` due to a missing refactor since we transitioned to the static metering point dataset.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #502 
