### PR TITLE
refac: remove period filtering in get_master_basis_data

### DIFF
--- a/source/databricks/calculation-engine/package/balance_fixing.py
+++ b/source/databricks/calculation-engine/package/balance_fixing.py
@@ -43,8 +43,6 @@ def calculate_balance_fixing(
     basis_data_writer.write(
         metering_points_periods_df,
         enriched_time_series_point_df,
-        period_start_datetime,
-        period_end_datetime,
         time_zone,
     )
 

--- a/source/databricks/calculation-engine/package/basis_data/__init__.py
+++ b/source/databricks/calculation-engine/package/basis_data/__init__.py
@@ -35,22 +35,9 @@ from datetime import datetime
 
 def get_master_basis_data_df(
     metering_point_df: DataFrame,
-    period_start_datetime: datetime,
-    period_end_datetime: datetime,
 ) -> DataFrame:
     return (
-        metering_point_df.withColumn(
-            Colname.from_date,
-            when(
-                col(Colname.from_date) < period_start_datetime, period_start_datetime
-            ).otherwise(col(Colname.from_date)),
-        )
-        .withColumn(
-            Colname.to_date,
-            when(
-                col(Colname.to_date) > period_end_datetime, period_end_datetime
-            ).otherwise(col(Colname.to_date)),
-        )
+        metering_point_df
         .select(
             col(Colname.metering_point_id).alias(BasisDataColname.metering_point_id),
             col(Colname.from_date).alias(BasisDataColname.valid_from),

--- a/source/databricks/calculation-engine/package/output_writers/basis_data_writer.py
+++ b/source/databricks/calculation-engine/package/output_writers/basis_data_writer.py
@@ -32,8 +32,6 @@ class BasisDataWriter:
         self,
         metering_points_periods_df: DataFrame,
         enriched_time_series_point_df: DataFrame,
-        period_start_datetime: datetime,
-        period_end_datetime: datetime,
         time_zone: str,
     ) -> None:
         (
@@ -44,7 +42,7 @@ class BasisDataWriter:
         )
 
         master_basis_data_df = basis_data.get_master_basis_data_df(
-            metering_points_periods_df, period_start_datetime, period_end_datetime
+            metering_points_periods_df
         )
 
         self._write(master_basis_data_df, timeseries_quarter_df, timeseries_hour_df)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Metering point periods are already filtered by period, so there is no need to also do it in get_master_basis_data

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
