### PR TITLE
fix: Fix culture error while parsing decimal from string

### DIFF
--- a/source/dotnet/Services/Application/ProcessResult/ProcessStepResultApplicationService.cs
+++ b/source/dotnet/Services/Application/ProcessResult/ProcessStepResultApplicationService.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Globalization;
 using System.Text.Json;
 using Energinet.DataHub.Wholesale.Application.Infrastructure;
 using Energinet.DataHub.Wholesale.Contracts;
@@ -69,7 +70,7 @@ public class ProcessStepResultApplicationService : IProcessStepResultApplication
         var pointsDto = points.Select(
                 point => new TimeSeriesPointDto(
                     DateTimeOffset.Parse(point.quarter_time),
-                    decimal.Parse(point.quantity),
+                    decimal.Parse(point.quantity, CultureInfo.InvariantCulture),
                     point.quality))
             .ToList();
 

--- a/source/dotnet/Services/Tests/Application/ProcessResult/ProcessResultApplicationServiceTests.cs
+++ b/source/dotnet/Services/Tests/Application/ProcessResult/ProcessResultApplicationServiceTests.cs
@@ -65,6 +65,23 @@ public class ProcessResultApplicationServiceTests
     }
 
     [Fact]
+    public async Task GetResultAsync_Quantity_IsRead()
+    {
+        // Arrange
+        var sut = ProcessResultApplicationService();
+
+        // Act
+        var actual = await sut.GetResultAsync(
+            new ProcessStepResultRequestDto(
+                Guid.NewGuid(),
+                GridAreaCode,
+                ProcessStepType.AggregateProductionPerGridArea));
+
+        // Assert
+        actual.TimeSeriesPoints.First().Quantity.Should().Be(1.000m);
+    }
+
+    [Fact]
     public async Task GetResultAsync_Quality_IsRead()
     {
         // Arrange


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
It is best practice to design for globalization and localization. This involves developing in a culture neutral way. See more [here](https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-and-localization).

The added test would fail on host systems not using a culture (number formatting) where '.' (dots) are used as decimal separators.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #199
