### PR TITLE
refac: Make migration contracts more specific

### DIFF
--- a/source/databricks/package/schemas/metering_point_period_schema.py
+++ b/source/databricks/package/schemas/metering_point_period_schema.py
@@ -42,7 +42,7 @@ metering_point_period_schema = StructType(
         # Used in balance fixing and settlement.
         # Example: 578710000000000103
         StructField("MeteringPointId", StringType(), False),
-        # "E17" (consumption) | "E18" (production) | "E20" (exchange) | "D01"-"D99" (child)
+        # "E17" (consumption) | "E18" (production) | "E20" (exchange) | "D01"-"D16", "D19", "D21"-"D98" (child)
         # Used in balance fixing and settlement. However, child metering points are only used in settlement.
         # Example: E20
         StructField("Type", StringType(), False),

--- a/source/databricks/package/schemas/metering_point_period_schema.py
+++ b/source/databricks/package/schemas/metering_point_period_schema.py
@@ -42,7 +42,7 @@ metering_point_period_schema = StructType(
         # Used in balance fixing and settlement.
         # Example: 578710000000000103
         StructField("MeteringPointId", StringType(), False),
-        # "E17" (consumption) | "E18" (production) | "E20" (exchange) | "D01"-"D16", "D19", "D21"-"D98" (child)
+        # "E17" (consumption) | "E18" (production) | "E20" (exchange) | "D01", "D03"-"D16", "D19", "D21"-"D98" (child)
         # Used in balance fixing and settlement. However, child metering points are only used in settlement.
         # Example: E20
         StructField("Type", StringType(), False),

--- a/source/databricks/package/schemas/time_series_point_schema.py
+++ b/source/databricks/package/schemas/time_series_point_schema.py
@@ -35,7 +35,7 @@ time_series_point_schema = StructType(
         # GSRN (18 characters) that uniquely identifies the metering point
         # Example: 578710000000000103
         StructField(Colname.metering_point_id, StringType(), False),
-        # Energy quantity for the given observation time.
+        # Energy quantity in kWh for the given observation time.
         # Null when quality is missing.
         # Example: 1234.534217
         StructField(Colname.quantity, DecimalType(18, 6), True),


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Metering points of type D02, D17, D18, D20, and D99 are not used in wholesale and should be omitted.

Time series quantity must always be in kWh (kilo Watt hour).

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #690
