### PR TITLE
refac: bumped contracts verison

### DIFF
--- a/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Wholesale Contracts Release notes
 
+## Version 3.0.1
+
+No functional changes.
+
 ## Version 3.0.0
 
 Renamed BalanceFixingEventName to MessageType and its value from BalanceFixingCalculationResultCompleted to CalculationResultCompleted.

--- a/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
@@ -33,7 +33,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Wholesale.Contracts</PackageId>
-    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.1$(VersionSuffix)</PackageVersion>
     <Title>Wholesale Contracts</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
The EDI solution has a problem with the generated NuGet package. Some newer values are missing. 
This PR bumps the version number to see if the new NuGet package contains the newer values. This is not a fix.
For example:

WholeSale
![image](https://github.com/Energinet-DataHub/opengeh-wholesale/assets/122119488/c7611047-26ab-4e1e-85ac-f91c5f7e5416)

EDI
![image](https://github.com/Energinet-DataHub/opengeh-wholesale/assets/122119488/06d43d4e-d55d-4f90-9f0b-c2092c02c251)

## Description

<!--- Please leave a helpful description of the pull request here. --->

[## References](https://app.zenhub.com/workspaces/phoenix--60a6105157304f00119be86e/issues/gh/energinet-datahub/team-batman/22)

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
