### PR TITLE
feat: add TimeSeriesType to ProcessStepResultDto in V3

### DIFF
--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/V3/ProcessStepResultFactoryTests.cs
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/V3/ProcessStepResultFactoryTests.cs
@@ -44,7 +44,8 @@ public class ProcessStepResultFactoryTests
             {
                 new(point.Time, point.Quantity, point.Quality),
             },
-            batchDto.ProcessType);
+            batchDto.ProcessType,
+            resultDto.TimeSeriesType);
 
         // Act
         var actual = sut.Create(resultDto, batchDto);

--- a/source/dotnet/wholesale-api/WebApi/V3/ProcessStepResult/ProcessStepResultDto.cs
+++ b/source/dotnet/wholesale-api/WebApi/V3/ProcessStepResult/ProcessStepResultDto.cs
@@ -28,6 +28,7 @@ namespace Energinet.DataHub.Wholesale.WebApi.V3.ProcessStepResult;
 /// <param name="Unit">kWh</param>
 /// <param name="TimeSeriesPoints"></param>
 /// <param name="ProcessType"></param>
+/// <param name="TimeSeriesType"></param>
 public sealed record ProcessStepResultDto(
     decimal Sum,
     decimal Min,
@@ -37,4 +38,5 @@ public sealed record ProcessStepResultDto(
     string Resolution,
     string Unit,
     TimeSeriesPointDto[] TimeSeriesPoints,
-    ProcessType ProcessType);
+    ProcessType ProcessType,
+    TimeSeriesType TimeSeriesType);

--- a/source/dotnet/wholesale-api/WebApi/V3/ProcessStepResult/ProcessStepResultFactory.cs
+++ b/source/dotnet/wholesale-api/WebApi/V3/ProcessStepResult/ProcessStepResultFactory.cs
@@ -29,7 +29,8 @@ public class ProcessStepResultFactory : IProcessStepResultFactory
             batch.Resolution,
             batch.Unit,
             stepResult.TimeSeriesPoints.Select(MapTimeSeriesPoint()).ToArray(),
-            batch.ProcessType);
+            batch.ProcessType,
+            stepResult.TimeSeriesType);
     }
 
     private static Func<Contracts.TimeSeriesPointDto, TimeSeriesPointDto> MapTimeSeriesPoint()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

The `TimeSeriesType` was missing from the `ProcessStepResultDto` in the V3 API.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
