### PR TITLE
fix: Validate batch period end

### DIFF
--- a/source/dotnet/Services/Domain/BatchAggregate/Batch.cs
+++ b/source/dotnet/Services/Domain/BatchAggregate/Batch.cs
@@ -83,9 +83,23 @@ public class Batch
 
     public JobRunId? RunId { get; private set; }
 
+    /// <summary>
+    /// Must be exactly at the beginning (at 00:00:00 o'clock) of the local date.
+    /// </summary>
     public Instant PeriodStart { get; }
 
+    /// <summary>
+    /// Must be exactly 1 ms before the end (midnight) of the local date.
+    /// The 1 ms off is by design originating from the front-end decision on how to handle date periods.
+    /// </summary>
     public Instant PeriodEnd { get; }
+
+    /// <summary>
+    /// Gets an open-ended period end. That is a period end, which is exactly at midnight and thus exclusive.
+    /// This is used in calculations as it prevents loss of e.g. time-series received in the last millisecond
+    /// before midnight.
+    /// </summary>
+    public Instant OpenPeriodEnd => PeriodEnd.Plus(Duration.FromMilliseconds(1));
 
     public bool IsBasisDataDownloadAvailable { get; set; }
 

--- a/source/dotnet/Services/Domain/BatchAggregate/Batch.cs
+++ b/source/dotnet/Services/Domain/BatchAggregate/Batch.cs
@@ -41,6 +41,17 @@ public class Batch
             throw new ArgumentException("periodStart is greater or equal to periodEnd");
         }
 
+        // Validate that period end is set to 1 millisecond before midnight
+        // The hard coded time zone will be refactored out of this class in an upcoming PR
+        var dateTimeZone = DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!;
+        var zonedDateTime = new ZonedDateTime(PeriodEnd.Plus(Duration.FromMilliseconds(1)), dateTimeZone);
+        var localDateTime = zonedDateTime.LocalDateTime;
+        if (localDateTime.TimeOfDay != LocalTime.Midnight)
+        {
+            throw new ArgumentException(
+                $"The period end '{periodEnd.ToString()}' must be one millisecond before midnight.");
+        }
+
         ExecutionTimeStart = _clock.GetCurrentInstant();
         ExecutionTimeEnd = null;
         IsBasisDataDownloadAvailable = false;

--- a/source/dotnet/Services/DomainTests/WebApiTests.cs
+++ b/source/dotnet/Services/DomainTests/WebApiTests.cs
@@ -117,7 +117,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
             {
                 // Arrange
                 var startDate = new DateTimeOffset(2020, 1, 28, 23, 0, 0, TimeSpan.Zero);
-                var endDate = new DateTimeOffset(2020, 1, 29, 23, 0, 0, TimeSpan.Zero);
+                var endDate = new DateTimeOffset(2020, 1, 29, 23, 0, 0, TimeSpan.Zero).AddMilliseconds(-1);
                 var batchRequestDto = new BatchRequestDto(
                     ProcessType.BalanceFixing,
                     new List<string> { ExistingGridAreaCode },

--- a/source/dotnet/Services/Infrastructure/JobRunner/DatabricksCalculatorJobParametersFactory.cs
+++ b/source/dotnet/Services/Infrastructure/JobRunner/DatabricksCalculatorJobParametersFactory.cs
@@ -14,19 +14,11 @@
 
 using Energinet.DataHub.Wholesale.Application.JobRunner;
 using Energinet.DataHub.Wholesale.Domain.BatchAggregate;
-using NodaTime;
 
 namespace Energinet.DataHub.Wholesale.Infrastructure.JobRunner;
 
 public class DatabricksCalculatorJobParametersFactory : ICalculatorJobParametersFactory
 {
-    private readonly IClock _clock;
-
-    public DatabricksCalculatorJobParametersFactory(IClock clock)
-    {
-        _clock = clock;
-    }
-
     public IEnumerable<string> CreateParameters(Batch batch)
     {
         var gridAreas = string.Join(", ", batch.GridAreaCodes.Select(c => c.Code));
@@ -36,7 +28,7 @@ public class DatabricksCalculatorJobParametersFactory : ICalculatorJobParameters
             $"--batch-id={batch.Id}",
             $"--batch-grid-areas=[{gridAreas}]",
             $"--batch-period-start-datetime={batch.PeriodStart}",
-            $"--batch-period-end-datetime={batch.PeriodEnd}",
+            $"--batch-period-end-datetime={batch.OpenPeriodEnd}",
         };
     }
 }

--- a/source/dotnet/Services/IntegrationTests/ProcessManager/BasisDataApplicationServiceTests.cs
+++ b/source/dotnet/Services/IntegrationTests/ProcessManager/BasisDataApplicationServiceTests.cs
@@ -26,6 +26,7 @@ using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.Fixture.Database;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
+using NodaTime.Extensions;
 using Test.Core;
 using Xunit;
 
@@ -101,8 +102,8 @@ public sealed class BasisDataApplicationServiceTests
         var batch = new Batch(
             ProcessType.BalanceFixing,
             new[] { gridAreaCode },
-            SystemClock.Instance.GetCurrentInstant(),
-            SystemClock.Instance.GetCurrentInstant(),
+            DateTimeOffset.Parse("2021-12-31T23:00Z").ToInstant(),
+            DateTimeOffset.Parse("2022-01-31T22:59:59.999Z").ToInstant(),
             SystemClock.Instance);
         batch.SetPrivateProperty(b => b.Id, batchCompletedEvent.BatchId);
         return batch;

--- a/source/dotnet/Services/IntegrationTests/ProcessManager/BatchApplicationServiceTests.cs
+++ b/source/dotnet/Services/IntegrationTests/ProcessManager/BatchApplicationServiceTests.cs
@@ -72,7 +72,7 @@ public sealed class BatchApplicationServiceTests
         const string gridAreaCode = "123";
 
         // Act
-        await target.CreateAsync(new BatchRequestDto(ProcessType.BalanceFixing, new[] { gridAreaCode }, DateTimeOffset.Now, DateTimeOffset.Now));
+        await target.CreateAsync(CreateBatchRequestDto(gridAreaCode));
         await target.StartSubmittingAsync();
         await target.UpdateExecutionStateAsync();
 
@@ -102,7 +102,7 @@ public sealed class BatchApplicationServiceTests
         const string gridAreaCode = "456";
 
         // Act
-        await target.CreateAsync(new BatchRequestDto(ProcessType.BalanceFixing, new[] { gridAreaCode }, DateTimeOffset.Now, DateTimeOffset.Now));
+        await target.CreateAsync(CreateBatchRequestDto(gridAreaCode));
         await target.StartSubmittingAsync();
         await target.UpdateExecutionStateAsync();
 
@@ -132,7 +132,7 @@ public sealed class BatchApplicationServiceTests
         const string gridAreaCode = "789";
 
         // Act
-        await target.CreateAsync(new BatchRequestDto(ProcessType.BalanceFixing, new[] { gridAreaCode }, DateTimeOffset.Now, DateTimeOffset.Now));
+        await target.CreateAsync(CreateBatchRequestDto(gridAreaCode));
         await target.StartSubmittingAsync();
         await target.UpdateExecutionStateAsync();
 
@@ -179,5 +179,14 @@ public sealed class BatchApplicationServiceTests
                 },
         };
         return calculatorJob;
+    }
+
+    private static BatchRequestDto CreateBatchRequestDto(string gridAreaCode)
+    {
+        return new BatchRequestDto(
+            ProcessType.BalanceFixing,
+            new[] { gridAreaCode },
+            DateTimeOffset.Parse("2021-12-31T23:00Z"),
+            DateTimeOffset.Parse("2022-01-31T22:59:59.999Z"));
     }
 }

--- a/source/dotnet/Services/IntegrationTests/TestCommon/ProcessManager/SubmitCreatedBatchesEndpointTests.cs
+++ b/source/dotnet/Services/IntegrationTests/TestCommon/ProcessManager/SubmitCreatedBatchesEndpointTests.cs
@@ -24,8 +24,8 @@ using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.Function;
 using Energinet.DataHub.Wholesale.ProcessManager.Endpoints;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using NodaTime;
+using NodaTime.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -117,8 +117,9 @@ public class SubmitCreatedBatchesEndpointTests
         private async Task<Guid> CreateAndSavePendingBatch(string gridAreaCode)
         {
             await using var dbContext = Fixture.DatabaseManager.CreateDbContext();
-            var periodStart = Instant.FromDateTimeOffset(DateTimeOffset.Now);
-            var periodEnd = periodStart.PlusHours(1);
+            var periodStart = DateTimeOffset.Parse("2021-12-31T23:00Z").ToInstant();
+            var periodEnd = DateTimeOffset.Parse("2022-01-31T22:59:59.999Z").ToInstant();
+
             var clock = SystemClock.Instance;
             var pendingBatch = new Batch(
                 ProcessType.BalanceFixing,

--- a/source/dotnet/Services/IntegrationTests/TestCommon/WebApi/BatchControllerTests.cs
+++ b/source/dotnet/Services/IntegrationTests/TestCommon/WebApi/BatchControllerTests.cs
@@ -61,30 +61,6 @@ public class BatchControllerTests :
     }
 
     [Theory]
-    [InlineData("2023-01-31T23:00Z")]
-    [InlineData("2023-01-31T22:59:59Z")]
-    [InlineData("2023-01-31T22:59:59.9999999Z")]
-    [InlineData("2023-01-31")]
-    public async Task CreateAsync_WhenCalledWithInvalidPeriodEnd_ReturnsBadRequest(string periodEndString)
-    {
-        // Arrange
-        const string baseUrl = "/v2/batch";
-        var periodStart = DateTimeOffset.Parse("2022-12-31T23:00:00Z");
-        var periodEnd = DateTimeOffset.Parse(periodEndString);
-        var batchRequest = new BatchRequestDto(
-            ProcessType.BalanceFixing,
-            new List<string> { "805" },
-            periodStart,
-            periodEnd);
-
-        // Act
-        var response = await _client.PostAsJsonAsync(baseUrl, batchRequest, CancellationToken.None);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-    }
-
-    [Theory]
     [InlineData("/v2/batch")]
     public async Task SearchAsync_WhenCalled_AlwaysReturnsOk(string baseUrl)
     {

--- a/source/dotnet/Services/IntegrationTests/TestCommon/WebApi/BatchControllerTests.cs
+++ b/source/dotnet/Services/IntegrationTests/TestCommon/WebApi/BatchControllerTests.cs
@@ -55,20 +55,9 @@ public class BatchControllerTests :
     [InlineData("/v2/batch")]
     public async Task CreateAsync_WhenCalled_AlwaysReturnsOk(string baseUrl)
     {
-        // Arrange
-        var periodStart = DateTimeOffset.Now;
-        var periodEnd = periodStart.AddHours(1);
-        var batchRequest = new BatchRequestDto(
-            ProcessType.BalanceFixing,
-            new List<string> { "805" },
-            periodStart,
-            periodEnd);
-
-        // Act
-        var response = await _client.PostAsJsonAsync(baseUrl, batchRequest, CancellationToken.None);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var batchRequest = CreateBatchRequestDto();
+        var actual = await _client.PostAsJsonAsync(baseUrl, batchRequest, CancellationToken.None);
+        actual.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Theory]
@@ -100,15 +89,7 @@ public class BatchControllerTests :
     public async Task SearchAsync_WhenCalled_AlwaysReturnsOk(string baseUrl)
     {
         // Arrange
-        var minExecutionTime = new DateTimeOffset(
-            2022,
-            01,
-            02,
-            1,
-            2,
-            3,
-            50,
-            TimeSpan.Zero);
+        var minExecutionTime = new DateTimeOffset(2022, 01, 02, 1, 2, 3, 50, TimeSpan.Zero);
         var maxExecutionTime = minExecutionTime + TimeSpan.FromMinutes(33);
         var batchSearchDto = new BatchSearchDto(minExecutionTime, maxExecutionTime);
 
@@ -125,13 +106,7 @@ public class BatchControllerTests :
     public async Task GetAsync_WhenCalled_ReturnsOk(string baseUrl)
     {
         // Arrange
-        var periodStart = DateTimeOffset.Now;
-        var periodEnd = periodStart.AddHours(1);
-        var batchRequest = new BatchRequestDto(
-            ProcessType.BalanceFixing,
-            new List<string> { "805" },
-            periodStart,
-            periodEnd);
+        var batchRequest = CreateBatchRequestDto();
         var responseCreateAsync = await _client.PostAsJsonAsync(baseUrl, batchRequest, CancellationToken.None);
         var batchId = await responseCreateAsync.Content.ReadFromJsonAsync<Guid>();
 
@@ -141,5 +116,17 @@ public class BatchControllerTests :
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private static BatchRequestDto CreateBatchRequestDto()
+    {
+        var periodStart = DateTimeOffset.Parse("2021-12-31T23:00Z");
+        var periodEnd = DateTimeOffset.Parse("2022-01-31T22:59:59.999Z");
+        var batchRequest = new BatchRequestDto(
+            ProcessType.BalanceFixing,
+            new List<string> { "805" },
+            periodStart,
+            periodEnd);
+        return batchRequest;
     }
 }

--- a/source/dotnet/Services/IntegrationTests/TestCommon/WebApi/BatchControllerTests.cs
+++ b/source/dotnet/Services/IntegrationTests/TestCommon/WebApi/BatchControllerTests.cs
@@ -72,6 +72,30 @@ public class BatchControllerTests :
     }
 
     [Theory]
+    [InlineData("2023-01-31T23:00Z")]
+    [InlineData("2023-01-31T22:59:59Z")]
+    [InlineData("2023-01-31T22:59:59.9999999Z")]
+    [InlineData("2023-01-31")]
+    public async Task CreateAsync_WhenCalledWithInvalidPeriodEnd_ReturnsBadRequest(string periodEndString)
+    {
+        // Arrange
+        const string baseUrl = "/v2/batch";
+        var periodStart = DateTimeOffset.Parse("2022-12-31T23:00:00Z");
+        var periodEnd = DateTimeOffset.Parse(periodEndString);
+        var batchRequest = new BatchRequestDto(
+            ProcessType.BalanceFixing,
+            new List<string> { "805" },
+            periodStart,
+            periodEnd);
+
+        // Act
+        var response = await _client.PostAsJsonAsync(baseUrl, batchRequest, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Theory]
     [InlineData("/v2/batch")]
     public async Task SearchAsync_WhenCalled_AlwaysReturnsOk(string baseUrl)
     {

--- a/source/dotnet/Services/Tests/Application/BatchDtoMapperTests.cs
+++ b/source/dotnet/Services/Tests/Application/BatchDtoMapperTests.cs
@@ -16,14 +16,10 @@ using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
 using Energinet.DataHub.Wholesale.Application.Batches;
 using Energinet.DataHub.Wholesale.Contracts;
 using Energinet.DataHub.Wholesale.Domain.BatchAggregate;
-using Energinet.DataHub.Wholesale.Domain.GridAreaAggregate;
 using Energinet.DataHub.Wholesale.Tests.Domain.BatchAggregate;
 using FluentAssertions;
-using Moq;
-using NodaTime;
 using Xunit;
 using Xunit.Categories;
-using ProcessType = Energinet.DataHub.Wholesale.Domain.ProcessAggregate.ProcessType;
 
 namespace Energinet.DataHub.Wholesale.Tests.Application;
 
@@ -51,11 +47,7 @@ public class BatchDtoMapperTests
         BatchDtoMapper sut)
     {
         // Arrange
-        var clockMock = new Mock<IClock>();
-        var someGridAreasIds = new List<GridAreaCode> { new("004"), new("805") };
-        var somePeriodStart = Instant.FromUtc(2022, 5, 31, 22, 00);
-        var somePeriodEnd = Instant.FromUtc(2022, 6, 1, 22, 00);
-        var batch = new Batch(ProcessType.BalanceFixing, someGridAreasIds, somePeriodStart, somePeriodEnd, clockMock.Object);
+        var batch = new BatchBuilder().Build();
 
         // Act
         var batchDto = sut.Map(batch);
@@ -71,11 +63,7 @@ public class BatchDtoMapperTests
         BatchDtoMapper sut)
     {
         // Arrange
-        var clockMock = new Mock<IClock>();
-        var someGridAreasIds = new List<GridAreaCode> { new("004"), new("805") };
-        var somePeriodStart = Instant.FromUtc(2022, 5, 31, 22, 00);
-        var somePeriodEnd = Instant.FromUtc(2022, 6, 1, 22, 00);
-        var batch = new Batch(ProcessType.BalanceFixing, someGridAreasIds, somePeriodStart, somePeriodEnd, clockMock.Object);
+        var batch = new BatchBuilder().Build();
         batch.MarkAsExecuting(); // this sets ExecutionTimeStart
         batch.MarkAsCompleted(); // this sets ExecutionTimeEnd
 

--- a/source/dotnet/Services/Tests/Domain/BatchAggregate/BatchBuilder.cs
+++ b/source/dotnet/Services/Tests/Domain/BatchAggregate/BatchBuilder.cs
@@ -24,11 +24,20 @@ namespace Energinet.DataHub.Wholesale.Tests.Domain.BatchAggregate;
 public class BatchBuilder
 {
     private readonly IClock _clock = SystemClock.Instance;
-    private readonly Instant _periodStart = Instant.FromDateTimeOffset(DateTimeOffset.Now);
-    private readonly Instant _periodEnd = Instant.FromDateTimeOffset(DateTimeOffset.Now).PlusHours(1);
+    private readonly Instant _periodStart;
+    private readonly Instant _periodEnd;
 
     private BatchExecutionState? _state;
     private List<GridAreaCode> _gridAreaCodes = new() { new("805") };
+
+    public BatchBuilder()
+    {
+        // Create a valid period representing January in a +01:00 offset (e.g. time zone "Europe/Copenhagen")
+        // In order to be valid the last millisecond must be omitted
+        var firstOfJanuary = DateTimeOffset.Parse("2021-01-31T23:00Z");
+        _periodStart = Instant.FromDateTimeOffset(firstOfJanuary);
+        _periodEnd = Instant.FromDateTimeOffset(firstOfJanuary.AddMonths(1).AddMilliseconds(-1));
+    }
 
     public BatchBuilder WithStateSubmitted()
     {

--- a/source/dotnet/Services/Tests/Domain/BatchAggregate/BatchFactoryTests.cs
+++ b/source/dotnet/Services/Tests/Domain/BatchAggregate/BatchFactoryTests.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
-using Energinet.DataHub.Wholesale.Contracts.WholesaleProcess;
 using Energinet.DataHub.Wholesale.Domain.BatchAggregate;
 using Energinet.DataHub.Wholesale.Domain.ProcessAggregate;
 using FluentAssertions;
@@ -26,37 +25,31 @@ namespace Energinet.DataHub.Wholesale.Tests.Domain.BatchAggregate;
 [UnitTest]
 public class BatchFactoryTests
 {
+    private readonly DateTimeOffset _startDate = DateTimeOffset.Parse("2021-12-31T23:00Z");
+    private readonly DateTimeOffset _endDate = DateTimeOffset.Parse("2022-01-31T22:59:59.999Z");
+    private readonly List<string> _someGridAreasIds = new() { "004", "805" };
+
     [Theory]
     [InlineAutoMoqData]
     public void Create_ReturnsBatchWithCorrectPeriod(BatchFactory sut)
     {
-        // Arrange
-        var startDate = new DateTimeOffset(2022, 5, 1, 8, 6, 32, TimeSpan.Zero);
-        var endDate = new DateTimeOffset(2022, 5, 5, 8, 6, 32, TimeSpan.Zero);
-        var someGridAreasIds = new List<string> { "004", "805" };
-
         // Act
-        var batch = sut.Create(ProcessType.BalanceFixing, someGridAreasIds, startDate, endDate);
+        var batch = sut.Create(ProcessType.BalanceFixing, _someGridAreasIds, _startDate, _endDate);
 
         // Assert
-        batch.PeriodStart.Should().Be(Instant.FromDateTimeOffset(startDate));
-        batch.PeriodEnd.Should().Be(Instant.FromDateTimeOffset(endDate));
+        batch.PeriodStart.Should().Be(Instant.FromDateTimeOffset(_startDate));
+        batch.PeriodEnd.Should().Be(Instant.FromDateTimeOffset(_endDate));
     }
 
     [Theory]
     [InlineAutoMoqData]
     public void Create_ReturnsBatchWithCorrectGridAreas(BatchFactory sut)
     {
-        // Arrange
-        var startDate = new DateTimeOffset(2022, 5, 1, 8, 6, 32, TimeSpan.Zero);
-        var endDate = new DateTimeOffset(2022, 5, 5, 8, 6, 32, TimeSpan.Zero);
-        var someGridAreasIds = new List<string> { "004", "805" };
-
         // Act
-        var batch = sut.Create(ProcessType.BalanceFixing, someGridAreasIds, startDate, endDate);
+        var batch = sut.Create(ProcessType.BalanceFixing, _someGridAreasIds, _startDate, _endDate);
 
         // Assert
-        batch.GridAreaCodes.Select(x => x.Code).Should().Contain(someGridAreasIds);
-        batch.GridAreaCodes.Count.Should().Be(someGridAreasIds.Count);
+        batch.GridAreaCodes.Select(x => x.Code).Should().Contain(_someGridAreasIds);
+        batch.GridAreaCodes.Count.Should().Be(_someGridAreasIds.Count);
     }
 }

--- a/source/dotnet/Services/Tests/Infrastructure/JobRunner/DatabricksCalculatorJobParametersFactoryTests.cs
+++ b/source/dotnet/Services/Tests/Infrastructure/JobRunner/DatabricksCalculatorJobParametersFactoryTests.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.Wholesale.Tests.TestHelpers;
 using FluentAssertions;
 using Moq;
 using NodaTime;
+using NodaTime.Extensions;
 using Xunit;
 
 namespace Energinet.DataHub.Wholesale.Tests.Infrastructure.JobRunner;
@@ -35,12 +36,11 @@ public class DatabricksCalculatorJobParametersFactoryTests
         DatabricksCalculatorJobParametersFactory sut)
     {
         // Arrange
-        clockMock.Setup(clock => clock.GetCurrentInstant()).Returns(Instant.FromUtc(2022, 6, 2, 22, 00));
         var batch = new Batch(
             ProcessType.BalanceFixing,
             new List<GridAreaCode> { new("805"), new("806") },
-            Instant.FromUtc(2022, 5, 31, 22, 00),
-            Instant.FromUtc(2022, 6, 1, 22, 00),
+            DateTimeOffset.Parse("2022-05-31T22:00Z").ToInstant(),
+            DateTimeOffset.Parse("2022-06-01T21:59:59.999Z").ToInstant(),
             clockMock.Object);
 
         using var stream = EmbeddedResources.GetStream("Infrastructure.JobRunner.calculation-job-parameters-reference.txt");


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Observed behaviour:
- 1 millisecond offset from midnight (period end received from BFF) may cause missing some calculation input
- Generated basis data reports has wrong period end time (off by 1 millisecond from midnight)

Decided solution:
- Accept - and validate - that period end received from BFF is exactly one millisecond before midnight.
- Invoke calculator job with a period end value adjusted one millisecond to be exactly at midnight in order to prevent missing required calculation input
- (Will be done in another PR) Wholesale web API returns HTTP BadRequest upon unexpected period end time

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #664
