### PR TITLE
fix: Fix bugs in `SqlStatementClient`

### DIFF
--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/Infrastructure/SqlStatements/SqlStatementClientBuilder.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/Infrastructure/SqlStatements/SqlStatementClientBuilder.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.SqlStatements;
+using Energinet.DataHub.Wholesale.Common.Databricks.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Energinet.DataHub.Wholesale.CalculationResults.UnitTests.Infrastructure.SqlStatements;
+
+public sealed class SqlStatementClientBuilder
+{
+    private readonly List<HttpResponseMessage> _responseMessages = new();
+    private IDatabricksSqlResponseParser? _parser;
+
+    public SqlStatementClientBuilder AddHttpClientResponse(string content)
+    {
+        _responseMessages.Add(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(content), });
+        return this;
+    }
+
+    public SqlStatementClientBuilder UseParser(IDatabricksSqlResponseParser parser)
+    {
+        _parser = parser;
+        return this;
+    }
+
+    public SqlStatementClient Build()
+    {
+        var handlerMock = new HttpMessageHandlerMock(_responseMessages);
+        var client = new HttpClient(handlerMock);
+        var options = new Mock<IOptions<DatabricksOptions>>();
+        options.Setup(o => o.Value).Returns(new DatabricksOptions
+        {
+            DATABRICKS_WORKSPACE_URL = "https://foo.com",
+        });
+        var parser = _parser ?? new Mock<IDatabricksSqlResponseParser>().Object;
+        var logger = new Mock<ILogger<SqlStatementClient>>();
+        return new SqlStatementClient(client, options.Object, parser, logger.Object);
+    }
+
+    private class HttpMessageHandlerMock : HttpMessageHandler
+    {
+        private readonly List<HttpResponseMessage> _messages;
+        private int _index;
+
+        public HttpMessageHandlerMock(List<HttpResponseMessage> messages)
+        {
+            _index = 0;
+            _messages = messages;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_messages[_index++]);
+        }
+    }
+}

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/Infrastructure/SqlStatements/SqlStatementClientTests.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/Infrastructure/SqlStatements/SqlStatementClientTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
+using Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.SqlStatements;
+using Moq;
+using Xunit;
+
+namespace Energinet.DataHub.Wholesale.CalculationResults.UnitTests.Infrastructure.SqlStatements;
+
+public class SqlStatementClientTests
+{
+    private const string Running = @"
+{
+  ""statement_id"": ""01ed9db9-24c4-1cb6-a320-fb6ebbe7410d"",
+  ""status"": {
+    ""state"": ""RUNNING""
+  }
+}";
+
+    private const string Closed = @"
+{
+    ""statement_id"": ""01ee34ba-ae2f-1ae5-92ba-ff597e3f57fa"",
+    ""status"": {
+        ""state"": ""CLOSED""
+    }
+}
+";
+
+    private const string Error = @"
+{
+    ""error_code"": ""NOT_FOUND"",
+    ""message"": ""The statement 01ee338a-2b5c-1287-8f90-ed2274193b76 was not found."",
+    ""details"": [
+        {
+            ""@type"": ""type.googleapis.com/google.rpc.ResourceInfo"",
+            ""resource_type"": ""statement"",
+            ""resource_name"": ""01ee338a-2b5c-1287-8f90-ed2274193b76"",
+            ""owner"": """",
+            ""description"": ""does not exist""
+        }
+    ]
+}
+";
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ExecuteAsync_WhenStatementIsClosed_ThrowsDatabricksSqlException(
+        Guid statementId,
+        Mock<IDatabricksSqlResponseParser> parserMock,
+        SqlStatementClientBuilder builder)
+    {
+        // Arrange
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(Running))
+            .Returns(DatabricksSqlResponse.CreateAsRunning(statementId));
+        parserMock
+            .Setup(parser => parser.ParseStatusResponse(Closed))
+            .Returns(DatabricksSqlResponse.CreateAsClosed(statementId));
+        var sut = builder
+            .AddHttpClientResponse(Running)
+            .AddHttpClientResponse(Closed)
+            .UseParser(parserMock.Object)
+            .Build();
+
+        // Act and assert
+        await Assert.ThrowsAsync<DatabricksSqlException>(async () => await sut.ExecuteAsync("some sql").ToListAsync());
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
This PR fixes a bug where the client in a loop doesn't use the new response from the Databricks API, but continues to use the original response.

In addition, the client keeps querying for status results without a back-off algorithm. This has been added to lower the immense load on the API.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1314
