### PR TITLE
refac: ProcessStepApplicationService

### DIFF
--- a/source/dotnet/Services/Application/ProcessStep/IProcessStepApplicationService.cs
+++ b/source/dotnet/Services/Application/ProcessStep/IProcessStepApplicationService.cs
@@ -23,7 +23,5 @@ public interface IProcessStepApplicationService
 {
     Task<WholesaleActorDto[]> GetActorsAsync(ProcessStepActorsRequest processStepActorsRequest);
 
-    Task<ProcessStepResultDto> GetResultAsync(ProcessStepResultRequestDto processStepResultRequestDto);
-
-    Task<ProcessStepResultDto> GetResultAsync(ProcessStepResultRequestDtoV2 processStepResultRequestDtoV2);
+    Task<ProcessStepResultDto> GetResultAsync(Guid batchId, string gridAreaCode, TimeSeriesType timeSeriesType, string gln);
 }

--- a/source/dotnet/Services/Application/ProcessStep/ProcessStepApplicationService.cs
+++ b/source/dotnet/Services/Application/ProcessStep/ProcessStepApplicationService.cs
@@ -17,7 +17,6 @@ using Energinet.DataHub.Wholesale.Contracts;
 using Energinet.DataHub.Wholesale.Domain.ActorAggregate;
 using Energinet.DataHub.Wholesale.Domain.GridAreaAggregate;
 using Energinet.DataHub.Wholesale.Domain.ProcessStepResultAggregate;
-using TimeSeriesType = Energinet.DataHub.Wholesale.Domain.ProcessStepResultAggregate.TimeSeriesType;
 
 namespace Energinet.DataHub.Wholesale.Application.ProcessStep;
 
@@ -51,25 +50,13 @@ public class ProcessStepApplicationService : IProcessStepApplicationService
         return actors.Select(batchActor => new WholesaleActorDto(batchActor.Gln)).ToArray();
     }
 
-    public async Task<ProcessStepResultDto> GetResultAsync(ProcessStepResultRequestDto processStepResultRequestDto)
+    public async Task<ProcessStepResultDto> GetResultAsync(Guid batchId, string gridAreaCode, Contracts.TimeSeriesType timeSeriesType, string gln)
     {
         var processActorResult = await _processStepResultRepository.GetAsync(
-                processStepResultRequestDto.BatchId,
-                new GridAreaCode(processStepResultRequestDto.GridAreaCode),
-                TimeSeriesType.Production,
-                "grid_area")
-            .ConfigureAwait(false);
-
-        return _processStepResultMapper.MapToDto(processActorResult);
-    }
-
-    public async Task<ProcessStepResultDto> GetResultAsync(ProcessStepResultRequestDtoV2 processStepResultRequestDtoV2)
-    {
-        var processActorResult = await _processStepResultRepository.GetAsync(
-                processStepResultRequestDtoV2.BatchId,
-                new GridAreaCode(processStepResultRequestDtoV2.GridAreaCode),
-                TimeSeriesTypeMapper.Map(processStepResultRequestDtoV2.TimeSeriesType),
-                processStepResultRequestDtoV2.Gln)
+                batchId,
+                new GridAreaCode(gridAreaCode),
+                TimeSeriesTypeMapper.Map(timeSeriesType),
+                gln)
             .ConfigureAwait(false);
 
         return _processStepResultMapper.MapToDto(processActorResult);

--- a/source/dotnet/Services/WebApi.IntegrationTests/WebApi/ProcessStepControllerTests.cs
+++ b/source/dotnet/Services/WebApi.IntegrationTests/WebApi/ProcessStepControllerTests.cs
@@ -90,7 +90,7 @@ public class ProcessStepControllerTests :
     {
         // Arrange
         applicationServiceMock
-            .Setup(service => service.GetResultAsync(request))
+            .Setup(service => service.GetResultAsync(request.BatchId, request.GridAreaCode, TimeSeriesType.Production, "grid_area"))
             .ReturnsAsync(() => expectedProcessStepResult);
         _factory.ProcessStepApplicationServiceMock = applicationServiceMock;
 
@@ -114,7 +114,7 @@ public class ProcessStepControllerTests :
     {
         // Arrange
         applicationServiceMock
-            .Setup(service => service.GetResultAsync(request))
+            .Setup(service => service.GetResultAsync(request.BatchId, request.GridAreaCode, TimeSeriesType.Production, "grid_area"))
             .ReturnsAsync(() => expectedProcessStepResult);
         _factory.ProcessStepApplicationServiceMock = applicationServiceMock;
 
@@ -138,7 +138,7 @@ public class ProcessStepControllerTests :
     {
         // Arrange
         applicationServiceMock
-            .Setup(service => service.GetResultAsync(request))
+            .Setup(service => service.GetResultAsync(request.BatchId, request.GridAreaCode, TimeSeriesType.Production, "grid_area"))
             .ReturnsAsync(() => expectedProcessStepResult);
         _factory.ProcessStepApplicationServiceMock = applicationServiceMock;
 
@@ -162,7 +162,7 @@ public class ProcessStepControllerTests :
     {
         // Arrange
         applicationServiceMock
-            .Setup(service => service.GetResultAsync(request))
+            .Setup(service => service.GetResultAsync(request.BatchId, request.GridAreaCode, request.TimeSeriesType, request.Gln))
             .ReturnsAsync(() => expectedProcessStepResult);
         _factory.ProcessStepApplicationServiceMock = applicationServiceMock;
 

--- a/source/dotnet/Services/WebApi.IntegrationTests/WebApi/V3/ProcessStepBalanceResponsiblePartyTests.cs
+++ b/source/dotnet/Services/WebApi.IntegrationTests/WebApi/V3/ProcessStepBalanceResponsiblePartyTests.cs
@@ -19,7 +19,7 @@ using Energinet.DataHub.Wholesale.Application.ProcessStep;
 using Energinet.DataHub.Wholesale.Contracts;
 using Energinet.DataHub.Wholesale.WebApi.IntegrationTests.Fixtures.TestCommon.Fixture.WebApi;
 using Energinet.DataHub.Wholesale.WebApi.IntegrationTests.Fixtures.WebApi;
-using Energinet.DataHub.Wholesale.WebApi.V3.ProcessStepActor;
+using Energinet.DataHub.Wholesale.WebApi.V3;
 using FluentAssertions;
 using Moq;
 using Xunit;

--- a/source/dotnet/Services/WebApi.IntegrationTests/WebApi/V3/ProcessStepEnergySupplierTests.cs
+++ b/source/dotnet/Services/WebApi.IntegrationTests/WebApi/V3/ProcessStepEnergySupplierTests.cs
@@ -19,7 +19,7 @@ using Energinet.DataHub.Wholesale.Application.ProcessStep;
 using Energinet.DataHub.Wholesale.Contracts;
 using Energinet.DataHub.Wholesale.WebApi.IntegrationTests.Fixtures.TestCommon.Fixture.WebApi;
 using Energinet.DataHub.Wholesale.WebApi.IntegrationTests.Fixtures.WebApi;
-using Energinet.DataHub.Wholesale.WebApi.V3.ProcessStepActor;
+using Energinet.DataHub.Wholesale.WebApi.V3;
 using FluentAssertions;
 using Moq;
 using Xunit;

--- a/source/dotnet/Services/WebApi.IntegrationTests/WebApi/V3/ProcessStepResultTests.cs
+++ b/source/dotnet/Services/WebApi.IntegrationTests/WebApi/V3/ProcessStepResultTests.cs
@@ -21,7 +21,6 @@ using Energinet.DataHub.Wholesale.Application.ProcessStep;
 using Energinet.DataHub.Wholesale.Contracts;
 using Energinet.DataHub.Wholesale.WebApi.IntegrationTests.Fixtures.TestCommon.Fixture.WebApi;
 using Energinet.DataHub.Wholesale.WebApi.IntegrationTests.Fixtures.WebApi;
-using Energinet.DataHub.Wholesale.WebApi.V3.ProcessStepActor;
 using FluentAssertions;
 using Moq;
 using Test.Core;
@@ -53,7 +52,7 @@ public class ProcessStepResultTests : WebApiTestBase
         request.SetPrivateProperty(r => r.Type, TimeSeriesType.Production);
         result.SetPrivateProperty(r => r.TimeSeriesPoints, new TimeSeriesPointDto[] { new(DateTimeOffset.Now, decimal.One, "A04") });
         processStepApplicationServiceMock
-            .Setup(service => service.GetResultAsync(It.IsAny<ProcessStepResultRequestDto>()))
+            .Setup(service => service.GetResultAsync(request.BatchId, request.GridAreaCode, TimeSeriesType.Production, "grid_area"))
             .ReturnsAsync(() => result);
         batchApplicationServiceMock.Setup(service => service.GetAsync(request.BatchId)).ReturnsAsync(batchDto);
         Factory.ProcessStepApplicationServiceMock = processStepApplicationServiceMock;

--- a/source/dotnet/Services/WebApi.UnitTests/Application/ProcessStep/ProcessStepApplicationServiceTests.cs
+++ b/source/dotnet/Services/WebApi.UnitTests/Application/ProcessStep/ProcessStepApplicationServiceTests.cs
@@ -59,10 +59,10 @@ public class ProcessStepApplicationServiceTests
 
         // Act
         var actual = await sut.GetResultAsync(
-            new ProcessStepResultRequestDto(
                 batchId,
                 gridAreaCode,
-                ProcessStepType.AggregateProductionPerGridArea));
+                Contracts.TimeSeriesType.Production,
+                "grid_area");
 
         // Assert
         actual.TimeSeriesPoints.First().Time.Should().Be(time);
@@ -147,7 +147,7 @@ public class ProcessStepApplicationServiceTests
             .Returns(() => resultDto);
 
         // Act
-        var actual = await sut.GetResultAsync(request);
+        var actual = await sut.GetResultAsync(request.BatchId, request.GridAreaCode, Contracts.TimeSeriesType.Production, "grid_area");
 
         actual.Should().BeEquivalentTo(resultDto);
     }

--- a/source/dotnet/Services/WebApi.UnitTests/Infrastructure/SettlementReport/SettlementReportRepositoryTests.cs
+++ b/source/dotnet/Services/WebApi.UnitTests/Infrastructure/SettlementReport/SettlementReportRepositoryTests.cs
@@ -209,10 +209,10 @@ public class SettlementReportRepositoryTests
 
         // Act
         var actual = await sut.GetResultAsync(
-            new ProcessStepResultRequestDto(
                 batchId,
                 gridAreaCode,
-                ProcessStepType.AggregateProductionPerGridArea));
+                Contracts.TimeSeriesType.Production,
+                "grid_area");
 
         // Assert
         actual.TimeSeriesPoints.First().Time.Should().Be(time);

--- a/source/dotnet/Services/WebApi/Configuration/ServiceCollectionExtensions.cs
+++ b/source/dotnet/Services/WebApi/Configuration/ServiceCollectionExtensions.cs
@@ -41,7 +41,7 @@ using Energinet.DataHub.Wholesale.Infrastructure.Persistence;
 using Energinet.DataHub.Wholesale.Infrastructure.Persistence.Batches;
 using Energinet.DataHub.Wholesale.Infrastructure.Processes;
 using Energinet.DataHub.Wholesale.Infrastructure.SettlementReports;
-using Energinet.DataHub.Wholesale.WebApi.Controllers.V2;
+using Energinet.DataHub.Wholesale.WebApi.V2;
 using Energinet.DataHub.Wholesale.WebApi.V3.ProcessStepResult;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;

--- a/source/dotnet/Services/WebApi/V2/BatchController.cs
+++ b/source/dotnet/Services/WebApi/V2/BatchController.cs
@@ -20,7 +20,7 @@ using Energinet.DataHub.Wholesale.Contracts;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 
-namespace Energinet.DataHub.Wholesale.WebApi.Controllers.V2;
+namespace Energinet.DataHub.Wholesale.WebApi.V2;
 
 /// <summary>
 /// Handle process batches.

--- a/source/dotnet/Services/WebApi/V2/BatchDtoV2Mapper.cs
+++ b/source/dotnet/Services/WebApi/V2/BatchDtoV2Mapper.cs
@@ -15,7 +15,7 @@
 using Energinet.DataHub.Wholesale.Application.Batches.Model;
 using Energinet.DataHub.Wholesale.Contracts;
 
-namespace Energinet.DataHub.Wholesale.WebApi.Controllers.V2;
+namespace Energinet.DataHub.Wholesale.WebApi.V2;
 
 public class BatchDtoV2Mapper : IBatchDtoV2Mapper
 {

--- a/source/dotnet/Services/WebApi/V2/IBatchDtoV2Mapper.cs
+++ b/source/dotnet/Services/WebApi/V2/IBatchDtoV2Mapper.cs
@@ -15,7 +15,7 @@
 using Energinet.DataHub.Wholesale.Application.Batches.Model;
 using Energinet.DataHub.Wholesale.Contracts;
 
-namespace Energinet.DataHub.Wholesale.WebApi.Controllers.V2;
+namespace Energinet.DataHub.Wholesale.WebApi.V2;
 
 public interface IBatchDtoV2Mapper
 {

--- a/source/dotnet/Services/WebApi/V2/ProcessStepControllerV21.cs
+++ b/source/dotnet/Services/WebApi/V2/ProcessStepControllerV21.cs
@@ -17,7 +17,7 @@ using Energinet.DataHub.Wholesale.Contracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Energinet.DataHub.Wholesale.WebApi.Controllers.V2;
+namespace Energinet.DataHub.Wholesale.WebApi.V2;
 
 [ApiController]
 [Route("v{version:apiVersion}/ProcessStepResult")]
@@ -39,7 +39,12 @@ public class ProcessStepV21Controller : ControllerBase
     [ApiVersion("2.1")]
     public async Task<IActionResult> GetAsync([FromBody] ProcessStepResultRequestDto processStepResultRequestDto)
     {
-        var resultDto = await _processStepApplicationService.GetResultAsync(processStepResultRequestDto).ConfigureAwait(false);
+        var resultDto = await _processStepApplicationService.GetResultAsync(
+            processStepResultRequestDto.BatchId,
+            processStepResultRequestDto.GridAreaCode,
+            TimeSeriesType.Production,
+            "grid_area").ConfigureAwait(false);
+
         return Ok(resultDto);
     }
 }

--- a/source/dotnet/Services/WebApi/V2/ProcessStepControllerV22.cs
+++ b/source/dotnet/Services/WebApi/V2/ProcessStepControllerV22.cs
@@ -17,7 +17,7 @@ using Energinet.DataHub.Wholesale.Contracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Energinet.DataHub.Wholesale.WebApi.Controllers.V2;
+namespace Energinet.DataHub.Wholesale.WebApi.V2;
 
 [ApiController]
 [Route("v2.2/ProcessStepResult")]
@@ -35,7 +35,11 @@ public class ProcessStepV22Controller : ControllerBase
     [ApiVersion("2.2")]
     public async Task<IActionResult> GetAsync([FromBody] ProcessStepResultRequestDtoV2 processStepResultRequestDtoV2)
     {
-        var resultDto = await _processStepApplicationService.GetResultAsync(processStepResultRequestDtoV2).ConfigureAwait(false);
+        var resultDto = await _processStepApplicationService.GetResultAsync(
+            processStepResultRequestDtoV2.BatchId,
+            processStepResultRequestDtoV2.GridAreaCode,
+            processStepResultRequestDtoV2.TimeSeriesType,
+            processStepResultRequestDtoV2.Gln).ConfigureAwait(false);
         return Ok(resultDto);
     }
 }

--- a/source/dotnet/Services/WebApi/V2/ProcessStepControllerV23.cs
+++ b/source/dotnet/Services/WebApi/V2/ProcessStepControllerV23.cs
@@ -17,7 +17,7 @@ using Energinet.DataHub.Wholesale.Contracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Energinet.DataHub.Wholesale.WebApi.Controllers.V2;
+namespace Energinet.DataHub.Wholesale.WebApi.V2;
 
 [ApiController]
 [Route("v2.3/ProcessStepResult")]

--- a/source/dotnet/Services/WebApi/V2/SettlementReportController.cs
+++ b/source/dotnet/Services/WebApi/V2/SettlementReportController.cs
@@ -15,7 +15,7 @@
 using Energinet.DataHub.Wholesale.Application.SettlementReport;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Energinet.DataHub.Wholesale.WebApi.Controllers.V2;
+namespace Energinet.DataHub.Wholesale.WebApi.V2;
 
 [ApiController]
 [ApiVersion(Version)]

--- a/source/dotnet/Services/WebApi/V3/ActorDto.cs
+++ b/source/dotnet/Services/WebApi/V3/ActorDto.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Energinet.DataHub.Wholesale.WebApi.V3.ProcessStepActor;
+namespace Energinet.DataHub.Wholesale.WebApi.V3;
 
 // ReSharper disable once NotAccessedPositionalProperty.Global - Property is accessed while serializing the API result
 public sealed record ActorDto(string Gln);

--- a/source/dotnet/Services/WebApi/V3/ProcessStepBalanceResponsibleParty/ProcessStepBalanceResponsiblePartyController.cs
+++ b/source/dotnet/Services/WebApi/V3/ProcessStepBalanceResponsibleParty/ProcessStepBalanceResponsiblePartyController.cs
@@ -14,7 +14,6 @@
 
 using Energinet.DataHub.Wholesale.Application.ProcessStep;
 using Energinet.DataHub.Wholesale.Contracts;
-using Energinet.DataHub.Wholesale.WebApi.V3.ProcessStepActor;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/source/dotnet/Services/WebApi/V3/ProcessStepEnergySupplier/ProcessStepEnergySupplierController.cs
+++ b/source/dotnet/Services/WebApi/V3/ProcessStepEnergySupplier/ProcessStepEnergySupplierController.cs
@@ -14,7 +14,6 @@
 
 using Energinet.DataHub.Wholesale.Application.ProcessStep;
 using Energinet.DataHub.Wholesale.Contracts;
-using Energinet.DataHub.Wholesale.WebApi.V3.ProcessStepActor;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/source/dotnet/Services/WebApi/V3/ProcessStepResult/ProcessStepResultController.cs
+++ b/source/dotnet/Services/WebApi/V3/ProcessStepResult/ProcessStepResultController.cs
@@ -52,8 +52,7 @@ public class ProcessStepResultController : ControllerBase
         [FromRoute] TimeSeriesType timeSeriesType,
         [FromQuery] string gln)
     {
-        var request = new ProcessStepResultRequestDtoV2(batchId, gridAreaCode, timeSeriesType, gln);
-        var stepResult = await _processStepApplicationService.GetResultAsync(request).ConfigureAwait(false);
+        var stepResult = await _processStepApplicationService.GetResultAsync(batchId, gridAreaCode, timeSeriesType, gln).ConfigureAwait(false);
         var batch = await _batchApplicationService.GetAsync(batchId).ConfigureAwait(false);
 
         return _processStepResultFactory.Create(stepResult, batch);
@@ -71,8 +70,12 @@ public class ProcessStepResultController : ControllerBase
     {
         if (timeSeriesType != TimeSeriesType.Production) throw new NotImplementedException();
 
-        var request = new ProcessStepResultRequestDto(batchId, gridAreaCode, ProcessStepType.AggregateProductionPerGridArea);
-        var stepResult = await _processStepApplicationService.GetResultAsync(request).ConfigureAwait(false);
+        var stepResult = await _processStepApplicationService.GetResultAsync(
+            batchId,
+            gridAreaCode,
+            timeSeriesType,
+            "grid_area").ConfigureAwait(false);
+
         var batch = await _batchApplicationService.GetAsync(batchId).ConfigureAwait(false);
 
         return _processStepResultFactory.Create(stepResult, batch);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

This pr will refactor the ProcessStepApplicationService to no longer be coupled with the exposed models: `ProcessResultRequstDto `and `ProcessResultRequstDtoV2`. 

Some namespaces were not updated, this PR will also update them.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #782 
