### PR TITLE
refac: use more explicit timeout on domain test

### DIFF
--- a/source/dotnet/domain-tests/Fixtures/AuthorizedClientFixture.cs
+++ b/source/dotnet/domain-tests/Fixtures/AuthorizedClientFixture.cs
@@ -100,7 +100,12 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
                 await ServiceBusAdministrationClient.DeleteSubscriptionAsync(_topicName, _subscriptionName);
             }
 
-            await ServiceBusAdministrationClient.CreateSubscriptionAsync(_topicName, _subscriptionName);
+            var options = new CreateSubscriptionOptions(_topicName, _subscriptionName)
+            {
+                AutoDeleteOnIdle = TimeSpan.FromHours(1),
+            };
+
+            await ServiceBusAdministrationClient.CreateSubscriptionAsync(options);
         }
 
         private ServiceBusReceiver CreateServiceBusReceiver()

--- a/source/dotnet/domain-tests/WebApiTests.cs
+++ b/source/dotnet/domain-tests/WebApiTests.cs
@@ -164,7 +164,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
 
                         if (cts.IsCancellationRequested)
                         {
-                            Assert.Fail("No messages received on topic subscription.");
+                            Assert.Fail($"No messages received on topic subscription match {batchId.ToString()}.");
                         }
                     }
                 }

--- a/source/dotnet/domain-tests/WebApiTests.cs
+++ b/source/dotnet/domain-tests/WebApiTests.cs
@@ -145,7 +145,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 var match = false;
                 using (var cts = new CancellationTokenSource())
                 {
-                    cts.CancelAfter(_defaultTimeout);
+                    cts.CancelAfter(TimeSpan.FromMinutes(5));
                     while (messageHasValue)
                     {
                         var message = await Fixture.Receiver.ReceiveMessageAsync();


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

this PR changes timeout handling in domain test to CancellationTokenSource.CancelAfter instead of maxWaitTime on RecceiveMessageAsync which does not seem to work when deployed.

Also added a autodelete feature on the service bus subscription being created for the test, after being idle for 1 hour it will delete itself.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
