### PR TITLE
refac: move file path contract test to test_process_step_result_writer

### DIFF
--- a/source/databricks/package/balance_fixing.py
+++ b/source/databricks/package/balance_fixing.py
@@ -32,7 +32,8 @@ from pyspark.sql.types import DecimalType
 
 
 def calculate_balance_fixing(
-    output_path: str,
+    basis_data_writer: BasisDataWriter,
+    process_step_result_writer: ProcessStepResultWriter,
     metering_points_periods_df: DataFrame,
     timeseries_points: DataFrame,
     period_start_datetime: datetime,
@@ -48,7 +49,7 @@ def calculate_balance_fixing(
     )
 
     _create_and_write_basis_data(
-        output_path,
+        basis_data_writer,
         metering_points_periods_df,
         enriched_time_series_point_df,
         period_start_datetime,
@@ -56,11 +57,11 @@ def calculate_balance_fixing(
         time_zone,
     )
 
-    _calculate(output_path, enriched_time_series_point_df)
+    _calculate(process_step_result_writer, enriched_time_series_point_df)
 
 
 def _create_and_write_basis_data(
-    output_path: str,
+    basis_data_writer: BasisDataWriter,
     metering_points_periods_df: DataFrame,
     enriched_time_series_point_df: DataFrame,
     period_start_datetime: datetime,
@@ -78,15 +79,15 @@ def _create_and_write_basis_data(
         metering_points_periods_df, period_start_datetime, period_end_datetime
     )
 
-    basis_data_writer = BasisDataWriter(output_path)
     basis_data_writer.write(
         master_basis_data_df, timeseries_quarter_df, timeseries_hour_df
     )
 
 
-def _calculate(output_path: str, enriched_time_series_point_df: DataFrame) -> None:
+def _calculate(
+    result_writer: ProcessStepResultWriter, enriched_time_series_point_df: DataFrame
+) -> None:
 
-    result_writer = ProcessStepResultWriter(output_path)
     metadata_fake = Metadata("1", "1", "1", "1")
 
     _calculate_production(result_writer, enriched_time_series_point_df, metadata_fake)

--- a/source/databricks/package/calculator_job.py
+++ b/source/databricks/package/calculator_job.py
@@ -13,13 +13,9 @@
 # limitations under the License.
 
 import sys
+
 import configargparse
-from .calculator_args import CalculatorArgs
-from .args_helper import valid_date, valid_list, valid_log_level
-from .datamigration import islocked
 import package.calculation_input as calculation_input
-from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.types import Row
 from configargparse import argparse
 from package import (
     calculate_balance_fixing,
@@ -29,6 +25,14 @@ from package import (
     initialize_spark,
     log,
 )
+from package.file_writers.basis_data_writer import BasisDataWriter
+from package.file_writers.process_step_result_writer import ProcessStepResultWriter
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import Row
+
+from .args_helper import valid_date, valid_list, valid_log_level
+from .calculator_args import CalculatorArgs
+from .datamigration import islocked
 
 
 def _get_valid_args_or_throw(command_line_args: list[str]) -> argparse.Namespace:
@@ -87,10 +91,14 @@ def _start_calculator(spark: SparkSession, args: CalculatorArgs) -> None:
         args.batch_period_end_datetime,
     )
 
-    output_path = f"{args.wholesale_container_path}/{infrastructure.OUTPUT_FOLDER}/batch_id={args.batch_id}"
+    process_step_result_writer = ProcessStepResultWriter(
+        args.wholesale_container_path, args.batch_id
+    )
+    basis_data_writer = BasisDataWriter(args.wholesale_container_path, args.batch_id)
 
     calculate_balance_fixing(
-        output_path,
+        process_step_result_writer,
+        basis_data_writer,
         metering_point_periods_df,
         timeseries_points_df,
         args.batch_period_start_datetime,

--- a/source/databricks/package/calculator_job.py
+++ b/source/databricks/package/calculator_job.py
@@ -97,8 +97,8 @@ def _start_calculator(spark: SparkSession, args: CalculatorArgs) -> None:
     basis_data_writer = BasisDataWriter(args.wholesale_container_path, args.batch_id)
 
     calculate_balance_fixing(
-        process_step_result_writer,
         basis_data_writer,
+        process_step_result_writer,
         metering_point_periods_df,
         timeseries_points_df,
         args.batch_period_start_datetime,

--- a/source/databricks/package/file_writers/basis_data_writer.py
+++ b/source/databricks/package/file_writers/basis_data_writer.py
@@ -14,14 +14,14 @@
 
 from pyspark.sql import DataFrame
 from package.constants import Colname
+import package.infrastructure as infra
 
 
 class BasisDataWriter:
-    def __init__(
-        self,
-        output_path: str,
-    ):
-        self.__output_path = output_path
+    def __init__(self, container_path: str, batch_id: str):
+        self.__output_path = (
+            f"{container_path}/{infra.get_batch_relative_path(batch_id)}"
+        )
 
     def write(
         self,

--- a/source/databricks/package/file_writers/process_step_result_writer.py
+++ b/source/databricks/package/file_writers/process_step_result_writer.py
@@ -18,11 +18,14 @@ from package.constants.time_series_type import TimeSeriesType
 from package.constants.market_role import MarketRole
 from pyspark.sql.functions import col, lit
 from package.file_writers import actors_writer
+import package.infrastructure as infra
 
 
 class ProcessStepResultWriter:
-    def __init__(self, output_path: str):
-        self.__output_path = output_path
+    def __init__(self, container_path: str, batch_id: str):
+        self.__output_path = (
+            f"{container_path}/{infra.get_batch_relative_path(batch_id)}"
+        )
 
     def write_per_ga(
         self, result_df: DataFrame, time_series_type: TimeSeriesType

--- a/source/databricks/package/infrastructure.py
+++ b/source/databricks/package/infrastructure.py
@@ -72,3 +72,7 @@ def get_master_basis_data_relative_path(batch_id: str, grid_area: str, gln: str)
 
 def _get_batch_path(batch_id: str) -> str:
     return f"{OUTPUT_FOLDER}/batch_id={batch_id}"
+
+
+def _get_batch_folder(container_root_path: str, batch_id: str) -> str:
+    return f"{container_root_path}/{OUTPUT_FOLDER}/batch_id={batch_id}"

--- a/source/databricks/package/infrastructure.py
+++ b/source/databricks/package/infrastructure.py
@@ -39,7 +39,7 @@ def get_result_file_relative_path(
     gln: str,
     time_series_type: TimeSeriesType,
 ) -> str:
-    batch_path = _get_batch_path(batch_id)
+    batch_path = get_batch_relative_path(batch_id)
     return f"{batch_path}/{RESULT_FOLDER}/grid_area={grid_area}/gln={gln}/time_series_type={time_series_type.value}"
 
 
@@ -49,26 +49,26 @@ def get_actors_file_relative_path(
     time_series_type: TimeSeriesType,
     market_role: MarketRole,
 ) -> str:
-    batch_path = _get_batch_path(batch_id)
+    batch_path = get_batch_relative_path(batch_id)
     return f"{batch_path}/{ACTORS_FOLDER}/grid_area={grid_area}/time_series_type={time_series_type.value}/market_role={market_role.value}"
 
 
 def get_time_series_quarter_relative_path(
     batch_id: str, grid_area: str, gln: str
 ) -> str:
-    batch_path = _get_batch_path(batch_id)
+    batch_path = get_batch_relative_path(batch_id)
     return f"{batch_path}/{BASIS_DATA_FOLDER}/time_series_quarter/grid_area={grid_area}/gln={gln}"
 
 
 def get_time_series_hour_relative_path(batch_id: str, grid_area: str, gln: str) -> str:
-    batch_path = _get_batch_path(batch_id)
+    batch_path = get_batch_relative_path(batch_id)
     return f"{batch_path}/{BASIS_DATA_FOLDER}/time_series_hour/grid_area={grid_area}/gln={gln}"
 
 
 def get_master_basis_data_relative_path(batch_id: str, grid_area: str, gln: str) -> str:
-    batch_path = _get_batch_path(batch_id)
+    batch_path = get_batch_relative_path(batch_id)
     return f"{batch_path}/{BASIS_DATA_FOLDER}/master_basis_data/grid_area={grid_area}/gln={gln}"
 
 
-def _get_batch_path(batch_id: str) -> str:
+def get_batch_relative_path(batch_id: str) -> str:
     return f"{OUTPUT_FOLDER}/batch_id={batch_id}"

--- a/source/databricks/package/infrastructure.py
+++ b/source/databricks/package/infrastructure.py
@@ -72,7 +72,3 @@ def get_master_basis_data_relative_path(batch_id: str, grid_area: str, gln: str)
 
 def _get_batch_path(batch_id: str) -> str:
     return f"{OUTPUT_FOLDER}/batch_id={batch_id}"
-
-
-def _get_batch_folder(container_root_path: str, batch_id: str) -> str:
-    return f"{container_root_path}/{OUTPUT_FOLDER}/batch_id={batch_id}"

--- a/source/databricks/tests/conftest.py
+++ b/source/databricks/tests/conftest.py
@@ -90,6 +90,17 @@ def databricks_path(source_path: str) -> str:
 
 
 @pytest.fixture(scope="session")
+def contracts_path(source_path: str) -> str:
+    """
+    Returns the source/contract folder path.
+    Please note that this only works if current folder haven't been changed prior using `os.chdir()`.
+    The correctness also relies on the prerequisite that this function is actually located in a
+    file located directly in the integration tests folder.
+    """
+    return f"{source_path}/contracts"
+
+
+@pytest.fixture(scope="session")
 def timestamp_factory() -> Callable[[str], Optional[datetime]]:
     "Creates timestamp from utc string in correct format yyyy-mm-ddThh:mm:ss.nnnZ"
 

--- a/source/databricks/tests/helpers/assert_calculation_file_path.py
+++ b/source/databricks/tests/helpers/assert_calculation_file_path.py
@@ -54,9 +54,4 @@ def assert_file_path_match_contract(
         extension,
     )
 
-    print("start debug")
-    print(expected_path_expression)
-    print(actual_file_path)
-    print("end debug")
-
     assert re.match(expected_path_expression, actual_file_path)

--- a/source/databricks/tests/helpers/assert_calculation_file_path.py
+++ b/source/databricks/tests/helpers/assert_calculation_file_path.py
@@ -1,0 +1,62 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import yaml
+from enum import Enum
+import re
+from tests.helpers import file_utils
+
+
+class CalculationFileType(Enum):
+    TimeSeriesQuarterBasisData = "time_series_quarter_basis_data_file"
+    TimeSeriesHourBasisData = "time_series_hour_basis_data_file"
+    MasterBasisData = "master_basis_data_file"
+    ResultFile = "result_file"
+    ActorsFile = "actors_file"
+
+
+def calculation_file_paths_contract(
+    contracts_path: str, calculation_file_type: CalculationFileType
+) -> tuple[str, str]:
+    with open(f"{contracts_path}/calculation-file-paths.yml", "r") as stream:
+        file_paths = yaml.safe_load(stream)
+        extension = file_paths[calculation_file_type.value]["extension"]
+        directory_expression = file_paths[calculation_file_type.value][
+            "directory_expression"
+        ]
+
+        return (directory_expression, extension)
+
+
+def assert_file_path_match_contract(
+    contracts_path: str,
+    actual_file_path: str,
+    calculation_file_type: CalculationFileType,
+) -> None:
+    (directory_expression, extension) = calculation_file_paths_contract(
+        contracts_path, calculation_file_type
+    )
+
+    expected_path_expression = file_utils.create_file_path_expression(
+        directory_expression,
+        extension,
+    )
+
+    print("start debug")
+    print(expected_path_expression)
+    print(actual_file_path)
+    print("end debug")
+
+    assert re.match(expected_path_expression, actual_file_path)

--- a/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
+++ b/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
@@ -13,17 +13,23 @@
 # limitations under the License.
 
 import json
-from pathlib import Path
-from package.file_writers.process_step_result_writer import ProcessStepResultWriter
-from package.constants.time_series_type import TimeSeriesType
-from package.constants.market_role import MarketRole
-from package.constants import Colname
-from package.codelists import TimeSeriesQuality, MeteringPointResolution
-from pyspark.sql import SparkSession
-from decimal import Decimal
 from datetime import datetime
-from tests.helpers.file_utils import find_file
+from decimal import Decimal
+from pathlib import Path
 from unittest.mock import patch
+
+from package.codelists import MeteringPointResolution, TimeSeriesQuality
+from package.constants import Colname
+from package.constants.market_role import MarketRole
+from package.constants.time_series_type import TimeSeriesType
+from package.file_writers.process_step_result_writer import ProcessStepResultWriter
+import package.infrastructure as infra
+from pyspark.sql import SparkSession
+from tests.helpers.assert_calculation_file_path import (
+    CalculationFileType,
+    assert_file_path_match_contract,
+)
+from tests.helpers.file_utils import find_file
 
 ACTORS_FOLDER = "actors"
 
@@ -49,26 +55,18 @@ def _create_result_row(
     return row
 
 
-def _get_actors_path(
-    output_path: str,
-    grid_area: str,
-    time_series_type: TimeSeriesType,
-    market_role: MarketRole,
-) -> str:
-    return f"{output_path}/{ACTORS_FOLDER}/grid_area={grid_area}/time_series_type={time_series_type.value}/market_role={market_role.value}"
-
-
 def _get_gln_from_actors_file(
     output_path: str,
+    batch_id: str,
     grid_area: str,
     time_series_type: TimeSeriesType,
     market_role: MarketRole,
 ) -> list[str]:
 
-    actors_path = _get_actors_path(
-        output_path, grid_area, time_series_type, market_role
+    actors_path = infra.get_actors_file_relative_path(
+        batch_id, grid_area, time_series_type, market_role
     )
-    actors_json = find_file(actors_path, "part-*.json")
+    actors_json = find_file(output_path, f"{actors_path}/part-*.json")
 
     gln = []
     with open(actors_json, "r") as json_file:
@@ -87,7 +85,7 @@ def test__write_per_ga__does_not_call_actors_writer(
     # Arrange
     row = [_create_result_row(grid_area="805", energy_supplier_id="123")]
     result_df = spark.createDataFrame(data=row)
-    sut = ProcessStepResultWriter(str(tmpdir))
+    sut = ProcessStepResultWriter(str(tmpdir), "1234")
 
     # Act
     sut.write_per_ga(result_df, TimeSeriesType.NON_PROFILED_CONSUMPTION)
@@ -102,6 +100,7 @@ def test__write_per_ga_per_actor__actors_file_has_expected_gln(
 
     # Arrange
     output_path = str(tmpdir)
+    batch_id = "321"
     expected_gln_805 = ["123", "234"]
     expected_gln_806 = ["123", "345"]
     time_series_type = TimeSeriesType.NON_PROFILED_CONSUMPTION
@@ -122,17 +121,17 @@ def test__write_per_ga_per_actor__actors_file_has_expected_gln(
     )
     result_df = spark.createDataFrame(rows)
 
-    sut = ProcessStepResultWriter(output_path)
+    sut = ProcessStepResultWriter(output_path, batch_id)
 
     # Act
     sut.write_per_ga_per_actor(result_df, time_series_type, market_role)
 
     # Assert
     actual_gln_805 = _get_gln_from_actors_file(
-        output_path, "805", time_series_type, market_role
+        output_path, batch_id, "805", time_series_type, market_role
     )
     actual_gln_806 = _get_gln_from_actors_file(
-        output_path, "806", time_series_type, market_role
+        output_path, batch_id, "806", time_series_type, market_role
     )
 
     assert len(actual_gln_805) == len(expected_gln_805) and len(actual_gln_806) == len(
@@ -141,3 +140,66 @@ def test__write_per_ga_per_actor__actors_file_has_expected_gln(
     assert set(actual_gln_805) == set(expected_gln_805) and set(actual_gln_806) == set(
         expected_gln_806
     )
+
+
+def test__write_per_ga_per_actor__actors_file_path_matches_contract(
+    spark: SparkSession,
+    contracts_path: str,
+    tmpdir,
+) -> None:
+    # Arrange
+    batch_id = "0b15a420-9fc8-409a-a169-fbd49479d718"
+    grid_area = "105"
+    row = [_create_result_row(grid_area=grid_area, energy_supplier_id="123")]
+    result_df = spark.createDataFrame(data=row)
+    sut = ProcessStepResultWriter(str(tmpdir), batch_id)
+
+    # Act
+    sut.write_per_ga_per_actor(
+        result_df, TimeSeriesType.NON_PROFILED_CONSUMPTION, MarketRole.ENERGY_SUPPLIER
+    )
+
+    # Assert
+    relative_output_path = infra.get_actors_file_relative_path(
+        batch_id,
+        grid_area,
+        TimeSeriesType.NON_PROFILED_CONSUMPTION,
+        MarketRole.ENERGY_SUPPLIER,
+    )
+    actual_result_file = find_file(
+        f"{str(tmpdir)}/",
+        f"{relative_output_path}/part-*.json",
+    )
+    assert_file_path_match_contract(
+        contracts_path, actual_result_file, CalculationFileType.ActorsFile
+    )
+
+
+# def test__result_file_path_matches_contract(
+#     data_lake_path,
+#     worker_id,
+#     contracts_path,
+#     executed_calculation_job,
+# ):
+#     # Arrange
+#     contract = calculation_file_paths_contract.result_file
+#     expected_path_expression = create_file_path_expression(
+#         contract.directory_expression,
+#         contract.extension,
+#     )
+#     relative_output_path = infra.get_result_file_relative_path(
+#         executed_batch_id,
+#         "805",
+#         grid_area_gln,
+#         TimeSeriesType.PRODUCTION,
+#     )
+
+#     # Act: Executed in fixture executed_calculation_job
+
+#     # Assert
+#     actual_result_file = find_file(
+#         f"{data_lake_path}/{worker_id}", f"{relative_output_path}/part-*.json"
+#     )
+#     assert_file_path_match_contract(
+#         contracts_path, actual_result_file, CalculationFileType.ResultFile
+#     )

--- a/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
+++ b/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
@@ -199,7 +199,7 @@ def test__write_per_ga_per_actor__result_file_path_matches_contract(
         DEFAULT_BATCH_ID,
         DEFAULT_GRID_AREA,
         DEFAULT_ENERGY_SUPPLIER_ID,
-        TimeSeriesType.PRODUCTION,
+        TimeSeriesType.NON_PROFILED_CONSUMPTION,
     )
     sut = ProcessStepResultWriter(str(tmpdir), DEFAULT_BATCH_ID)
 

--- a/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
+++ b/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
@@ -187,7 +187,7 @@ def test__write_per_ga_per_actor__result_file_path_matches_contract(
     spark: SparkSession,
     contracts_path: str,
     tmpdir,
-):
+) -> None:
     # Arrange
     row = [
         _create_result_row(

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -33,6 +33,7 @@ from tests.helpers.assert_calculation_file_path import (
 from tests.helpers.file_utils import find_file, create_file_path_expression
 
 
+import package.infrastructure as infra
 executed_batch_id = "0b15a420-9fc8-409a-a169-fbd49479d718"
 grid_area_gln = "grid_area"
 energy_supplier_gln_a = "8100000000108"

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -25,6 +25,7 @@ from package.constants.market_role import MarketRole
 import package.infrastructure as infra
 from package.schemas import time_series_point_schema, metering_point_period_schema
 from pyspark.sql.functions import lit
+from tests.helpers.file_utils import find_first_file
 from tests.helpers.assert_calculation_file_path import (
     CalculationFileType,
     assert_file_path_match_contract,

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -30,7 +30,6 @@ from tests.helpers.assert_calculation_file_path import (
     CalculationFileType,
     assert_file_path_match_contract,
 )
-from tests.helpers.file_utils import find_file, create_file_path_expression
 
 
 executed_batch_id = "0b15a420-9fc8-409a-a169-fbd49479d718"
@@ -284,68 +283,6 @@ def test__quantity_is_with_precision_3(
 
     assert re.search(r"^\d+\.\d{3}$", result_production.first().quantity)
     assert re.search(r"^\d+\.\d{3}$", result_non_profiled_consumption.first().quantity)
-
-
-@pytest.fixture(scope="session")
-def calculation_file_paths_contract(source_path):
-    with open(f"{source_path}/contracts/calculation-file-paths.yml", "r") as stream:
-        return DictObj(yaml.safe_load(stream))
-
-
-def test__actors_file_path_matches_contract(
-    data_lake_path,
-    worker_id,
-    contracts_path,
-    executed_calculation_job,
-):
-    # Arrange
-
-    # Act: Executed in fixture executed_calculation_job
-
-    # Assert
-    relative_output_path = infra.get_actors_file_relative_path(
-        executed_batch_id,
-        "805",
-        TimeSeriesType.NON_PROFILED_CONSUMPTION,
-        MarketRole.ENERGY_SUPPLIER,
-    )
-    actual_result_file = find_file(
-        f"{data_lake_path}/{worker_id}/",
-        f"{relative_output_path}/part-*.json",
-    )
-    assert_file_path_match_contract(
-        contracts_path, actual_result_file, CalculationFileType.ActorsFile
-    )
-
-
-def test__result_file_path_matches_contract(
-    data_lake_path,
-    worker_id,
-    contracts_path,
-    executed_calculation_job,
-):
-    # Arrange
-    contract = calculation_file_paths_contract.result_file
-    expected_path_expression = create_file_path_expression(
-        contract.directory_expression,
-        contract.extension,
-    )
-    relative_output_path = infra.get_result_file_relative_path(
-        executed_batch_id,
-        "805",
-        grid_area_gln,
-        TimeSeriesType.PRODUCTION,
-    )
-
-    # Act: Executed in fixture executed_calculation_job
-
-    # Assert
-    actual_result_file = find_file(
-        f"{data_lake_path}/{worker_id}", f"{relative_output_path}/part-*.json"
-    )
-    assert_file_path_match_contract(
-        contracts_path, actual_result_file, CalculationFileType.ResultFile
-    )
 
 
 def test__result_file_has_correct_number_of_rows_based_on_period(

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -343,7 +343,7 @@ def test__result_file_path_matches_contract(
         f"{data_lake_path}/{worker_id}", f"{relative_output_path}/part-*.json"
     )
     assert_file_path_match_contract(
-        contracts_path, actual_result_file, CalculationFileType.ActorsFile
+        contracts_path, actual_result_file, CalculationFileType.ResultFile
     )
 
 

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -21,7 +21,6 @@ from tests.contract_utils import assert_contract_matches_schema
 from package.calculator_job import _get_valid_args_or_throw, _start_calculator, start
 from package.calculator_args import CalculatorArgs
 from package.constants.time_series_type import TimeSeriesType
-from package.constants.market_role import MarketRole
 import package.infrastructure as infra
 from package.schemas import time_series_point_schema, metering_point_period_schema
 from pyspark.sql.functions import lit

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -25,7 +25,7 @@ from package.constants.market_role import MarketRole
 import package.infrastructure as infra
 from package.schemas import time_series_point_schema, metering_point_period_schema
 from pyspark.sql.functions import lit
-from tests.helpers.file_utils import find_first_file
+from tests.helpers.file_utils import find_file
 from tests.helpers.assert_calculation_file_path import (
     CalculationFileType,
     assert_file_path_match_contract,
@@ -33,7 +33,6 @@ from tests.helpers.assert_calculation_file_path import (
 from tests.helpers.file_utils import find_file, create_file_path_expression
 
 
-import package.infrastructure as infra
 executed_batch_id = "0b15a420-9fc8-409a-a169-fbd49479d718"
 grid_area_gln = "grid_area"
 energy_supplier_gln_a = "8100000000108"
@@ -525,7 +524,6 @@ def test__master_basis_data_file_matches_contract(
     master_basis_data_path = infra.get_master_basis_data_relative_path(
         executed_batch_id, "805", grid_area_gln
     )
-
 
     # Act: Executed in fixture executed_calculation_job
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description
With this PR, ProcessStepResultWriter is responsible for defining the path where results are stored - calculator_job is no longer responsible for constucting parts of the relative path. 
It is now also possible to move the tests to test_process_step_result_writwer
## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #199 
