### PR TITLE
fix: Correct bad schema ordering

### DIFF
--- a/source/databricks/calculation-engine/package/datamigration/migration_scripts/202304191400_Add_result_table.py
+++ b/source/databricks/calculation-engine/package/datamigration/migration_scripts/202304191400_Add_result_table.py
@@ -30,23 +30,23 @@ RESULT_TABLE_NAME = "result"
 
 RESULTS_SCHEMA = StructType(
     [
-        StructField("batch_id", StringType(), False),
-        StructField("batch_execution_time_start", TimestampType(), False),
-        StructField("batch_process_type", StringType(), False),
-        StructField("time_series_type", StringType(), False),
         # The grid area in question. In case of exchange it's the in-grid area.
         StructField("grid_area", StringType(), False),
-        StructField("out_grid_area", StringType(), True),
-        StructField("balance_responsible_id", StringType(), True),
         StructField("energy_supplier_id", StringType(), True),
-        # The time when the energy was consumed/produced/exchanged
-        StructField("time", TimestampType(), False),
+        StructField("balance_responsible_id", StringType(), True),
         # Energy quantity in kWh for the given observation time.
         # Null when quality is missing.
         # Example: 1234.534
         StructField("quantity", DecimalType(18, 3), True),
         StructField("quantity_quality", StringType(), False),
+        # The time when the energy was consumed/produced/exchanged
+        StructField("time", TimestampType(), False),
         StructField("aggregation_level", StringType(), False),
+        StructField("time_series_type", StringType(), False),
+        StructField("batch_id", StringType(), False),
+        StructField("batch_process_type", StringType(), False),
+        StructField("batch_execution_time_start", TimestampType(), False),
+        StructField("out_grid_area", StringType(), True),
     ]
 )
 

--- a/source/databricks/calculation-engine/package/file_writers/process_step_result_writer.py
+++ b/source/databricks/calculation-engine/package/file_writers/process_step_result_writer.py
@@ -191,26 +191,26 @@ class ProcessStepResultWriter:
 
         # Map column names to the Delta table field names
         df = df.select(
-            col(Colname.batch_id).alias(ResultTableColName.batch_id),
-            col(Colname.batch_execution_time_start).alias(
-                ResultTableColName.batch_execution_time_start
-            ),
-            col(Colname.batch_process_type).alias(
-                ResultTableColName.batch_process_type
-            ),
-            lit(time_series_type.value).alias(ResultTableColName.time_series_type),
             col(Colname.grid_area).alias(ResultTableColName.grid_area),
-            col(Colname.out_grid_area).alias(ResultTableColName.out_grid_area),
-            col(Colname.balance_responsible_id).alias(
-                ResultTableColName.balance_responsible_id
-            ),
             col(Colname.energy_supplier_id).alias(
                 ResultTableColName.energy_supplier_id
             ),
-            col(Colname.time_window_start).alias(ResultTableColName.time),
+            col(Colname.balance_responsible_id).alias(
+                ResultTableColName.balance_responsible_id
+            ),
             col(Colname.sum_quantity).alias(ResultTableColName.quantity),
             col(Colname.quality).alias(ResultTableColName.quantity_quality),
+            col(Colname.time_window_start).alias(ResultTableColName.time),
             lit(aggregation_level.value).alias(ResultTableColName.aggregation_level),
+            lit(time_series_type.value).alias(ResultTableColName.time_series_type),
+            col(Colname.batch_id).alias(ResultTableColName.batch_id),
+            col(Colname.batch_process_type).alias(
+                ResultTableColName.batch_process_type
+            ),
+            col(Colname.batch_execution_time_start).alias(
+                ResultTableColName.batch_execution_time_start
+            ),
+            col(Colname.out_grid_area).alias(ResultTableColName.out_grid_area),
         )
 
         df.write.format("delta").mode("append").option(

--- a/source/databricks/calculation-engine/package/schemas/results_schema.py
+++ b/source/databricks/calculation-engine/package/schemas/results_schema.py
@@ -24,24 +24,24 @@ from package.constants import ResultTableColName
 
 results_schema = StructType(
     [
-        StructField(ResultTableColName.batch_id, StringType(), False),
-        StructField(
-            ResultTableColName.batch_execution_time_start, TimestampType(), False
-        ),
-        StructField(ResultTableColName.batch_process_type, StringType(), False),
-        StructField(ResultTableColName.time_series_type, StringType(), False),
         # The grid area in question. In case of exchange it's the in-grid area.
         StructField(ResultTableColName.grid_area, StringType(), False),
-        StructField(ResultTableColName.out_grid_area, StringType(), True),
-        StructField(ResultTableColName.balance_responsible_id, StringType(), True),
         StructField(ResultTableColName.energy_supplier_id, StringType(), True),
-        # The time when the energy was consumed/produced/exchanged
-        StructField(ResultTableColName.time, TimestampType(), False),
+        StructField(ResultTableColName.balance_responsible_id, StringType(), True),
         # Energy quantity in kWh for the given observation time.
         # Null when quality is missing.
         # Example: 1234.534
         StructField(ResultTableColName.quantity, DecimalType(18, 3), True),
         StructField(ResultTableColName.quantity_quality, StringType(), False),
+        StructField(ResultTableColName.time, TimestampType(), False),
         StructField(ResultTableColName.aggregation_level, StringType(), False),
+        StructField(ResultTableColName.time_series_type, StringType(), False),
+        StructField(ResultTableColName.batch_id, StringType(), False),
+        StructField(ResultTableColName.batch_process_type, StringType(), False),
+        StructField(
+            ResultTableColName.batch_execution_time_start, TimestampType(), False
+        ),
+        # The time when the energy was consumed/produced/exchanged
+        StructField(ResultTableColName.out_grid_area, StringType(), True),
     ]
 )

--- a/source/databricks/calculation-engine/tests/datamigration/test_migration_scripts.py
+++ b/source/databricks/calculation-engine/tests/datamigration/test_migration_scripts.py
@@ -34,18 +34,18 @@ DATABASE_NAME = "wholesale_output"
 
 def _create_df(spark: SparkSession) -> DataFrame:
     row = {
-        ResultTableColName.batch_id: "batch_id",
-        ResultTableColName.batch_execution_time_start: datetime(2020, 1, 1, 0, 0),
-        ResultTableColName.batch_process_type: "BalanceFixing",
-        ResultTableColName.time_series_type: "production",
         ResultTableColName.grid_area: "543",
-        ResultTableColName.out_grid_area: "843",
-        ResultTableColName.balance_responsible_id: "balance_responsible_id",
         ResultTableColName.energy_supplier_id: "energy_supplier_id",
-        ResultTableColName.time: datetime(2020, 1, 1, 0, 0),
+        ResultTableColName.balance_responsible_id: "balance_responsible_id",
         ResultTableColName.quantity: Decimal("1.123"),
         ResultTableColName.quantity_quality: "missing",
+        ResultTableColName.time: datetime(2020, 1, 1, 0, 0),
         ResultTableColName.aggregation_level: "total_ga",
+        ResultTableColName.time_series_type: "production",
+        ResultTableColName.batch_id: "batch_id",
+        ResultTableColName.batch_process_type: "BalanceFixing",
+        ResultTableColName.batch_execution_time_start: datetime(2020, 1, 1, 0, 0),
+        ResultTableColName.out_grid_area: "843",
     }
     return spark.createDataFrame(data=[row], schema=results_schema)
 

--- a/source/databricks/calculation-engine/tests/integration/calculator/file_writers/test_process_step_result_writer.py
+++ b/source/databricks/calculation-engine/tests/integration/calculator/file_writers/test_process_step_result_writer.py
@@ -250,7 +250,8 @@ def test__write__writes_aggregation_level(
     assert actual_df.collect()[0]["aggregation_level"] == aggregation_level.value
 
 
-batch_id = str(uuid.uuid4())  # Needed in both test param and test implementation
+# The batch id is used in parameterized test executed using xdist, which does not allow parameters to change
+batch_id = "some batch id"  # Needed in both test param and test implementation
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

It appears that writing to delta from pyspark requires the same ordering of the columns in the dataframe as of the columns in the delta table.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/green-energy-hub/415
