### PR TITLE
fix: Add missing `python-dateutil` module to wheel

### DIFF
--- a/source/databricks/setup.py
+++ b/source/databricks/setup.py
@@ -28,6 +28,7 @@ setup(
         "azure-storage-file-datalake==12.9.1",
         "azure-storage-blob==12.14.1",
         "databricks-cli==0.17.3",
+        "python-dateutil==1.16.0",
     ],
     entry_points={
         "console_scripts": [

--- a/source/databricks/setup.py
+++ b/source/databricks/setup.py
@@ -28,7 +28,7 @@ setup(
         "azure-storage-file-datalake==12.9.1",
         "azure-storage-blob==12.14.1",
         "databricks-cli==0.17.3",
-        "python-dateutil==1.16.0",
+        "python-dateutil==2.8.2",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
