### PR TITLE
fix: use one underscore for private methods

### DIFF
--- a/source/databricks/package/steps/aggregation/__init__.py
+++ b/source/databricks/package/steps/aggregation/__init__.py
@@ -25,7 +25,6 @@ from .aggregators import (
     aggregate_production_ga,
     aggregate_non_profiled_consumption_ga,
     aggregate_flex_consumption_ga,
-    _aggregate_per_ga_and_brp_and_es,
 )
 from .grid_loss_calculator import (
     calculate_grid_loss,

--- a/source/databricks/package/steps/aggregation/__init__.py
+++ b/source/databricks/package/steps/aggregation/__init__.py
@@ -25,7 +25,7 @@ from .aggregators import (
     aggregate_production_ga,
     aggregate_non_profiled_consumption_ga,
     aggregate_flex_consumption_ga,
-    __aggregate_per_ga_and_brp_and_es,
+    _aggregate_per_ga_and_brp_and_es,
 )
 from .grid_loss_calculator import (
     calculate_grid_loss,

--- a/source/databricks/package/steps/aggregation/aggregators.py
+++ b/source/databricks/package/steps/aggregation/aggregators.py
@@ -162,7 +162,7 @@ def aggregate_net_exchange_per_ga(results: dict, metadata: Metadata) -> DataFram
 def aggregate_non_profiled_consumption_ga_brp_es(
     enriched_time_series: DataFrame, metadata: Metadata
 ) -> DataFrame:
-    return __aggregate_per_ga_and_brp_and_es(
+    return _aggregate_per_ga_and_brp_and_es(
         enriched_time_series,
         MeteringPointType.consumption,
         SettlementMethod.non_profiled,
@@ -173,7 +173,7 @@ def aggregate_non_profiled_consumption_ga_brp_es(
 def aggregate_flex_consumption_ga_brp_es(
     enriched_time_series: DataFrame, metadata: Metadata
 ) -> DataFrame:
-    return __aggregate_per_ga_and_brp_and_es(
+    return _aggregate_per_ga_and_brp_and_es(
         enriched_time_series,
         MeteringPointType.consumption,
         SettlementMethod.flex,
@@ -184,13 +184,13 @@ def aggregate_flex_consumption_ga_brp_es(
 def aggregate_production_ga_brp_es(
     enriched_time_series: DataFrame, metadata: Metadata
 ) -> DataFrame:
-    return __aggregate_per_ga_and_brp_and_es(
+    return _aggregate_per_ga_and_brp_and_es(
         enriched_time_series, MeteringPointType.production, None, metadata
     )
 
 
 # Function to aggregate sum per grid area and energy supplier (step 12, 13 and 14)
-def __aggregate_per_ga_and_brp_and_es(
+def _aggregate_per_ga_and_brp_and_es(
     df: DataFrame,
     market_evaluation_point_type: MeteringPointType,
     settlement_method: Union[SettlementMethod, None],
@@ -288,7 +288,7 @@ def __aggregate_per_ga_and_brp_and_es(
 
 
 def aggregate_production_ga_brp(results: dict, metadata: Metadata) -> DataFrame:
-    return __aggregate_per_ga_and_brp(
+    return _aggregate_per_ga_and_brp(
         results[ResultKeyName.production_with_system_correction_and_grid_loss],
         MeteringPointType.production,
         metadata,
@@ -298,7 +298,7 @@ def aggregate_production_ga_brp(results: dict, metadata: Metadata) -> DataFrame:
 def aggregate_non_profiled_consumption_ga_brp(
     result: DataFrame, metadata: Metadata
 ) -> DataFrame:
-    return __aggregate_per_ga_and_brp(
+    return _aggregate_per_ga_and_brp(
         result,
         MeteringPointType.consumption,
         metadata,
@@ -306,7 +306,7 @@ def aggregate_non_profiled_consumption_ga_brp(
 
 
 def aggregate_flex_consumption_ga_brp(results: dict, metadata: Metadata) -> DataFrame:
-    return __aggregate_per_ga_and_brp(
+    return _aggregate_per_ga_and_brp(
         results[ResultKeyName.flex_consumption_with_grid_loss],
         MeteringPointType.consumption,
         metadata,
@@ -314,7 +314,7 @@ def aggregate_flex_consumption_ga_brp(results: dict, metadata: Metadata) -> Data
 
 
 # Function to aggregate sum per grid area and balance responsible party (step 15, 16 and 17)
-def __aggregate_per_ga_and_brp(
+def _aggregate_per_ga_and_brp(
     df: DataFrame,
     market_evaluation_point_type: MeteringPointType,
     metadata: Metadata,
@@ -334,7 +334,7 @@ def __aggregate_per_ga_and_brp(
 
 
 def aggregate_production_ga(production: DataFrame, metadata: Metadata) -> DataFrame:
-    return __aggregate_per_ga(
+    return _aggregate_per_ga(
         production,
         MeteringPointType.production,
         metadata,
@@ -344,7 +344,7 @@ def aggregate_production_ga(production: DataFrame, metadata: Metadata) -> DataFr
 def aggregate_non_profiled_consumption_ga(
     consumption: DataFrame, metadata: Metadata
 ) -> DataFrame:
-    return __aggregate_per_ga(
+    return _aggregate_per_ga(
         consumption,
         MeteringPointType.consumption,
         metadata,
@@ -352,7 +352,7 @@ def aggregate_non_profiled_consumption_ga(
 
 
 def aggregate_flex_consumption_ga(results: dict, metadata: Metadata) -> DataFrame:
-    return __aggregate_per_ga(
+    return _aggregate_per_ga(
         results[ResultKeyName.flex_consumption_with_grid_loss],
         MeteringPointType.consumption,
         metadata,
@@ -360,7 +360,7 @@ def aggregate_flex_consumption_ga(results: dict, metadata: Metadata) -> DataFram
 
 
 # Function to aggregate sum per grid area (step 18, 19 and 20)
-def __aggregate_per_ga(
+def _aggregate_per_ga(
     df: DataFrame,
     market_evaluation_point_type: MeteringPointType,
     metadata: Metadata,

--- a/source/databricks/tests/integration/calculator/steps/aggregation/test_flex_consumption_ga_brp_es.py
+++ b/source/databricks/tests/integration/calculator/steps/aggregation/test_flex_consumption_ga_brp_es.py
@@ -14,7 +14,7 @@
 from decimal import Decimal
 from datetime import datetime
 from package.constants import Colname
-from package.steps.aggregation import (
+from package.steps.aggregation.aggregators import (
     aggregate_flex_consumption_ga_brp_es,
     _aggregate_per_ga_and_brp_and_es,
 )

--- a/source/databricks/tests/integration/calculator/steps/aggregation/test_flex_consumption_ga_brp_es.py
+++ b/source/databricks/tests/integration/calculator/steps/aggregation/test_flex_consumption_ga_brp_es.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from package.constants import Colname
 from package.steps.aggregation import (
     aggregate_flex_consumption_ga_brp_es,
-    __aggregate_per_ga_and_brp_and_es,
+    _aggregate_per_ga_and_brp_and_es,
 )
 from package.codelists import (
     MeteringPointType,
@@ -273,7 +273,7 @@ def test_flex_consumption_test_filter_by_domain_is_present(
     time_series_row_factory: Callable[..., DataFrame],
 ) -> None:
     df = time_series_row_factory()
-    aggregated_df = __aggregate_per_ga_and_brp_and_es(
+    aggregated_df = _aggregate_per_ga_and_brp_and_es(
         df,
         MeteringPointType.consumption,
         SettlementMethod.flex,
@@ -286,7 +286,7 @@ def test_flex_consumption_test_filter_by_domain_is_not_present(
     time_series_row_factory: Callable[..., DataFrame]
 ) -> None:
     df = time_series_row_factory()
-    aggregated_df = __aggregate_per_ga_and_brp_and_es(
+    aggregated_df = _aggregate_per_ga_and_brp_and_es(
         df,
         MeteringPointType.consumption,
         SettlementMethod.non_profiled,

--- a/source/databricks/tests/integration/calculator/steps/aggregation/test_non_profiled_consumption_ga_brp_es.py
+++ b/source/databricks/tests/integration/calculator/steps/aggregation/test_non_profiled_consumption_ga_brp_es.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from package.constants import Colname
 from package.steps.aggregation import (
     aggregate_non_profiled_consumption_ga_brp_es,
-    __aggregate_per_ga_and_brp_and_es,
+    _aggregate_per_ga_and_brp_and_es,
 )
 from package.codelists import (
     MeteringPointType,
@@ -240,7 +240,7 @@ def test_consumption_test_filter_by_domain_is_pressent(
     time_series_row_factory: Callable[..., DataFrame],
 ) -> None:
     df = time_series_row_factory()
-    aggregated_df = __aggregate_per_ga_and_brp_and_es(
+    aggregated_df = _aggregate_per_ga_and_brp_and_es(
         df,
         MeteringPointType.consumption,
         SettlementMethod.non_profiled,
@@ -253,7 +253,7 @@ def test_consumption_test_filter_by_domain_is_not_pressent(
     time_series_row_factory: Callable[..., DataFrame],
 ) -> None:
     df = time_series_row_factory()
-    aggregated_df = __aggregate_per_ga_and_brp_and_es(
+    aggregated_df = _aggregate_per_ga_and_brp_and_es(
         df,
         MeteringPointType.consumption,
         SettlementMethod.flex,

--- a/source/databricks/tests/integration/calculator/steps/aggregation/test_non_profiled_consumption_ga_brp_es.py
+++ b/source/databricks/tests/integration/calculator/steps/aggregation/test_non_profiled_consumption_ga_brp_es.py
@@ -14,7 +14,7 @@
 from decimal import Decimal
 from datetime import datetime
 from package.constants import Colname
-from package.steps.aggregation import (
+from package.steps.aggregation.aggregators import (
     aggregate_non_profiled_consumption_ga_brp_es,
     _aggregate_per_ga_and_brp_and_es,
 )

--- a/source/databricks/tests/integration/calculator/steps/aggregation/test_production_ga_brp_es.py
+++ b/source/databricks/tests/integration/calculator/steps/aggregation/test_production_ga_brp_es.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from package.constants import Colname
 from package.steps.aggregation import (
     aggregate_production_ga_brp_es,
-    __aggregate_per_ga_and_brp_and_es,
+    _aggregate_per_ga_and_brp_and_es,
 )
 from package.codelists import (
     MeteringPointType,
@@ -252,7 +252,7 @@ def test_production_test_filter_by_domain_is_pressent(
     enriched_time_series_factory: Callable[..., DataFrame],
 ) -> None:
     df = enriched_time_series_factory()
-    aggregated_df = __aggregate_per_ga_and_brp_and_es(
+    aggregated_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
     assert aggregated_df.count() == 1
@@ -266,7 +266,7 @@ def test__quarterly_sums_correctly(
     df = enriched_time_series_quarterly_same_time_factory(
         first_quantity=Decimal("1"), second_quantity=Decimal("2")
     )
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
     assert result_df.first().sum_quantity == 3
@@ -303,7 +303,7 @@ def test__hourly_sums_are_rounded_correctly(
         resolution=MeteringPointResolution.hour.value, quantity=quantity
     )
 
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
 
@@ -326,7 +326,7 @@ def test__quarterly_and_hourly_sums_correctly(
         second_resolution=MeteringPointResolution.hour.value,
         second_quantity=second_quantity,
     )
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
     sum_quant = result_df.agg(sum(Colname.sum_quantity).alias("sum_quant"))
@@ -343,7 +343,7 @@ def test__points_with_same_time_quantities_are_on_same_position(
         second_resolution=MeteringPointResolution.hour.value,
         second_quantity=Decimal("2"),
     )
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
     # total 'Quantity' on first position
@@ -365,7 +365,7 @@ def test__position_is_based_on_time_correctly(
         first_grid_area_code=grid_area_code_805,
         second_grid_area_code=grid_area_code_805,
     )
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     ).collect()
 
@@ -387,7 +387,7 @@ def test__that_hourly_quantity_is_summed_as_quarterly(
         first_obs_time_string="2022-06-08T12:09:15.000Z",
         second_obs_time_string="2022-06-08T13:09:15.000Z",
     )
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
     assert result_df.count() == 8
@@ -401,7 +401,7 @@ def test__that_grid_area_code_in_input_is_in_output(
 ) -> None:
     "Test that the grid area codes in input are in result"
     df = enriched_time_series_quarterly_same_time_factory()
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
     assert result_df.first().GridAreaCode == str(grid_area_code_805)
@@ -412,7 +412,7 @@ def test__each_grid_area_has_a_sum(
 ) -> None:
     """Test that multiple GridAreas receive each their calculation for a period"""
     df = enriched_time_series_quarterly_same_time_factory(second_grid_area_code="806")
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
     assert result_df.where("GridAreaCode == 805").count() == 1
@@ -443,7 +443,7 @@ def test__final_sum_of_different_magnitudes_should_not_lose_precision(
             )
         )
     )
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
     assert result_df.count() == 4
@@ -491,7 +491,7 @@ def test__quality_is_lowest_common_denominator_among_measured_estimated_and_miss
         .union(enriched_time_series_factory(quality=quality_2))
         .union(enriched_time_series_factory(quality=quality_3))
     )
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
     assert result_df.first().Quality == expected_quality
@@ -502,7 +502,7 @@ def test__when_time_series_point_is_missing__quality_has_value_incomplete(
 ) -> None:
     df = enriched_time_series_factory().withColumn("quality", lit(None))
 
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
     assert result_df.first().Quality == TimeSeriesQuality.missing.value
@@ -514,7 +514,7 @@ def test__when_time_series_point_is_missing__quantity_is_0(
     df = enriched_time_series_factory().withColumn(
         Colname.quantity, lit(None).cast(DecimalType())
     )
-    result_df = __aggregate_per_ga_and_brp_and_es(
+    result_df = _aggregate_per_ga_and_brp_and_es(
         df, MeteringPointType.production, None, metadata
     )
     assert result_df.first().sum_quantity == Decimal("0.000")

--- a/source/databricks/tests/integration/calculator/steps/aggregation/test_production_ga_brp_es.py
+++ b/source/databricks/tests/integration/calculator/steps/aggregation/test_production_ga_brp_es.py
@@ -14,7 +14,7 @@
 from decimal import Decimal
 from datetime import datetime
 from package.constants import Colname
-from package.steps.aggregation import (
+from package.steps.aggregation.aggregators import (
     aggregate_production_ga_brp_es,
     _aggregate_per_ga_and_brp_and_es,
 )


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Change private methods in aggregators.py to use one underscore instead of two, to follow python standards.
Remove the private method from __init__.py and import the private method directly into the tests files that use the method

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #782 
