### PR TITLE
bug: switched result to consumption for es_brp_ga

### DIFF
--- a/source/databricks/package/balance_fixing.py
+++ b/source/databricks/package/balance_fixing.py
@@ -79,12 +79,6 @@ def _calculate_production(
 
     result_writer.write(production_per_ga, TimeSeriesType.PRODUCTION, Grouping.total_ga)
 
-    result_writer.write(
-        production_per_per_ga_and_brp_and_es,
-        TimeSeriesType.PRODUCTION,
-        Grouping.es_per_brp_per_ga,
-    )
-
 
 def _calculate_non_profiled_consumption(
     actors_writer: ActorsWriter,
@@ -96,6 +90,12 @@ def _calculate_non_profiled_consumption(
         agg_steps.aggregate_non_profiled_consumption_ga_brp_es(
             enriched_time_series_point_df
         )
+    )
+
+    result_writer.write(
+        consumption_per_ga_and_brp_and_es,
+        TimeSeriesType.NON_PROFILED_CONSUMPTION,
+        Grouping.es_per_brp_per_ga,
     )
 
     # Non-profiled consumption per energy supplier

--- a/source/databricks/tests/integration/calculator/test_calculator_job.py
+++ b/source/databricks/tests/integration/calculator/test_calculator_job.py
@@ -211,14 +211,14 @@ def test__get_valid_args_or_throw__accepts_parameters_from_process_manager(
             "805",
             energy_supplier_gln_a,
             balance_responsible_party_gln_a,
-            TimeSeriesType.PRODUCTION,
+            TimeSeriesType.NON_PROFILED_CONSUMPTION,
             Grouping.es_per_brp_per_ga,
         ),
         (
             "806",
             energy_supplier_gln_a,
             balance_responsible_party_gln_a,
-            TimeSeriesType.PRODUCTION,
+            TimeSeriesType.NON_PROFILED_CONSUMPTION,
             Grouping.es_per_brp_per_ga,
         ),
         (


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #886 
