### PR TITLE
load input data from calculation-input folder instead of calculation-…

### DIFF
--- a/source/databricks/calculation-engine/package/calculator_job.py
+++ b/source/databricks/calculation-engine/package/calculator_job.py
@@ -64,15 +64,13 @@ def _start_calculator(spark: SparkSession, args: CalculatorArgs) -> None:
     timeseries_points_df = (
         spark.read.option("mode", "FAILFAST")
         .format("delta")
-        .load(
-            f"{args.wholesale_container_path}/calculation-input-v2/time-series-points"
-        )
+        .load(f"{args.wholesale_container_path}/calculation-input/time-series-points")
     )
     metering_points_periods_df = (
         spark.read.option("mode", "FAILFAST")
         .format("delta")
         .load(
-            f"{args.wholesale_container_path}/calculation-input-v2/metering-point-periods"
+            f"{args.wholesale_container_path}/calculation-input/metering-point-periods"
         )
     )
     batch_grid_areas_df = input.get_batch_grid_areas_df(args.batch_grid_areas, spark)

--- a/source/databricks/calculation-engine/tests/integration/calculator/calculator_job/conftest.py
+++ b/source/databricks/calculation-engine/tests/integration/calculator/calculator_job/conftest.py
@@ -73,7 +73,7 @@ def executed_calculation_job(
         schema=metering_point_period_schema,
     )
     metering_points_df.write.format("delta").save(
-        f"{data_lake_path}/calculation-input-v2/metering-point-periods",
+        f"{data_lake_path}/calculation-input/metering-point-periods",
         mode="overwrite",
     )
     timeseries_points_df = spark.read.csv(
@@ -83,7 +83,7 @@ def executed_calculation_job(
     )
 
     timeseries_points_df.write.format("delta").save(
-        f"{data_lake_path}/calculation-input-v2/time-series-points",
+        f"{data_lake_path}/calculation-input/time-series-points",
         mode="overwrite",
     )
 


### PR DESCRIPTION
…input-v2

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Volt is now placing migration data in calculation-input and not in calculation-input-v2.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
