### PR TITLE
test: Added tests of Databricks Health Checks

### DIFF
--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/HealthChecks/DataBricks/DatabricksJobsApiHealthCheckTests.cs
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/HealthChecks/DataBricks/DatabricksJobsApiHealthCheckTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
+using Energinet.DataHub.Wholesale.Common.Databricks.Options;
+using Energinet.DataHub.Wholesale.Common.DatabricksClient;
+using Energinet.DataHub.Wholesale.WebApi.HealthChecks.Databricks;
+using FluentAssertions;
+using Microsoft.Azure.Databricks.Client;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Moq;
+using NodaTime;
+using Xunit;
+
+namespace Energinet.DataHub.Wholesale.WebApi.UnitTests.WebApi.HealthChecks.DataBricks;
+
+public class DatabricksJobsApiHealthCheckTests
+{
+    [Theory]
+    [InlineAutoMoqData(6, 20, 14, HealthStatus.Healthy)] // Healthy because inside interval and check was successful
+    [InlineAutoMoqData(15, 20, 14, HealthStatus.Healthy)] // Healthy because outside interval (hours 15-20)
+    [InlineAutoMoqData(14, 14, 14, HealthStatus.Healthy)] // Healthy because just inside interval and check was successful
+    public async Task Databricks_Interval_HealthCheck_When_Calling_Dependency_Returns_Health_Status(
+        int startHour,
+        int endHour,
+        int currentHour,
+        HealthStatus expectedHealthStatus,
+        Mock<IJobsApiClient> jobsApiClientMock,
+        Mock<IClock> clock)
+    {
+        // Arrange
+        var options = new DatabricksOptions
+        {
+            DATABRICKS_HEALTH_CHECK_START_HOUR = new TimeOnly(startHour, 0),
+            DATABRICKS_HEALTH_CHECK_END_HOUR = new TimeOnly(endHour, 0),
+        };
+        clock.Setup(x => x.GetCurrentInstant()).Returns(Instant.FromUtc(2021, 1, 1, currentHour, 0));
+        jobsApiClientMock.Setup(x => x.Jobs).Returns(new Mock<IJobsApi>().Object);
+        var sut = new DatabricksJobsApiHealthRegistration(jobsApiClientMock.Object, clock.Object, options);
+
+        // Act
+        var actualHealthStatus = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None)
+            .ConfigureAwait(false);
+
+        // Assert
+        actualHealthStatus.Status.Should().Be(expectedHealthStatus);
+    }
+
+    [Theory]
+    [InlineAutoMoqData(6, 20, 14, 1)] // Inside interval
+    [InlineAutoMoqData(16, 20, 14, 0)] // Outside interval
+    public async Task Databricks_Interval_Health_Check_If_Calling_Dependency_Returns_HealthStatus(
+        int startHour,
+        int endHour,
+        int currentHour,
+        int times,
+        Mock<IJobsApiClient> jobsApiClientMock,
+        Mock<IClock> clock)
+    {
+        // Arrange
+        var options = new DatabricksOptions
+        {
+            DATABRICKS_HEALTH_CHECK_START_HOUR = new TimeOnly(startHour, 0),
+            DATABRICKS_HEALTH_CHECK_END_HOUR = new TimeOnly(endHour, 0),
+        };
+        clock.Setup(x => x.GetCurrentInstant()).Returns(Instant.FromUtc(2021, 1, 1, currentHour, 0));
+        jobsApiClientMock.Setup(x => x.Jobs).Returns(new Mock<IJobsApi>().Object);
+        var sut = new DatabricksJobsApiHealthRegistration(jobsApiClientMock.Object, clock.Object, options);
+
+        // Act
+        var actualHealthStatus = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None)
+            .ConfigureAwait(false);
+
+        // Assert
+        jobsApiClientMock.Verify(x => x.Jobs, Times.Exactly(times));
+        actualHealthStatus.Status.Should().Be(HealthStatus.Healthy);
+    }
+}

--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/HealthChecks/DataBricks/DatabricksSqlStatementsApiHealthCheckTests.cs
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/HealthChecks/DataBricks/DatabricksSqlStatementsApiHealthCheckTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using AutoFixture.Xunit2;
+using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
+using Energinet.DataHub.Wholesale.Common.Databricks.Options;
+using Energinet.DataHub.Wholesale.WebApi.HealthChecks.Databricks;
+using FluentAssertions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using NodaTime;
+using Xunit;
+
+namespace Energinet.DataHub.Wholesale.WebApi.UnitTests.WebApi.HealthChecks.DataBricks;
+
+public class DatabricksSqlStatementsApiHealthCheckTests
+{
+    [Theory]
+    [InlineAutoMoqData(6, 20, 14, HealthStatus.Healthy, HttpStatusCode.OK)] // Healthy because inside interval and check was successful
+    [InlineAutoMoqData(15, 20, 14, HealthStatus.Healthy, HttpStatusCode.OK)] // Healthy because outside interval (hours 15-20)
+    [InlineAutoMoqData(14, 14, 14, HealthStatus.Healthy, HttpStatusCode.OK)] // Healthy because just inside interval and check was successful
+    [InlineAutoMoqData(6, 20, 14, HealthStatus.Unhealthy, HttpStatusCode.BadRequest)] // Unhealthy because inside interval nut check was unsuccessful
+    public async Task Databricks_Interval_HealthCheck_When_Calling_Dependency_Returns_HealthStatus(
+        int startHour,
+        int endHour,
+        int currentHour,
+        HealthStatus expectedHealthStatus,
+        HttpStatusCode httpStatusCode,
+        [Frozen] Mock<IHttpClientFactory> httpClientFactoryMock,
+        [Frozen] Mock<HttpMessageHandler> httpMessageHandlerMock,
+        [Frozen] Mock<IClock> clockMock)
+    {
+        // Arrange
+        var options = new DatabricksOptions
+        {
+            DATABRICKS_HEALTH_CHECK_START_HOUR = new TimeOnly(startHour, 0),
+            DATABRICKS_HEALTH_CHECK_END_HOUR = new TimeOnly(endHour, 0),
+            DATABRICKS_WORKSPACE_URL = "https://fake",
+        };
+        clockMock.Setup(x => x.GetCurrentInstant()).Returns(Instant.FromUtc(2021, 1, 1, currentHour, 0));
+        httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(httpStatusCode));
+        using var httpClientMock = new HttpClient(httpMessageHandlerMock.Object);
+        httpClientFactoryMock.Setup(x => x.CreateClient(Options.DefaultName)).Returns(httpClientMock);
+        var sut = new DatabricksSqlStatementsApiHealthRegistration(httpClientFactoryMock.Object, clockMock.Object, options);
+
+        // Act
+        var actualHealthStatus = await sut
+            .CheckHealthAsync(new HealthCheckContext(), CancellationToken.None)
+            .ConfigureAwait(false);
+
+        // Assert
+        actualHealthStatus.Status.Should().Be(expectedHealthStatus);
+    }
+}

--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/HealthChecks/DataBricks/DatabricksSqlStatementsApiHealthCheckTests.cs
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/HealthChecks/DataBricks/DatabricksSqlStatementsApiHealthCheckTests.cs
@@ -33,7 +33,7 @@ public class DatabricksSqlStatementsApiHealthCheckTests
     [InlineAutoMoqData(6, 20, 14, HealthStatus.Healthy, HttpStatusCode.OK)] // Healthy because inside interval and check was successful
     [InlineAutoMoqData(15, 20, 14, HealthStatus.Healthy, HttpStatusCode.OK)] // Healthy because outside interval (hours 15-20)
     [InlineAutoMoqData(14, 14, 14, HealthStatus.Healthy, HttpStatusCode.OK)] // Healthy because just inside interval and check was successful
-    [InlineAutoMoqData(6, 20, 14, HealthStatus.Unhealthy, HttpStatusCode.BadRequest)] // Unhealthy because inside interval nut check was unsuccessful
+    [InlineAutoMoqData(6, 20, 14, HealthStatus.Unhealthy, HttpStatusCode.BadRequest)] // Inside interval but unhealthy because check was unsuccessful
     public async Task Databricks_Interval_HealthCheck_When_Calling_Dependency_Returns_HealthStatus(
         int startHour,
         int endHour,

--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/HealthChecks/DataLake/DataLakeHealthCheckTests.cs
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/HealthChecks/DataLake/DataLakeHealthCheckTests.cs
@@ -23,7 +23,7 @@ using Moq;
 using NodaTime;
 using Xunit;
 
-namespace Energinet.DataHub.Wholesale.WebApi.UnitTests.WebApi.HealthChecks.DataBricks;
+namespace Energinet.DataHub.Wholesale.WebApi.UnitTests.WebApi.HealthChecks.DataLake;
 
 public class DataLakeHealthCheckTests
 {


### PR DESCRIPTION
Added tests of Databricks Health Checks to verify the hourly interval, that is, the open period in which health checks are made. It can for example be from 8am to 4pm. The functionality is implemented to avoid flooding the dependency and thereby reducing the cost.

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

<!--- Please leave a helpful description of the pull request here. --->

<!--- Are there any issues, pull requests or similar that should be linked here? --->

https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/opengeh-wholesale/1366
