### PR TITLE
fix: Bug fix and move "period end off by 1ms hack" to boundary of web API

### DIFF
--- a/source/dotnet/Services/DatabaseMigration/DatabaseMigration.csproj
+++ b/source/dotnet/Services/DatabaseMigration/DatabaseMigration.csproj
@@ -33,6 +33,7 @@ limitations under the License.
       <EmbeddedResource Include="Scripts\202209191000_Add_Batch_Execution_Time.sql" />
       <EmbeddedResource Include="Scripts\202210261230_Add_IsBatchDataDownloadAvailable.sql" />
       <EmbeddedResource Include="Scripts\202301241200_Rename_To_Batch_AreSettlementReportsCreated.sql" />
+      <EmbeddedResource Include="Scripts\202302031300_Fix_Batch_PeriodEnds.sql" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/dotnet/Services/DatabaseMigration/Scripts/202302031300_Fix_Batch_PeriodEnds.sql
+++ b/source/dotnet/Services/DatabaseMigration/Scripts/202302031300_Fix_Batch_PeriodEnds.sql
@@ -1,0 +1,3 @@
+﻿update Batch
+set PeriodEnd = DateAdd(millisecond,1, PeriodEnd)
+where DATEPART(millisecond, PeriodEnd) = 999

--- a/source/dotnet/Services/Domain/BatchAggregate/Batch.cs
+++ b/source/dotnet/Services/Domain/BatchAggregate/Batch.cs
@@ -68,9 +68,9 @@ public class Batch
         if (periodStart >= periodEnd)
             errors.Add("periodStart is greater or equal to periodEnd");
 
-        // Validate that period end is set to 1 millisecond before midnight
-        if (new ZonedDateTime(periodEnd.Plus(Duration.FromMilliseconds(1)), dateTimeZone).TimeOfDay != LocalTime.Midnight)
-            errors.Add($"The period end '{periodEnd.ToString()}' must be one millisecond before midnight.");
+        // Validate that period end is set to midnight
+        if (new ZonedDateTime(periodEnd, dateTimeZone).TimeOfDay != LocalTime.Midnight)
+            errors.Add($"The period end '{periodEnd.ToString()}' must be midnight.");
 
         if (new ZonedDateTime(periodStart, dateTimeZone).TimeOfDay != LocalTime.Midnight)
             errors.Add($"The period start '{periodStart.ToString()}'must be midnight.");
@@ -114,13 +114,6 @@ public class Batch
     /// The 1 ms off is by design originating from the front-end decision on how to handle date periods.
     /// </summary>
     public Instant PeriodEnd { get; }
-
-    /// <summary>
-    /// Gets an open-ended period end. That is a period end, which is exactly at midnight and thus exclusive.
-    /// This is used in calculations as it prevents loss of e.g. time-series received in the last millisecond
-    /// before midnight.
-    /// </summary>
-    public Instant OpenPeriodEnd => PeriodEnd.Plus(Duration.FromMilliseconds(1));
 
     public bool AreSettlementReportsCreated { get; set; }
 

--- a/source/dotnet/Services/Infrastructure/Calculations/DatabricksCalculationParametersFactory.cs
+++ b/source/dotnet/Services/Infrastructure/Calculations/DatabricksCalculationParametersFactory.cs
@@ -28,7 +28,7 @@ public class DatabricksCalculationParametersFactory : ICalculationParametersFact
             $"--batch-id={batch.Id}",
             $"--batch-grid-areas=[{gridAreas}]",
             $"--batch-period-start-datetime={batch.PeriodStart}",
-            $"--batch-period-end-datetime={batch.OpenPeriodEnd}",
+            $"--batch-period-end-datetime={batch.PeriodEnd}",
         };
     }
 }

--- a/source/dotnet/Services/IntegrationTests/Fixtures/TestHelpers/Periods.cs
+++ b/source/dotnet/Services/IntegrationTests/Fixtures/TestHelpers/Periods.cs
@@ -15,7 +15,7 @@
 using NodaTime;
 using NodaTime.Extensions;
 
-namespace Energinet.DataHub.Wholesale.IntegrationTests.TestHelpers;
+namespace Energinet.DataHub.Wholesale.IntegrationTests.Fixtures.TestHelpers;
 
 public static class Periods
 {
@@ -23,8 +23,15 @@ public static class Periods
         January_EuropeCopenhagen =>
         (
             DateTimeOffset.Parse("2021-12-31T23:00Z"),
-            DateTimeOffset.Parse("2022-01-31T22:59:59.999Z"),
+            DateTimeOffset.Parse("2022-01-31T23:00Z"),
             DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!);
+
+    public static (DateTimeOffset PeriodStart, DateTimeOffset PeriodEnd, DateTimeZone DateTimeZone)
+        January_EuropeCopenhagen_1ms =>
+    (
+        DateTimeOffset.Parse("2021-12-31T23:00Z"),
+        DateTimeOffset.Parse("2022-01-31T22:59:59.999Z"),
+        DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!);
 
     public static (Instant PeriodStart, Instant PeriodEnd, DateTimeZone DateTimeZone) January_EuropeCopenhagen_Instant
     {

--- a/source/dotnet/Services/IntegrationTests/Infrastructure/BatchRepositoryTests.cs
+++ b/source/dotnet/Services/IntegrationTests/Infrastructure/BatchRepositoryTests.cs
@@ -16,6 +16,7 @@ using Energinet.DataHub.Wholesale.Domain.BatchAggregate;
 using Energinet.DataHub.Wholesale.Domain.GridAreaAggregate;
 using Energinet.DataHub.Wholesale.Domain.ProcessAggregate;
 using Energinet.DataHub.Wholesale.Infrastructure.Persistence.Batches;
+using Energinet.DataHub.Wholesale.IntegrationTests.Fixtures.TestHelpers;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.Fixture.Database;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestHelpers;
 using FluentAssertions;

--- a/source/dotnet/Services/IntegrationTests/ProcessManager/BatchApplicationServiceTests.cs
+++ b/source/dotnet/Services/IntegrationTests/ProcessManager/BatchApplicationServiceTests.cs
@@ -17,6 +17,7 @@ using Energinet.DataHub.Wholesale.Components.DatabricksClient;
 using Energinet.DataHub.Wholesale.Contracts;
 using Energinet.DataHub.Wholesale.Domain.BatchAggregate;
 using Energinet.DataHub.Wholesale.Domain.GridAreaAggregate;
+using Energinet.DataHub.Wholesale.IntegrationTests.Fixtures.TestHelpers;
 using Energinet.DataHub.Wholesale.IntegrationTests.Hosts;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.Fixture.Database;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestHelpers;

--- a/source/dotnet/Services/IntegrationTests/ProcessManager/PublishProcessCompletedIntegrationEventEndpointTests.cs
+++ b/source/dotnet/Services/IntegrationTests/ProcessManager/PublishProcessCompletedIntegrationEventEndpointTests.cs
@@ -21,6 +21,7 @@ using Energinet.DataHub.Wholesale.Application.Processes.Model;
 using Energinet.DataHub.Wholesale.Contracts;
 using Energinet.DataHub.Wholesale.Infrastructure.Core;
 using Energinet.DataHub.Wholesale.Infrastructure.ServiceBus;
+using Energinet.DataHub.Wholesale.IntegrationTests.Fixtures.TestHelpers;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.Fixture;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.Fixture.FunctionApp;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestHelpers;

--- a/source/dotnet/Services/IntegrationTests/ProcessManager/SettlementReportApplicationServiceTests.cs
+++ b/source/dotnet/Services/IntegrationTests/ProcessManager/SettlementReportApplicationServiceTests.cs
@@ -23,6 +23,7 @@ using Energinet.DataHub.Wholesale.Domain.GridAreaAggregate;
 using Energinet.DataHub.Wholesale.Domain.ProcessAggregate;
 using Energinet.DataHub.Wholesale.Infrastructure.Processes;
 using Energinet.DataHub.Wholesale.Infrastructure.SettlementReports;
+using Energinet.DataHub.Wholesale.IntegrationTests.Fixtures.TestHelpers;
 using Energinet.DataHub.Wholesale.IntegrationTests.Hosts;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.Fixture.Database;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestHelpers;

--- a/source/dotnet/Services/IntegrationTests/ProcessManager/SubmitCreatedBatchesEndpointTests.cs
+++ b/source/dotnet/Services/IntegrationTests/ProcessManager/SubmitCreatedBatchesEndpointTests.cs
@@ -13,17 +13,15 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.FunctionApp.TestCommon;
-using Energinet.DataHub.Wholesale.Application.Batches;
 using Energinet.DataHub.Wholesale.Application.Batches.Model;
-using Energinet.DataHub.Wholesale.Application.Processes;
 using Energinet.DataHub.Wholesale.Application.Processes.Model;
 using Energinet.DataHub.Wholesale.Domain.BatchAggregate;
 using Energinet.DataHub.Wholesale.Domain.GridAreaAggregate;
 using Energinet.DataHub.Wholesale.Domain.ProcessAggregate;
+using Energinet.DataHub.Wholesale.IntegrationTests.Fixtures.TestHelpers;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.Fixture;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.Fixture.FunctionApp;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.Function;
-using Energinet.DataHub.Wholesale.IntegrationTests.TestHelpers;
 using Energinet.DataHub.Wholesale.ProcessManager.Endpoints;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -31,7 +29,7 @@ using NodaTime;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.ProcessManager;
+namespace Energinet.DataHub.Wholesale.IntegrationTests.ProcessManager;
 
 public class SubmitCreatedBatchesEndpointTests
 {

--- a/source/dotnet/Services/IntegrationTests/WebApi/BatchControllerTests.cs
+++ b/source/dotnet/Services/IntegrationTests/WebApi/BatchControllerTests.cs
@@ -15,14 +15,15 @@
 using System.Net;
 using System.Net.Http.Json;
 using Energinet.DataHub.Wholesale.Contracts;
+using Energinet.DataHub.Wholesale.IntegrationTests.Fixtures.TestHelpers;
 using Energinet.DataHub.Wholesale.IntegrationTests.Fixtures.WebApi;
 using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.Fixture.WebApi;
-using Energinet.DataHub.Wholesale.IntegrationTests.TestHelpers;
+using Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.WebApi;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Energinet.DataHub.Wholesale.IntegrationTests.TestCommon.WebApi;
+namespace Energinet.DataHub.Wholesale.IntegrationTests.WebApi;
 
 [Collection(nameof(WholesaleWebApiCollectionFixture))]
 public class BatchControllerTests :
@@ -120,7 +121,7 @@ public class BatchControllerTests :
 
     private static BatchRequestDto CreateBatchRequestDto()
     {
-        var period = Periods.January_EuropeCopenhagen;
+        var period = Periods.January_EuropeCopenhagen_1ms;
         var batchRequest = new BatchRequestDto(
             ProcessType.BalanceFixing,
             new List<string> { "805" },

--- a/source/dotnet/Services/UnitTests/Domain/BatchAggregate/BatchBuilder.cs
+++ b/source/dotnet/Services/UnitTests/Domain/BatchAggregate/BatchBuilder.cs
@@ -34,7 +34,7 @@ public class BatchBuilder
         // In order to be valid the last millisecond must be omitted
         var firstOfJanuary = DateTimeOffset.Parse("2021-01-31T23:00Z");
         _periodStart = Instant.FromDateTimeOffset(firstOfJanuary);
-        _periodEnd = Instant.FromDateTimeOffset(firstOfJanuary.AddMonths(1).AddMilliseconds(-1));
+        _periodEnd = Instant.FromDateTimeOffset(firstOfJanuary.AddMonths(1));
     }
 
     public BatchBuilder WithStateSubmitted()

--- a/source/dotnet/Services/UnitTests/Domain/BatchAggregate/BatchFactoryTests.cs
+++ b/source/dotnet/Services/UnitTests/Domain/BatchAggregate/BatchFactoryTests.cs
@@ -28,7 +28,7 @@ namespace Energinet.DataHub.Wholesale.Tests.Domain.BatchAggregate;
 public class BatchFactoryTests
 {
     private readonly DateTimeOffset _startDate = DateTimeOffset.Parse("2021-12-31T23:00Z");
-    private readonly DateTimeOffset _endDate = DateTimeOffset.Parse("2022-01-31T22:59:59.999Z");
+    private readonly DateTimeOffset _endDate = DateTimeOffset.Parse("2022-01-31T23:00Z");
     private readonly DateTimeZone _timeZone = DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!;
     private readonly List<string> _someGridAreasIds = new() { "004", "805" };
 

--- a/source/dotnet/Services/UnitTests/Domain/BatchAggregate/BatchTests.cs
+++ b/source/dotnet/Services/UnitTests/Domain/BatchAggregate/BatchTests.cs
@@ -79,12 +79,11 @@ public class BatchTests
     }
 
     [Theory]
-    [InlineData("2023-01-31T23:00Z", "Europe/Copenhagen")]
+    [InlineData("2023-01-31T23:00:00.0001Z", "Europe/Copenhagen")]
     [InlineData("2023-01-31T22:59:59Z", "Europe/Copenhagen")]
     [InlineData("2023-01-31T22:59:59.9999999Z", "Europe/Copenhagen")]
-    [InlineData("2023-01-31", "Europe/Copenhagen")]
-    [InlineData("2023-01-31T22:59:59.999Z", "Asia/Tokyo")]
-    public void Ctor_WhenPeriodEndIsNot1MillisecondBeforeMidnight_ThrowsArgumentException(string periodEndString, string timeZoneId)
+    [InlineData("2023-01-31T23:00:00Z", "Asia/Tokyo")]
+    public void Ctor_WhenPeriodEndIsNotMidnight_ThrowsArgumentException(string periodEndString, string timeZoneId)
     {
         // Arrange
         var periodEnd = DateTimeOffset.Parse(periodEndString).ToInstant();

--- a/source/dotnet/Services/UnitTests/Infrastructure/Calculations/DatabricksCalculatorJobParametersFactoryTests.cs
+++ b/source/dotnet/Services/UnitTests/Infrastructure/Calculations/DatabricksCalculatorJobParametersFactoryTests.cs
@@ -37,7 +37,7 @@ public class DatabricksCalculatorJobParametersFactoryTests
             ProcessType.BalanceFixing,
             new List<GridAreaCode> { new("805"), new("806") },
             DateTimeOffset.Parse("2022-05-31T22:00Z").ToInstant(),
-            DateTimeOffset.Parse("2022-06-01T21:59:59.999Z").ToInstant(),
+            DateTimeOffset.Parse("2022-06-01T22:00Z").ToInstant(),
             SystemClock.Instance.GetCurrentInstant(),
             DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!);
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Move front-end related workaround of period ends being 1 ms before midnight to the boundaries of the web API. This solves the error of publishing batch completed integration events with bad period end.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
