### PR TITLE
refac: write result to delta table

### DIFF
--- a/source/databricks/package/balance_fixing.py
+++ b/source/databricks/package/balance_fixing.py
@@ -17,7 +17,7 @@ from datetime import datetime
 import package.steps.aggregation as agg_steps
 from package.codelists import MeteringPointResolution
 from package.constants import Colname
-from package.codelists import MarketRole, TimeSeriesType, Grouping
+from package.codelists import TimeSeriesType, Grouping
 from package.db_logging import debug
 from package.file_writers.actors_writer import ActorsWriter
 from package.file_writers.basis_data_writer import BasisDataWriter

--- a/source/databricks/package/balance_fixing.py
+++ b/source/databricks/package/balance_fixing.py
@@ -77,11 +77,9 @@ def _calculate_production(
         production_per_per_ga_and_brp_and_es
     )
 
-    result_writer.write_per_ga(
-        production_per_ga, TimeSeriesType.PRODUCTION, Grouping.total_ga
-    )
+    result_writer.write(production_per_ga, TimeSeriesType.PRODUCTION, Grouping.total_ga)
 
-    result_writer.write_per_ga_per_brp_per_es(
+    result_writer.write(
         production_per_per_ga_and_brp_and_es,
         TimeSeriesType.PRODUCTION,
         Grouping.es_per_brp_per_ga,
@@ -105,10 +103,9 @@ def _calculate_non_profiled_consumption(
         consumption_per_ga_and_brp_and_es
     )
 
-    result_writer.write_per_ga_per_actor(
+    result_writer.write(
         consumption_per_ga_and_es,
         TimeSeriesType.NON_PROFILED_CONSUMPTION,
-        MarketRole.ENERGY_SUPPLIER,
         Grouping.es_per_ga,
     )
 
@@ -117,10 +114,9 @@ def _calculate_non_profiled_consumption(
         consumption_per_ga_and_brp_and_es
     )
 
-    result_writer.write_per_ga_per_actor(
+    result_writer.write(
         consumption_per_ga_and_brp,
         TimeSeriesType.NON_PROFILED_CONSUMPTION,
-        MarketRole.BALANCE_RESPONSIBLE_PARTY,
         Grouping.brp_per_ga,
     )
 
@@ -129,7 +125,7 @@ def _calculate_non_profiled_consumption(
         consumption_per_ga_and_brp_and_es
     )
 
-    result_writer.write_per_ga(
+    result_writer.write(
         consumption_per_ga,
         TimeSeriesType.NON_PROFILED_CONSUMPTION,
         Grouping.total_ga,

--- a/source/databricks/package/codelists/grouping.py
+++ b/source/databricks/package/codelists/grouping.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 
-class Grouping:
+from enum import Enum
+
+
+class Grouping(Enum):
     total_ga = "total_ga"
     es_per_brp_per_ga = "es_brp_ga"
     es_per_ga = "es_ga"

--- a/source/databricks/package/codelists/grouping.py
+++ b/source/databricks/package/codelists/grouping.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from enum import Enum
-
-
-class Grouping(Enum):
+class Grouping:
     total_ga = "total_ga"
     es_per_brp_per_ga = "es_brp_ga"
     es_per_ga = "es_ga"

--- a/source/databricks/package/constants/colname.py
+++ b/source/databricks/package/constants/colname.py
@@ -19,6 +19,7 @@ class Colname:
     added_system_correction = "added_system_correction"
     aggregated_quality = "aggregated_quality"
     balance_responsible_id = "BalanceResponsibleId"
+    batch_id = "batch_id"
     charge_count = "charge_count"
     charge_id = "charge_id"
     charge_key = "charge_key"

--- a/source/databricks/package/constants/partition_key_name.py
+++ b/source/databricks/package/constants/partition_key_name.py
@@ -14,6 +14,8 @@
 
 
 class PartitionKeyName:
+    GROUPING: str = "grouping"
+    TIME_SERIES_TYPE: str = "time_series_type"
     ENERGY_SUPPLIER_GLN: str = "energy_supplier_gln"
     BALANCE_RESPONSIBLE_PARTY_GLN: str = "balance_responsible_party_gln"
     GRID_AREA: str = "grid_area"

--- a/source/databricks/package/file_writers/basis_data_writer.py
+++ b/source/databricks/package/file_writers/basis_data_writer.py
@@ -72,7 +72,7 @@ class BasisDataWriter:
         timeseries_quarter_df: DataFrame,
         timeseries_hour_df: DataFrame,
     ) -> None:
-        grouping_folder_name = f"grouping={Grouping.total_ga.value}"
+        grouping_folder_name = f"grouping={Grouping.total_ga}"
 
         partition_keys = [PartitionKeyName.GRID_AREA]
         timeseries_quarter_df = timeseries_quarter_df.drop(
@@ -99,7 +99,7 @@ class BasisDataWriter:
         timeseries_quarter_df: DataFrame,
         timeseries_hour_df: DataFrame,
     ) -> None:
-        grouping_folder_name = f"grouping={Grouping.es_per_ga.value}"
+        grouping_folder_name = f"grouping={Grouping.es_per_ga}"
 
         partition_keys = [
             PartitionKeyName.GRID_AREA,

--- a/source/databricks/package/file_writers/basis_data_writer.py
+++ b/source/databricks/package/file_writers/basis_data_writer.py
@@ -72,7 +72,7 @@ class BasisDataWriter:
         timeseries_quarter_df: DataFrame,
         timeseries_hour_df: DataFrame,
     ) -> None:
-        grouping_folder_name = f"grouping={Grouping.total_ga}"
+        grouping_folder_name = f"grouping={Grouping.total_ga.value}"
 
         partition_keys = [PartitionKeyName.GRID_AREA]
         timeseries_quarter_df = timeseries_quarter_df.drop(
@@ -99,7 +99,7 @@ class BasisDataWriter:
         timeseries_quarter_df: DataFrame,
         timeseries_hour_df: DataFrame,
     ) -> None:
-        grouping_folder_name = f"grouping={Grouping.es_per_ga}"
+        grouping_folder_name = f"grouping={Grouping.es_per_ga.value}"
 
         partition_keys = [
             PartitionKeyName.GRID_AREA,

--- a/source/databricks/package/file_writers/process_step_result_writer.py
+++ b/source/databricks/package/file_writers/process_step_result_writer.py
@@ -171,6 +171,7 @@ class ProcessStepResultWriter:
         df = df.withColumnRenamed(
             Colname.quality, "QuantityQuality"
         )  # TODO: use QuantityQuality everywhere
+        df = df.withColumnRenamed("quarter_time", "time")  # TODO: time everywhere
 
         if grouping == Grouping.total_ga:
             df = df.withColumn(

--- a/source/databricks/package/file_writers/process_step_result_writer.py
+++ b/source/databricks/package/file_writers/process_step_result_writer.py
@@ -28,56 +28,63 @@ class ProcessStepResultWriter:
             f"{container_path}/{infra.get_batch_relative_path(batch_id)}"
         )
 
-    def write_per_ga(
+    def write(
         self,
         result_df: DataFrame,
         time_series_type: TimeSeriesType,
         grouping: Grouping,
     ) -> None:
         result_df = self._prepare_result_for_output(
-            result_df,
+            result_df, time_series_type, grouping
         )
-
         # start: write to delta table (before dropping columns)
         self._write_result_to_table(result_df, time_series_type, grouping)
         # end: write to delta table
 
+        if grouping == Grouping.total_ga:
+            self._write_per_ga(result_df)
+        elif grouping == Grouping.es_per_ga:
+            self._write_per_ga_per_actor(result_df, MarketRole.ENERGY_SUPPLIER)
+        elif grouping == Grouping.brp_per_ga:
+            self._write_per_ga_per_actor(
+                result_df, MarketRole.BALANCE_RESPONSIBLE_PARTY
+            )
+        elif grouping == Grouping.es_per_brp_per_ga:
+            self._write_per_ga_per_brp_per_es(result_df)
+        else:
+            raise ValueError(f"Unsupported grouping, {grouping.value}")
+
+    def _write_per_ga(
+        self,
+        result_df: DataFrame,
+    ) -> None:
         result_df.drop(Colname.energy_supplier_id).drop(Colname.balance_responsible_id)
-        partition_by = [PartitionKeyName.GRID_AREA]
-        self._write_result_df(result_df, partition_by, time_series_type, grouping)
+        partition_by = [
+            PartitionKeyName.GROUPING,
+            PartitionKeyName.TIME_SERIES_TYPE,
+            PartitionKeyName.GRID_AREA,
+        ]
+        self._write_result_df(result_df, partition_by)
 
-    def write_per_ga_per_actor(
+    def _write_per_ga_per_actor(
         self,
         result_df: DataFrame,
-        time_series_type: TimeSeriesType,
         market_role: MarketRole,
-        grouping: Grouping,
     ) -> None:
-        result_df = self._prepare_result_for_output(
-            result_df,
-        )
-        # start: write to delta table (before dropping columns)
-        self._write_result_to_table(result_df, time_series_type, grouping)
-        # end: write to delta table
-
         result_df = self._add_gln(result_df, market_role)
         result_df.drop(Colname.energy_supplier_id).drop(Colname.balance_responsible_id)
-        partition_by = [PartitionKeyName.GRID_AREA, PartitionKeyName.GLN]
-        self._write_result_df(result_df, partition_by, time_series_type, grouping)
+        partition_by = [
+            PartitionKeyName.GROUPING,
+            PartitionKeyName.TIME_SERIES_TYPE,
+            PartitionKeyName.GRID_AREA,
+            PartitionKeyName.GLN,
+        ]
+        self._write_result_df(result_df, partition_by)
 
-    def write_per_ga_per_brp_per_es(
+    def _write_per_ga_per_brp_per_es(
         self,
         result_df: DataFrame,
-        time_series_type: TimeSeriesType,
-        grouping: Grouping,
     ) -> None:
-        result_df = self._prepare_result_for_output(
-            result_df,
-        )
-        # start: write to delta table (before dropping columns)
-        self._write_result_to_table(result_df, time_series_type, grouping)
-        # end: write to delta table
-
         result_df = result_df.withColumnRenamed(
             Colname.balance_responsible_id,
             PartitionKeyName.BALANCE_RESPONSIBLE_PARTY_GLN,
@@ -86,13 +93,20 @@ class ProcessStepResultWriter:
         )
 
         partition_by = [
+            PartitionKeyName.GROUPING,
+            PartitionKeyName.TIME_SERIES_TYPE,
             PartitionKeyName.GRID_AREA,
             PartitionKeyName.BALANCE_RESPONSIBLE_PARTY_GLN,
             PartitionKeyName.ENERGY_SUPPLIER_GLN,
         ]
-        self._write_result_df(result_df, partition_by, time_series_type, grouping)
+        self._write_result_df(result_df, partition_by)
 
-    def _prepare_result_for_output(self, result_df: DataFrame) -> DataFrame:
+    def _prepare_result_for_output(
+        self,
+        result_df: DataFrame,
+        time_series_type: TimeSeriesType,
+        grouping: Grouping,
+    ) -> DataFrame:
         result_df = result_df.select(
             col(Colname.grid_area).alias(PartitionKeyName.GRID_AREA),
             Colname.energy_supplier_id,
@@ -101,6 +115,10 @@ class ProcessStepResultWriter:
             col(Colname.quality).alias("quality"),
             col(Colname.time_window_start).alias("quarter_time"),
         )
+
+        result_df = result_df.withColumn(
+            PartitionKeyName.GROUPING, lit(grouping.value)
+        ).withColumn(PartitionKeyName.TIME_SERIES_TYPE, lit(time_series_type.value))
 
         return result_df
 
@@ -128,17 +146,15 @@ class ProcessStepResultWriter:
         self,
         result_df: DataFrame,
         partition_by: list[str],
-        time_series_type: TimeSeriesType,
-        grouping: Grouping,
     ) -> None:
-        result_data_directory = f"{self.__output_path}/result/grouping={grouping.value}/time_series_type={time_series_type.value}"
+        result_data_directory = f"{self.__output_path}/result/"
 
         # First repartition to co-locate all rows for a grid area on a single executor.
         # This ensures that only one file is being written/created for each grid area
         # When writing/creating the files. The partition by creates a folder for each grid area.
         (
             result_df.repartition(PartitionKeyName.GRID_AREA)
-            .write.mode("errorifexists")
+            .write.mode("append")
             .partitionBy(partition_by)
             .json(result_data_directory)
         )

--- a/source/databricks/package/file_writers/process_step_result_writer.py
+++ b/source/databricks/package/file_writers/process_step_result_writer.py
@@ -22,7 +22,7 @@ from pyspark.sql.functions import col, lit
 class ProcessStepResultWriter:
     def __init__(self, container_path: str, batch_id: str):
         self.__table_name = "result_table"
-        self.__delta_table_path = f"{container_path}/{infra.get_calculation_output_folder()}/{self.__table_name}"
+        self.__delta_table_path = f"{container_path}/{infra.OUTPUT_FOLDER}/{self.__table_name}"
         self.__batch_id = batch_id
         self.__output_path = (
             f"{container_path}/{infra.get_batch_relative_path(batch_id)}"
@@ -52,7 +52,7 @@ class ProcessStepResultWriter:
         elif grouping == Grouping.es_per_brp_per_ga:
             self._write_per_ga_per_brp_per_es(result_df)
         else:
-            raise ValueError(f"Unsupported grouping, {grouping.value}")
+            raise ValueError(f"Unsupported grouping, {grouping}")
 
     def _write_per_ga(
         self,
@@ -117,7 +117,7 @@ class ProcessStepResultWriter:
         )
 
         result_df = result_df.withColumn(
-            PartitionKeyName.GROUPING, lit(grouping.value)
+            PartitionKeyName.GROUPING, lit(grouping)
         ).withColumn(PartitionKeyName.TIME_SERIES_TYPE, lit(time_series_type.value))
 
         return result_df
@@ -167,7 +167,7 @@ class ProcessStepResultWriter:
     ) -> None:
         df = (
             df.withColumn(Colname.time_series_type, lit(time_series_type.value))
-            .withColumn("grouping", lit(grouping.value))
+            .withColumn("grouping", lit(grouping))
             .withColumn(Colname.batch_id, lit(self.__batch_id))
         )
 
@@ -180,7 +180,7 @@ class ProcessStepResultWriter:
         elif grouping == Grouping.brp_per_ga:
             df = df.withColumn(Colname.energy_supplier_id, lit(None).cast("string"))
         elif grouping != Grouping.es_per_brp_per_ga:
-            raise ValueError(f"Unsupported grouping, {grouping.value}")
+            raise ValueError(f"Unsupported grouping, {grouping}")
 
         df.write.format("delta").mode("append").option(
             "path", self.__delta_table_path

--- a/source/databricks/package/file_writers/process_step_result_writer.py
+++ b/source/databricks/package/file_writers/process_step_result_writer.py
@@ -177,6 +177,11 @@ class ProcessStepResultWriter:
         elif grouping != Grouping.es_per_brp_per_ga:
             raise ValueError(f"Unsupported grouping, {grouping.value}")
 
-        df.write.format("delta").mode("append").option(
-            "path", self.__delta_table_path
-        ).saveAsTable(self.__table_name)
+        (
+            df.write.format("delta")
+            .mode("append")
+            .option("mergeSchema", "false")
+            .option("overwriteSchema", "false")
+            .option("path", self.__delta_table_path)
+            .saveAsTable(self.__table_name)
+        )

--- a/source/databricks/package/file_writers/process_step_result_writer.py
+++ b/source/databricks/package/file_writers/process_step_result_writer.py
@@ -22,7 +22,7 @@ from pyspark.sql.functions import col, lit
 class ProcessStepResultWriter:
     def __init__(self, container_path: str, batch_id: str):
         self.__table_name = "result_table"
-        self.__delta_table_path = f"{container_path}/{infra.OUTPUT_FOLDER}/{self.__table_name}"
+        self.__delta_table_path = f"{container_path}/{infra.get_calculation_output_folder()}/{self.__table_name}"
         self.__batch_id = batch_id
         self.__output_path = (
             f"{container_path}/{infra.get_batch_relative_path(batch_id)}"
@@ -52,7 +52,7 @@ class ProcessStepResultWriter:
         elif grouping == Grouping.es_per_brp_per_ga:
             self._write_per_ga_per_brp_per_es(result_df)
         else:
-            raise ValueError(f"Unsupported grouping, {grouping}")
+            raise ValueError(f"Unsupported grouping, {grouping.value}")
 
     def _write_per_ga(
         self,
@@ -117,7 +117,7 @@ class ProcessStepResultWriter:
         )
 
         result_df = result_df.withColumn(
-            PartitionKeyName.GROUPING, lit(grouping)
+            PartitionKeyName.GROUPING, lit(grouping.value)
         ).withColumn(PartitionKeyName.TIME_SERIES_TYPE, lit(time_series_type.value))
 
         return result_df
@@ -167,7 +167,7 @@ class ProcessStepResultWriter:
     ) -> None:
         df = (
             df.withColumn(Colname.time_series_type, lit(time_series_type.value))
-            .withColumn("grouping", lit(grouping))
+            .withColumn("grouping", lit(grouping.value))
             .withColumn(Colname.batch_id, lit(self.__batch_id))
         )
 
@@ -180,7 +180,7 @@ class ProcessStepResultWriter:
         elif grouping == Grouping.brp_per_ga:
             df = df.withColumn(Colname.energy_supplier_id, lit(None).cast("string"))
         elif grouping != Grouping.es_per_brp_per_ga:
-            raise ValueError(f"Unsupported grouping, {grouping}")
+            raise ValueError(f"Unsupported grouping, {grouping.value}")
 
         df.write.format("delta").mode("append").option(
             "path", self.__delta_table_path

--- a/source/databricks/package/file_writers/process_step_result_writer.py
+++ b/source/databricks/package/file_writers/process_step_result_writer.py
@@ -38,7 +38,7 @@ class ProcessStepResultWriter:
             result_df, time_series_type, grouping
         )
         # start: write to delta table (before dropping columns)
-        self._write_result_to_table(result_df, time_series_type, grouping)
+        self._write_result_to_table(result_df, grouping)
         # end: write to delta table
 
         if grouping == Grouping.total_ga:
@@ -162,14 +162,9 @@ class ProcessStepResultWriter:
     def _write_result_to_table(
         self,
         df: DataFrame,
-        time_series_type: TimeSeriesType,
         grouping: Grouping,
     ) -> None:
-        df = (
-            df.withColumn(Colname.time_series_type, lit(time_series_type.value))
-            .withColumn("grouping", lit(grouping.value))
-            .withColumn(Colname.batch_id, lit(self.__batch_id))
-        )
+        df = df.withColumn(Colname.batch_id, lit(self.__batch_id))
 
         if grouping == Grouping.total_ga:
             df = df.withColumn(

--- a/source/databricks/package/file_writers/process_step_result_writer.py
+++ b/source/databricks/package/file_writers/process_step_result_writer.py
@@ -165,6 +165,12 @@ class ProcessStepResultWriter:
         grouping: Grouping,
     ) -> None:
         df = df.withColumn(Colname.batch_id, lit(self.__batch_id))
+        df = df.withColumnRenamed(
+            PartitionKeyName.GROUPING, "AggregationLevel"
+        )  # TODO: rename Grouping enum to AggragationLevel
+        df = df.withColumnRenamed(
+            Colname.quality, "QuantityQuality"
+        )  # TODO: use QuantityQuality everywhere
 
         if grouping == Grouping.total_ga:
             df = df.withColumn(

--- a/source/databricks/package/infrastructure.py
+++ b/source/databricks/package/infrastructure.py
@@ -14,7 +14,7 @@
 
 # Resource names and variables defined in the infrastructure repository (https://github.com/Energinet-DataHub/dh3-infrastructure)
 
-from package.codelists import TimeSeriesType
+from package.codelists import TimeSeriesType, Grouping
 from package.constants import PartitionKeyName
 from typing import Union
 from package.codelists import BasisDataType
@@ -41,10 +41,10 @@ def get_result_file_relative_path(
     energy_supplier_gln: Union[str, None],
     balance_responsible_gln: Union[str, None],
     time_series_type: TimeSeriesType,
-    grouping: str,
+    grouping: Grouping,
 ) -> str:
     batch_path = get_batch_relative_path(batch_id)
-    relative_path = f"{batch_path}/{RESULT_FOLDER}/grouping={grouping}/time_series_type={time_series_type.value}/grid_area={grid_area}"
+    relative_path = f"{batch_path}/{RESULT_FOLDER}/grouping={grouping.value}/time_series_type={time_series_type.value}/grid_area={grid_area}"
 
     if (energy_supplier_gln is None) and (balance_responsible_gln is None):
         return relative_path
@@ -81,6 +81,10 @@ def get_basis_data_path(
         return f"{basis_data_root_path}/grouping=total_ga/grid_area={grid_area}"
     else:
         return f"{basis_data_root_path}/grouping=es_ga/grid_area={grid_area}/energy_supplier_gln={energy_supplier_id}"
+
+
+def get_calculation_output_folder() -> str:
+    return OUTPUT_FOLDER
 
 
 def get_batch_relative_path(batch_id: str) -> str:

--- a/source/databricks/package/infrastructure.py
+++ b/source/databricks/package/infrastructure.py
@@ -44,7 +44,7 @@ def get_result_file_relative_path(
     grouping: Grouping,
 ) -> str:
     batch_path = get_batch_relative_path(batch_id)
-    relative_path = f"{batch_path}/{RESULT_FOLDER}/grouping={grouping}/time_series_type={time_series_type.value}/grid_area={grid_area}"
+    relative_path = f"{batch_path}/{RESULT_FOLDER}/grouping={grouping.value}/time_series_type={time_series_type.value}/grid_area={grid_area}"
 
     if (energy_supplier_gln is None) and (balance_responsible_gln is None):
         return relative_path
@@ -81,6 +81,10 @@ def get_basis_data_path(
         return f"{basis_data_root_path}/grouping=total_ga/grid_area={grid_area}"
     else:
         return f"{basis_data_root_path}/grouping=es_ga/grid_area={grid_area}/energy_supplier_gln={energy_supplier_id}"
+
+
+def get_calculation_output_folder() -> str:
+    return OUTPUT_FOLDER
 
 
 def get_batch_relative_path(batch_id: str) -> str:

--- a/source/databricks/package/infrastructure.py
+++ b/source/databricks/package/infrastructure.py
@@ -44,7 +44,7 @@ def get_result_file_relative_path(
     grouping: Grouping,
 ) -> str:
     batch_path = get_batch_relative_path(batch_id)
-    relative_path = f"{batch_path}/{RESULT_FOLDER}/grouping={grouping.value}/time_series_type={time_series_type.value}/grid_area={grid_area}"
+    relative_path = f"{batch_path}/{RESULT_FOLDER}/grouping={grouping}/time_series_type={time_series_type.value}/grid_area={grid_area}"
 
     if (energy_supplier_gln is None) and (balance_responsible_gln is None):
         return relative_path
@@ -81,10 +81,6 @@ def get_basis_data_path(
         return f"{basis_data_root_path}/grouping=total_ga/grid_area={grid_area}"
     else:
         return f"{basis_data_root_path}/grouping=es_ga/grid_area={grid_area}/energy_supplier_gln={energy_supplier_id}"
-
-
-def get_calculation_output_folder() -> str:
-    return OUTPUT_FOLDER
 
 
 def get_batch_relative_path(batch_id: str) -> str:

--- a/source/databricks/tests/integration/calculator/file_writers/test_actors_writer.py
+++ b/source/databricks/tests/integration/calculator/file_writers/test_actors_writer.py
@@ -20,7 +20,6 @@ from unittest.mock import patch
 
 from package.codelists import MeteringPointResolution, TimeSeriesQuality
 from package.constants import Colname
-from package.codelists.market_role import MarketRole
 from package.codelists.time_series_type import TimeSeriesType
 from package.file_writers.actors_writer import ActorsWriter
 import package.infrastructure as infra

--- a/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
+++ b/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
@@ -86,10 +86,9 @@ def test__write_per_ga_per_actor__result_file_path_matches_contract(
     sut = ProcessStepResultWriter(str(tmpdir), DEFAULT_BATCH_ID)
 
     # Act: Executed in fixture executed_calculation_job
-    sut.write_per_ga_per_actor(
+    sut.write(
         result_df,
         TimeSeriesType.NON_PROFILED_CONSUMPTION,
-        MarketRole.ENERGY_SUPPLIER,
         Grouping.es_per_ga,
     )
 
@@ -124,7 +123,7 @@ def test__write_per_ga__result_file_path_matches_contract(
     sut = ProcessStepResultWriter(str(tmpdir), DEFAULT_BATCH_ID)
 
     # Act: Executed in fixture executed_calculation_job
-    sut.write_per_ga(
+    sut.write(
         result_df,
         TimeSeriesType.PRODUCTION,
         Grouping.total_ga,
@@ -167,7 +166,7 @@ def test__write_ga_brp_es__result_file_path_matches_contract(
     sut = ProcessStepResultWriter(str(tmpdir), DEFAULT_BATCH_ID)
 
     # Act: Executed in fixture executed_calculation_job
-    sut.write_per_ga_per_brp_per_es(
+    sut.write(
         result_df,
         TimeSeriesType.PRODUCTION,
         Grouping.es_per_brp_per_ga,

--- a/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
+++ b/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
@@ -216,8 +216,7 @@ def test__write__writes_grouping_column(
 
     # Assert
     actual_df = spark.read.table(table_name)
-    actual_df.show()
-    assert actual_df.collect()[0]["grouping"] == grouping.value
+    assert actual_df.collect()[0]["AggregationLevel"] == grouping.value
 
 
 @pytest.mark.parametrize(
@@ -288,6 +287,11 @@ def test__write_result_to_table__when_schema_differs_from_table__raise_exception
     spark: SparkSession, tmpdir: Path
 ) -> None:
     # Arrange
+    table_name = "result_table"
+    spark.sql(
+        f"DROP TABLE IF EXISTS {table_name}"
+    )  # needed to avoid conflict between parametrized tests
+
     row = [
         _create_result_row(
             grid_area=DEFAULT_GRID_AREA,

--- a/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
+++ b/source/databricks/tests/integration/calculator/file_writers/test_process_step_result_writer.py
@@ -16,16 +16,17 @@ from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
 
+import package.infrastructure as infra
+import pytest
+from delta.tables import DeltaTable
 from package.codelists import (
+    Grouping,
     MeteringPointResolution,
     TimeSeriesQuality,
-    MarketRole,
     TimeSeriesType,
-    Grouping,
 )
 from package.constants import Colname
 from package.file_writers.process_step_result_writer import ProcessStepResultWriter
-import package.infrastructure as infra
 from pyspark.sql import SparkSession
 from tests.helpers.assert_calculation_file_path import (
     CalculationFileType,
@@ -63,7 +64,7 @@ def _create_result_row(
     return row
 
 
-def test__write_per_ga_per_actor__result_file_path_matches_contract(
+def test__write___when_grouping_is_es_per_ga__result_file_path_matches_contract(
     spark: SparkSession,
     contracts_path: str,
     tmpdir: Path,
@@ -104,7 +105,7 @@ def test__write_per_ga_per_actor__result_file_path_matches_contract(
     )
 
 
-def test__write_per_ga__result_file_path_matches_contract(
+def test__write___when_grouping_is_total_ga__result_file_path_matches_contract(
     spark: SparkSession,
     contracts_path: str,
     tmpdir: Path,
@@ -141,7 +142,7 @@ def test__write_per_ga__result_file_path_matches_contract(
     )
 
 
-def test__write_ga_brp_es__result_file_path_matches_contract(
+def test__write___when_grouping_is_ga_brp_es__result_file_path_matches_contract(
     spark: SparkSession,
     contracts_path: str,
     tmpdir: Path,
@@ -182,3 +183,73 @@ def test__write_ga_brp_es__result_file_path_matches_contract(
         actual_result_file,
         CalculationFileType.ResultFileForGaBrpEs,
     )
+
+
+@pytest.mark.parametrize(
+    "grouping",
+    Grouping,
+)
+def test__write__writes_grouping_column(
+    spark: SparkSession, tmpdir: Path, grouping: Grouping
+) -> None:
+    # Arrange
+    table_name = "result_table"
+    spark.sql(
+        f"DROP TABLE IF EXISTS {table_name}"
+    )  # needed to avoid conflict between parametrized tests
+    row = [
+        _create_result_row(
+            grid_area=DEFAULT_GRID_AREA,
+            energy_supplier_id=DEFAULT_ENERGY_SUPPLIER_ID,
+            balance_responsible_id=DEFAULT_BALANCE_RESPONSIBLE_ID,
+        )
+    ]
+    result_df = spark.createDataFrame(data=row)
+    sut = ProcessStepResultWriter(str(tmpdir), DEFAULT_BATCH_ID)
+
+    # Act: Executed in fixture executed_calculation_job
+    sut.write(
+        result_df,
+        TimeSeriesType.PRODUCTION,
+        grouping,
+    )
+
+    # Assert
+    actual_df = spark.read.table(table_name)
+    actual_df.show()
+    assert actual_df.collect()[0]["grouping"] == grouping.value
+
+
+@pytest.mark.parametrize(
+    "time_series_type",
+    TimeSeriesType,
+)
+def test__write__writes_time_series_type_column(
+    spark: SparkSession, tmpdir: Path, time_series_type: TimeSeriesType
+) -> None:
+    # Arrange
+    table_name = "result_table"
+    spark.sql(
+        f"DROP TABLE IF EXISTS {table_name}"
+    )  # needed to avoid conflict between parametrized tests
+
+    row = [
+        _create_result_row(
+            grid_area=DEFAULT_GRID_AREA,
+            energy_supplier_id=DEFAULT_ENERGY_SUPPLIER_ID,
+            balance_responsible_id=DEFAULT_BALANCE_RESPONSIBLE_ID,
+        )
+    ]
+    result_df = spark.createDataFrame(data=row)
+    sut = ProcessStepResultWriter(str(tmpdir), DEFAULT_BATCH_ID)
+
+    # Act: Executed in fixture executed_calculation_job
+    sut.write(
+        result_df,
+        time_series_type,
+        Grouping.total_ga,
+    )
+
+    # Assert
+    actual_df = spark.read.table(table_name)
+    assert actual_df.collect()[0]["time_series_type"] == time_series_type.value

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -631,8 +631,8 @@ def test__creates_hour_for_total_ga__per_grid_area(
     basis_data_relative_path_805 = infra.get_basis_data_path(
         BasisDataType.TimeSeriesHour, executed_batch_id, "805"
     )
-    basis_data_relative_path_806 = infra.get_basis_data_path(
-        BasisDataType.TimeSeriesHour, executed_batch_id, "806"
+    basis_data_relative_path_806 = (
+        infra.get_basis_data_path(BasisDataType.TimeSeriesHour, executed_batch_id, "806")
     )
 
     # Act

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -246,7 +246,7 @@ def test__result_is_generated_for_requested_grid_areas(
     energy_supplier_gln: str,
     balance_responsible_party_gln: str,
     time_series_type: TimeSeriesType,
-    grouping: str,
+    grouping: Grouping,
 ) -> None:
     # Act
     # we run the calculator once per session. See the fixture executed_calculation_job in top of this file
@@ -631,8 +631,8 @@ def test__creates_hour_for_total_ga__per_grid_area(
     basis_data_relative_path_805 = infra.get_basis_data_path(
         BasisDataType.TimeSeriesHour, executed_batch_id, "805"
     )
-    basis_data_relative_path_806 = (
-        infra.get_basis_data_path(BasisDataType.TimeSeriesHour, executed_batch_id, "806")
+    basis_data_relative_path_806 = infra.get_basis_data_path(
+        BasisDataType.TimeSeriesHour, executed_batch_id, "806"
     )
 
     # Act

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -631,8 +631,8 @@ def test__creates_hour_for_total_ga__per_grid_area(
     basis_data_relative_path_805 = infra.get_basis_data_path(
         BasisDataType.TimeSeriesHour, executed_batch_id, "805"
     )
-    basis_data_relative_path_806 = (
-        infra.get_basis_data_path(BasisDataType.TimeSeriesHour, executed_batch_id, "806")
+    basis_data_relative_path_806 = infra.get_basis_data_path(
+        BasisDataType.TimeSeriesHour, executed_batch_id, "806"
     )
 
     # Act


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Write data to delta table (while also still writing to the datalake as before). The delta table is stored in the calculation-output (next to all the batches). We now use 'time_series_type' and 'grouping' as partitioning when we store to the normal data lake. This means that we need to use the 'append' safemode. This was done to streamline the code a bit - hopefully we will anyway eventually remove the normal datalake writings.

With the PR the delta lake will have the following columns:  batch_id, time_series_type, grid_area, quarter_time, quality, grouping, balance_responsible_id, energy_supplier_id


## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #892 