### PR TITLE
refac: remove snapshot-datetime

### DIFF
--- a/source/contracts/internal/calculation-job-parameters-reference.txt
+++ b/source/contracts/internal/calculation-job-parameters-reference.txt
@@ -7,6 +7,5 @@
 
 --batch-id={batch-id}
 --batch-grid-areas=[805, 806]
---batch-snapshot-datetime=2022-06-02T21:59:00Z
 --batch-period-start-datetime=2022-05-31T22:00:00Z
 --batch-period-end-datetime=2022-06-01T22:00:00Z

--- a/source/databricks/package/calculator_job.py
+++ b/source/databricks/package/calculator_job.py
@@ -46,7 +46,6 @@ def _get_valid_args_or_throw(command_line_args: list[str]) -> argparse.Namespace
 
     # Run parameters
     p.add("--batch-id", type=str, required=True)
-    p.add("--batch-snapshot-datetime", type=valid_date, required=True)
     p.add("--batch-grid-areas", type=valid_list, required=True)
     p.add("--batch-period-start-datetime", type=valid_date, required=True)
     p.add("--batch-period-end-datetime", type=valid_date, required=True)

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -54,7 +54,6 @@ def test_data_job_parameters(
             "process_results_path": f"{data_lake_path}/{worker_id}/results",
             "batch_id": executed_batch_id,
             "batch_grid_areas": [805, 806],
-            "batch_snapshot_datetime": timestamp_factory("2022-09-02T21:59:00.000Z"),
             "batch_period_start_datetime": timestamp_factory(
                 "2018-01-01T22:00:00.000Z"
             ),

--- a/source/dotnet/Services/Infrastructure/JobRunner/DatabricksCalculatorJobParametersFactory.cs
+++ b/source/dotnet/Services/Infrastructure/JobRunner/DatabricksCalculatorJobParametersFactory.cs
@@ -35,8 +35,6 @@ public class DatabricksCalculatorJobParametersFactory : ICalculatorJobParameters
         {
             $"--batch-id={batch.Id}",
             $"--batch-grid-areas=[{gridAreas}]",
-            // Subtract 1 minute to prevent race condition and thus problems with fetching basis data correctly later
-            $"--batch-snapshot-datetime={_clock.GetCurrentInstant().Minus(Duration.FromMinutes(1))}",
             $"--batch-period-start-datetime={batch.PeriodStart}",
             $"--batch-period-end-datetime={batch.PeriodEnd}",
         };


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

This PR will remove any remnants of the "snapshot-datetime". I have made sure that the `calculator-job` is not called with the parameter any longer.

https://github.com/Energinet-DataHub/dh3-infrastructure/blob/main/wholesale/terraform/main/dbwj-calculator.tf
 
## References
* #625 
