### PR TITLE
refac: comment in tests in test_subscription_calculators

### DIFF
--- a/source/databricks/tests/integration/calculator/steps/wholesale/test_subscription_calculators.py
+++ b/source/databricks/tests/integration/calculator/steps/wholesale/test_subscription_calculators.py
@@ -376,9 +376,9 @@ subscription_charges_dataset_4 = [
     "subscription_charges,expected",
     [
         (subscription_charges_dataset_1, 1),
-        # (subscription_charges_dataset_2, 0),
-        # (subscription_charges_dataset_3, 0),
-        # (subscription_charges_dataset_4, 0),
+        (subscription_charges_dataset_2, 0),
+        (subscription_charges_dataset_3, 0),
+        (subscription_charges_dataset_4, 0),
     ],
 )
 def test__filter_on_metering_point_type_and_settlement_method__filters_on_E17_and_D01(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Some tests were left out on my last PR. This PR will reintroduce some tests in `test_subscription_calculators.py`
## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #625
