### PR TITLE
build: remove test folder from the wheel

### DIFF
--- a/source/databricks/setup.py
+++ b/source/databricks/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description="",
     long_description_content_type="text/markdown",
     license="MIT",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     install_requires=[
         "ConfigArgParse==1.5.3",
         "pyspark==3.3.0",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

This change will make sure the `tests` folder is not included when building the wheel.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #610 
