### PR TITLE
test: Added schema compare tests (input reader)

### DIFF
--- a/source/databricks/calculation-engine/tests/integration/calculation_input/test_calculation_input_reader.py
+++ b/source/databricks/calculation-engine/tests/integration/calculation_input/test_calculation_input_reader.py
@@ -233,7 +233,7 @@ def test__read_data__returns_df(
     row = create_row()
     reader = CalculationInputReader(spark)
     df = spark.createDataFrame(data=[row], schema=expected_schema)
-    sut = getattr(reader, str(method_name.__name__))
+    sut = getattr(reader, method_name.__name__)
 
     # Act
     with mock.patch.object(reader, "_read_table", return_value=df):
@@ -281,7 +281,7 @@ def test__read_data__raises_value_error_when_schema_mismatch(
     sut = CalculationInputReader(spark)
     df = spark.createDataFrame(data=[row], schema=expected_schema)
     df = df.withColumn("test", lit("test"))
-    method = getattr(sut, str(method_name.__name__))
+    method = getattr(sut, method_name.__name__)
     is_exception_thrown = False
 
     # Act

--- a/source/databricks/calculation-engine/tests/integration/calculation_input/test_calculation_input_reader.py
+++ b/source/databricks/calculation-engine/tests/integration/calculation_input/test_calculation_input_reader.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 from datetime import datetime
+from decimal import Decimal
 from unittest import mock
 import pytest
 from pyspark.sql import SparkSession
+from pyspark.sql.functions import lit
+
 from package.codelists import (
     InputMeteringPointType,
     InputSettlementMethod,
@@ -23,12 +26,18 @@ from package.codelists import (
     SettlementMethod,
 )
 from package.calculation_input import CalculationInputReader
-from package.calculation_input.schemas import metering_point_period_schema
+from package.calculation_input.schemas import (
+    metering_point_period_schema,
+    charge_price_points_schema,
+    time_series_point_schema,
+    charge_link_periods_schema,
+    charge_master_data_periods_schema,
+)
 from package.constants import Colname
+from pyspark.sql.types import StructType
 
 
-def _create_row(
-    spark: SparkSession,
+def _create_metering_point_period_row(
     metering_point_type: InputMeteringPointType = InputMeteringPointType.CONSUMPTION,
     settlement_method: InputSettlementMethod = InputSettlementMethod.FLEX,
 ) -> dict:
@@ -44,6 +53,49 @@ def _create_row(
         Colname.parent_metering_point_id: "foo",
         Colname.energy_supplier_id: "foo",
         Colname.balance_responsible_id: "foo",
+        Colname.from_date: datetime(2022, 6, 8, 22, 0, 0),
+        Colname.to_date: datetime(2022, 6, 8, 22, 0, 0),
+    }
+
+
+def _create_change_price_point_row() -> dict:
+    return {
+        Colname.charge_id: "foo",
+        Colname.charge_type: "foo",
+        Colname.charge_owner: "foo",
+        Colname.charge_price: Decimal("1.123456"),
+        Colname.observation_time: datetime(2022, 6, 8, 22, 0, 0),
+    }
+
+
+def _create_time_series_point_row() -> dict:
+    return {
+        Colname.metering_point_id: "foo",
+        Colname.quantity: Decimal("1.123456"),
+        Colname.quality: "foo",
+        Colname.observation_time: datetime(2022, 6, 8, 22, 0, 0),
+    }
+
+
+def _create_charge_link_period_row() -> dict:
+    return {
+        Colname.charge_id: "foo",
+        Colname.charge_type: "foo",
+        Colname.charge_owner: "foo",
+        Colname.metering_point_id: "foo",
+        Colname.quantity: 1,
+        Colname.from_date: datetime(2022, 6, 8, 22, 0, 0),
+        Colname.to_date: datetime(2022, 6, 8, 22, 0, 0),
+    }
+
+
+def _create_charge_master_period_row() -> dict:
+    return {
+        Colname.charge_id: "foo",
+        Colname.charge_type: "foo",
+        Colname.charge_owner: "foo",
+        Colname.resolution: "foo",
+        Colname.charge_tax: False,
         Colname.from_date: datetime(2022, 6, 8, 22, 0, 0),
         Colname.to_date: datetime(2022, 6, 8, 22, 0, 0),
     }
@@ -84,7 +136,7 @@ def test___read_metering_point_periods__returns_df_with_correct_metering_point_t
     expected: MeteringPointType,
 ) -> None:
     # Arrange
-    row = _create_row(spark, metering_point_type=metering_point_type)
+    row = _create_metering_point_period_row(metering_point_type=metering_point_type)
     df = spark.createDataFrame(data=[row], schema=metering_point_period_schema)
     sut = CalculationInputReader(spark)
 
@@ -108,7 +160,7 @@ def test___read_metering_point_periods__returns_df_with_correct_settlemet_method
     settlement_method: InputSettlementMethod,
     expected: SettlementMethod,
 ) -> None:
-    row = _create_row(spark, settlement_method=settlement_method)
+    row = _create_metering_point_period_row(settlement_method=settlement_method)
     df = spark.createDataFrame(data=[row], schema=metering_point_period_schema)
     sut = CalculationInputReader(spark)
 
@@ -118,3 +170,127 @@ def test___read_metering_point_periods__returns_df_with_correct_settlemet_method
 
     # Assert
     assert actual.collect()[0][Colname.settlement_method] == expected.value
+
+
+@pytest.mark.parametrize(
+    "settlement_method,expected",
+    [
+        [InputSettlementMethod.FLEX, SettlementMethod.FLEX],
+        [InputSettlementMethod.NON_PROFILED, SettlementMethod.NON_PROFILED],
+    ],
+)
+def test___read_metering_point_periods__returns_df_with_correct_settlement_methods(
+    spark: SparkSession,
+    settlement_method: InputSettlementMethod,
+    expected: SettlementMethod,
+) -> None:
+    row = _create_metering_point_period_row(settlement_method=settlement_method)
+    df = spark.createDataFrame(data=[row], schema=metering_point_period_schema)
+    sut = CalculationInputReader(spark)
+
+    # Act
+    with mock.patch.object(sut, "_read_table", return_value=df):
+        actual = sut.read_metering_point_periods()
+
+    # Assert
+    assert actual.collect()[0][Colname.settlement_method] == expected.value
+
+
+@pytest.mark.parametrize(
+    "expected_schema, method_name, create_row",
+    [
+        (
+            metering_point_period_schema,
+            CalculationInputReader.read_metering_point_periods,
+            _create_metering_point_period_row,
+        ),
+        (
+            time_series_point_schema,
+            CalculationInputReader.read_time_series_points,
+            _create_time_series_point_row,
+        ),
+        (
+            charge_master_data_periods_schema,
+            CalculationInputReader.read_charge_master_data_periods,
+            _create_charge_master_period_row,
+        ),
+        (
+            charge_link_periods_schema,
+            CalculationInputReader.read_charge_links_periods,
+            _create_charge_link_period_row,
+        ),
+        (
+            charge_price_points_schema,
+            CalculationInputReader.read_charge_price_points,
+            _create_change_price_point_row,
+        ),
+    ],
+)
+def test__read_data__returns_df(
+    spark: SparkSession, expected_schema: StructType, method_name: str, create_row: any
+) -> None:
+    # Arrange
+    row = create_row()
+    sut = CalculationInputReader(spark)
+    df = spark.createDataFrame(data=[row], schema=expected_schema)
+    method = getattr(sut, str(method_name.__name__))
+
+    # Act & Assert
+    with mock.patch.object(sut, "_read_table", return_value=df):
+        method()
+
+
+@pytest.mark.parametrize(
+    "expected_schema, method_name, create_row",
+    [
+        (
+            metering_point_period_schema,
+            CalculationInputReader.read_metering_point_periods,
+            _create_metering_point_period_row,
+        ),
+        (
+            time_series_point_schema,
+            CalculationInputReader.read_time_series_points,
+            _create_time_series_point_row,
+        ),
+        (
+            charge_master_data_periods_schema,
+            CalculationInputReader.read_charge_master_data_periods,
+            _create_charge_master_period_row,
+        ),
+        (
+            charge_link_periods_schema,
+            CalculationInputReader.read_charge_links_periods,
+            _create_charge_link_period_row,
+        ),
+        (
+            charge_price_points_schema,
+            CalculationInputReader.read_charge_price_points,
+            _create_change_price_point_row,
+        ),
+    ],
+)
+def test__read_data__throws_exception_when_schema_mismatch(
+    spark: SparkSession, expected_schema: StructType, method_name: str, create_row: any
+) -> None:
+    # Arrange
+    row = create_row()
+    sut = CalculationInputReader(spark)
+    df = spark.createDataFrame(data=[row], schema=expected_schema)
+    df = df.withColumn("test", lit("test"))
+    method = getattr(sut, str(method_name.__name__))
+    is_exception_thrown = False
+
+    # Act
+    with mock.patch.object(sut, "_read_table", return_value=df):
+        try:
+            method()
+            print("This test fails because the schemas are identical!")
+        except Exception:
+            is_exception_thrown = True
+
+    # Assert
+    if is_exception_thrown:
+        assert True
+    else:
+        assert False


### PR DESCRIPTION
The added tests that check input table schemas (Databricks) don't change.

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/green-energy-hub/470

