### PR TITLE
chore(deps): bump TestCommon from 4.3.1 to 4.3.2

### DIFF
--- a/source/dotnet/domain-tests/DomainTests.csproj
+++ b/source/dotnet/domain-tests/DomainTests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.15.0" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.1" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />

--- a/source/dotnet/wholesale-api/Batches/Batches.IntegrationTests/Batches.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.IntegrationTests/Batches.IntegrationTests.csproj
@@ -6,8 +6,8 @@
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.1" />
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.1" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/Batches/Batches.UnitTests/Batches.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.UnitTests/Batches.UnitTests.csproj
@@ -6,8 +6,8 @@
       <IsTestProject>true</IsTestProject>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.1" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.1" />
+      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
+      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
       <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
       <PackageReference Include="FluentAssertions" Version="6.11.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.1" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.1" />
+      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
+      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
       <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
       <PackageReference Include="FluentAssertions" Version="6.11.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
@@ -13,7 +13,7 @@
       <PackageReference Include="System.Linq.Async" Version="6.0.1" />
       <PackageReference Include="xunit" Version="2.4.2" />
       <PackageReference Include="YamlDotNet" Version="13.1.1" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.1" />
+      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
       <PackageReference Include="xunit.categories" Version="2.0.7" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Events/Events.IntegrationTests/Events.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.IntegrationTests/Events.IntegrationTests.csproj
@@ -4,8 +4,8 @@
       <RootNamespace>Energinet.DataHub.Wholesale.Events.IntegrationTests</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.1" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.1" />
+      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
+      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
       <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
       <PackageReference Include="FluentAssertions" Version="6.11.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/Events/Events.UnitTests/Events.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.UnitTests/Events.UnitTests.csproj
@@ -6,8 +6,8 @@
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.1" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.1" />
+      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
+      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
       <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
       <PackageReference Include="FluentAssertions" Version="6.11.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
+++ b/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
@@ -15,8 +15,8 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.1" />
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.1" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
@@ -27,8 +27,8 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.1" />
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.1" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
     <PackageReference Include="Energinet.DataHub.MeteringPoints.IntegrationEvents" Version="1.0.4" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Core" Version="3.4.0" />

--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi.UnitTests.csproj
@@ -40,7 +40,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.1" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
     <PackageReference Include="xunit.categories" Version="2.0.7" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

The certificte used in Azurite has been expired, which means that integration tests that use Azurite fails. This has been fixed in the latest version of TestCommon.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
