### PR TITLE
fix: calculator cant call exit

### DIFF
--- a/source/databricks/package/calculator_job.py
+++ b/source/databricks/package/calculator_job.py
@@ -182,7 +182,7 @@ def _start(command_line_args: list[str]) -> None:
 
     if islocked(args.data_storage_account_name, args.data_storage_account_key):
         log("Exiting because storage is locked due to data migrations running.")
-        exit(3)
+        sys.exit(3)
 
     spark = initialize_spark(
         args.data_storage_account_name, args.data_storage_account_key


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description
This Pr will change the call to `exit()` when exiting the calculator if the storage is locked to `sys.exit()`. The error is observed on this run here: https://adb-5870161604877074.14.azuredatabricks.net/?o=5870161604877074#job/1119732257340915/run/2667721

A fix was found here: https://stackoverflow.com/questions/45066518/nameerror-name-exit-is-not-defined

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #199
