### PR TITLE
chore(deps): bumps

### DIFF
--- a/source/dotnet/domain-tests/DomainTests.csproj
+++ b/source/dotnet/domain-tests/DomainTests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.15.0" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />

--- a/source/dotnet/wholesale-api/Batches/Batches.IntegrationTests/Batches.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.IntegrationTests/Batches.IntegrationTests.csproj
@@ -6,8 +6,8 @@
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.3" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.3" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/Batches/Batches.UnitTests/Batches.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.UnitTests/Batches.UnitTests.csproj
@@ -6,8 +6,8 @@
       <IsTestProject>true</IsTestProject>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
+      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.3" />
+      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.3" />
       <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
       <PackageReference Include="FluentAssertions" Version="6.11.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults.Infrastructure.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.15.0" />
     <PackageReference Include="CsvHelper" Version="30.0.1" />
-    <PackageReference Include="Energinet.DataHub.Core.JsonSerialization" Version="2.2.6" />
+    <PackageReference Include="Energinet.DataHub.Core.JsonSerialization" Version="2.2.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NodaTime" Version="3.1.9" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults.Infrastructure.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Energinet.DataHub.Wholesale.CalculationResults.Infrastructure</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.14.0" />
+    <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.15.0" />
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.JsonSerialization" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
+      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.3" />
+      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.3" />
       <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
       <PackageReference Include="FluentAssertions" Version="6.11.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
@@ -13,7 +13,7 @@
       <PackageReference Include="System.Linq.Async" Version="6.0.1" />
       <PackageReference Include="xunit" Version="2.4.2" />
       <PackageReference Include="YamlDotNet" Version="13.1.1" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
+      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.3" />
       <PackageReference Include="xunit.categories" Version="2.0.7" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Events/Communication/Communication/Communication.csproj
+++ b/source/dotnet/wholesale-api/Events/Communication/Communication/Communication.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.15.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.23.3" />
+    <PackageReference Include="Google.Protobuf" Version="3.23.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="NodaTime" Version="3.1.9" />

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.15.0" />
-    <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.14.0" />
+    <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.15.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="7.4.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.8" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.8" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.23.4" />
-    <PackageReference Include="Grpc.Tools" Version="2.56.0" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.56.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="7.4.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.8" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.23.3" />
+    <PackageReference Include="Google.Protobuf" Version="3.23.4" />
     <PackageReference Include="Grpc.Tools" Version="2.56.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">

--- a/source/dotnet/wholesale-api/Events/Events.IntegrationTests/Events.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.IntegrationTests/Events.IntegrationTests.csproj
@@ -4,8 +4,8 @@
       <RootNamespace>Energinet.DataHub.Wholesale.Events.IntegrationTests</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
+      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.3" />
+      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.3" />
       <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
       <PackageReference Include="FluentAssertions" Version="6.11.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/Events/Events.UnitTests/Events.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.UnitTests/Events.UnitTests.csproj
@@ -6,8 +6,8 @@
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
+      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.3" />
+      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.3" />
       <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
       <PackageReference Include="FluentAssertions" Version="6.11.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
+++ b/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
@@ -15,8 +15,8 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.3" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.3" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
@@ -27,8 +27,8 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.2" />
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.3" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.3" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
     <PackageReference Include="Energinet.DataHub.MeteringPoints.IntegrationEvents" Version="1.0.4" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Core" Version="3.4.0" />

--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi.UnitTests.csproj
@@ -40,7 +40,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.2" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.3" />
     <PackageReference Include="xunit.categories" Version="2.0.7" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

Bumps [Azure.Storage.Files.DataLake](https://github.com/Azure/azure-sdk-for-net) from 12.14.0 to 12.15.0.
Bumps [Energinet.DataHub.Core.JsonSerialization](https://github.com/Energinet-DataHub/geh-core) from 2.2.6 to 2.2.7.
Bumps [Google.Protobuf](https://github.com/protocolbuffers/protobuf) from 3.23.3 to 3.23.4.
Bumps [Grpc.Tools](https://github.com/grpc/grpc) from 2.56.0 to 2.56.2.
Bumps [Energinet.DataHub.Core.FunctionApp.TestCommon](https://github.com/Energinet-DataHub/geh-core) from 4.3.2 to 4.3.3.
Bumps [Energinet.DataHub.Core.TestCommon](https://github.com/Energinet-DataHub/geh-core) from 4.3.2 to 4.3.3.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
