### PR TITLE
fix: Handle 0-prefixed grid area codes correctly in calculator job args

### DIFF
--- a/source/contracts/internal/calculation-job-parameters-reference.txt
+++ b/source/contracts/internal/calculation-job-parameters-reference.txt
@@ -6,6 +6,6 @@
 # Empty lines and lines starting with '#' are ignores in the tests.
 
 --batch-id={batch-id}
---batch-grid-areas=[805, 806]
+--batch-grid-areas=[805, 806, 033]
 --batch-period-start-datetime=2022-05-31T22:00:00Z
 --batch-period-end-datetime=2022-06-01T22:00:00Z

--- a/source/databricks/package/args_helper.py
+++ b/source/databricks/package/args_helper.py
@@ -27,12 +27,21 @@ def valid_date(s: str) -> datetime:
 
 
 def valid_list(s: str) -> list[str]:
-    """See https://stackoverflow.com/questions/25470844/specify-date-format-for-python-argparse-input-arguments"""
-    try:
-        return ast.literal_eval(s)
-    except ValueError:
-        msg = "not a valid grid area list"
+    if not s.startswith("[") or not s.endswith("]"):
+        msg = "Grid area codes must be a list enclosed by an opening '[' and a closing ']'"
         raise configargparse.ArgumentTypeError(msg)
+
+    # 1. Remove enclosing list characters 2. Split each grid area code 3. Remove possibly enclosing spaces.
+    tokens = [token.strip() for token in s.strip("[]").split(",")]
+
+    # Grid area codes must always consist of 3 digits
+    if any(
+        len(token) != 3 or any(c < "0" or c > "9" for c in token) for token in tokens
+    ):
+        msg = "Grid area codes must consist of 3 digits"
+        raise configargparse.ArgumentTypeError(msg)
+
+    return tokens
 
 
 def valid_log_level(s: str) -> str:

--- a/source/dotnet/Services/WebApi.UnitTests/Infrastructure/Calculations/DatabricksCalculatorJobParametersFactoryTests.cs
+++ b/source/dotnet/Services/WebApi.UnitTests/Infrastructure/Calculations/DatabricksCalculatorJobParametersFactoryTests.cs
@@ -35,7 +35,7 @@ public class DatabricksCalculatorJobParametersFactoryTests
         // Arrange
         var batch = new Batch(
             ProcessType.BalanceFixing,
-            new List<GridAreaCode> { new("805"), new("806") },
+            new List<GridAreaCode> { new("805"), new("806"), new("033") },
             DateTimeOffset.Parse("2022-05-31T22:00Z").ToInstant(),
             DateTimeOffset.Parse("2022-06-01T22:00Z").ToInstant(),
             SystemClock.Instance.GetCurrentInstant(),


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #909
