### PR TITLE
refac: removed [AllowAnonymous] from WholesaleAPI

### DIFF
--- a/source/dotnet/Services/WebApi/V2/BatchControllerV21.cs
+++ b/source/dotnet/Services/WebApi/V2/BatchControllerV21.cs
@@ -47,7 +47,6 @@ public class BatchControllerV21 : ControllerBase
     /// <returns>Batches that matches the search criteria. Always 200 OK</returns>
     [HttpPost("Search")]
     [MapToApiVersion(Version)]
-    [AllowAnonymous]
     [Produces("application/json", Type = typeof(List<BatchDtoV2>))]
     public async Task<IActionResult> SearchAsync([FromBody] BatchSearchDtoV2 batchSearchDto)
     {

--- a/source/dotnet/Services/WebApi/V2/ProcessStepControllerV21.cs
+++ b/source/dotnet/Services/WebApi/V2/ProcessStepControllerV21.cs
@@ -34,7 +34,6 @@ public class ProcessStepV21Controller : ControllerBase
     /// <summary>
     /// Version 2.1: Quality added to points in result.
     /// </summary>
-    [AllowAnonymous] // TODO: Temporary hack to enable EDI integration while awaiting architects decision
     [HttpPost]
     [ApiVersion("2.0")]
     [ApiVersion("2.1")]

--- a/source/dotnet/Services/WebApi/V2/ProcessStepControllerV22.cs
+++ b/source/dotnet/Services/WebApi/V2/ProcessStepControllerV22.cs
@@ -31,7 +31,6 @@ public class ProcessStepV22Controller : ControllerBase
         _processStepApplicationService = processStepApplicationService;
     }
 
-    [AllowAnonymous] // TODO: Temporary hack to enable EDI integration while awaiting architects decision
     [HttpPost]
     [ApiVersion("2.2")]
     [Produces("application/json", Type = typeof(ProcessStepResultDto))]

--- a/source/dotnet/Services/WebApi/V2/ProcessStepControllerV23.cs
+++ b/source/dotnet/Services/WebApi/V2/ProcessStepControllerV23.cs
@@ -31,7 +31,6 @@ public class ProcessStepV23Controller : ControllerBase
         _processStepApplicationService = processStepApplicationService;
     }
 
-    [AllowAnonymous] // TODO: Temporary hack to enable EDI integration while awaiting architects decision
     [Obsolete("Use `/v3/batches/{batchId}/processes/{gridAreaCode}/time-series-types/{timeSeriesType}/market-roles/{marketRole}` instead")]
     [HttpPost]
     [ApiVersion("2.3")]

--- a/source/dotnet/Services/WebApi/V2/ProcessStepControllerV24.cs
+++ b/source/dotnet/Services/WebApi/V2/ProcessStepControllerV24.cs
@@ -37,7 +37,6 @@ public class ProcessStepV24Controller : ControllerBase
     /// if both 'BalanceResponsiblePartyGln' and 'EnergySupplierGln' is provided, a result is returned for the balance responsible party's energy supplier for requested grid area, for the specified time series type.
     /// if no 'BalanceResponsiblePartyGln' and 'EnergySupplierGln' is provided, a result is returned for the requested grid area, for the specified time series type.
     /// </summary>
-    [AllowAnonymous] // TODO: Temporary hack to enable EDI integration while awaiting architects decision
     [HttpPost]
     [ApiVersion("2.4")]
     [Produces("application/json", Type = typeof(ProcessStepResultDto))]

--- a/source/dotnet/Services/WebApi/V3/ProcessStepBalanceResponsibleParty/ProcessStepBalanceResponsiblePartyController.cs
+++ b/source/dotnet/Services/WebApi/V3/ProcessStepBalanceResponsibleParty/ProcessStepBalanceResponsiblePartyController.cs
@@ -35,7 +35,6 @@ public class ProcessStepBalanceResponsiblePartyController : V3ControllerBase
     /// <summary>
     /// Balance responsible parties.
     /// </summary>
-    [AllowAnonymous] // TODO: Temporary hack to enable EDI integration while awaiting architects decision
     [HttpGet]
     [Produces("application/json", Type = typeof(List<ActorDto>))]
     public async Task<List<ActorDto>> GetAllAsync(

--- a/source/dotnet/Services/WebApi/V3/ProcessStepEnergySupplier/ProcessStepEnergySupplierController.cs
+++ b/source/dotnet/Services/WebApi/V3/ProcessStepEnergySupplier/ProcessStepEnergySupplierController.cs
@@ -35,7 +35,6 @@ public class ProcessStepEnergySupplierController : V3ControllerBase
     /// <summary>
     /// Returns a list of Energy suppliers. If balance responsible party is specified by the <paramref name="balanceResponsibleParty"/> parameter only the energy suppliers associated with that balance responsible party is returned
     /// </summary>
-    [AllowAnonymous] // TODO: Temporary hack to enable EDI integration while awaiting architects decision
     [HttpGet]
     [Produces("application/json", Type = typeof(List<ActorDto>))]
     public async Task<List<ActorDto>> GetAsync([FromRoute] Guid batchId, [FromRoute] string gridAreaCode, [FromRoute] TimeSeriesType timeSeriesType, [FromQuery] string? balanceResponsibleParty)

--- a/source/dotnet/Services/WebApi/V3/ProcessStepResult/ProcessStepResultController.cs
+++ b/source/dotnet/Services/WebApi/V3/ProcessStepResult/ProcessStepResultController.cs
@@ -52,7 +52,6 @@ public class ProcessStepResultController : V3ControllerBase
     /// <param name="timeSeriesType">The time series type the result has</param>
     /// <param name="energySupplierGln">The GLN for the energy supplier the requested result</param>
     /// <param name="balanceResponsiblePartyGln">The GLN for the balance responsible party the requested result</param>
-    [AllowAnonymous] // TODO: Temporary hack to enable EDI integration while awaiting architects decision
     [HttpGet]
     [Produces("application/json", Type = typeof(ProcessStepResultDto))]
     public async Task<ProcessStepResultDto> GetResultAsync(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

EDI no longer uses the WebAPI, so we no longer have to `[AllowAnonymous]` on the controller methods they used.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #886 
