### PR TITLE
refac: Improve `aggregation_result_format` and usage

### DIFF
--- a/source/databricks/calculation-engine/package/calculation/energy/aggregators.py
+++ b/source/databricks/calculation-engine/package/calculation/energy/aggregators.py
@@ -114,7 +114,7 @@ def _aggregate_per_ga_and_brp_and_es(
             Colname.sum_quantity,
             lit(market_evaluation_point_type.value).alias(Colname.metering_point_type),
             lit(None if settlement_method is None else settlement_method.value)
-            .cast(StringType)
+            .cast(StringType())
             .alias(Colname.settlement_method),
             Colname.position,
         )

--- a/source/databricks/calculation-engine/package/calculation/energy/aggregators.py
+++ b/source/databricks/calculation-engine/package/calculation/energy/aggregators.py
@@ -111,9 +111,9 @@ def _aggregate_per_ga_and_brp_and_es(
             Colname.quality,
             Colname.sum_quantity,
             lit(market_evaluation_point_type.value).alias(Colname.metering_point_type),
-            lit(None if settlement_method is None else settlement_method.value).alias(
-                Colname.settlement_method
-            ),
+            lit(None if settlement_method is None else settlement_method.value)
+            .cast("string")
+            .alias(Colname.settlement_method),
             Colname.position,
         )
     )

--- a/source/databricks/calculation-engine/package/calculation/energy/aggregators.py
+++ b/source/databricks/calculation-engine/package/calculation/energy/aggregators.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from decimal import Decimal
 
 from package.codelists import (
@@ -27,6 +28,7 @@ from pyspark.sql.functions import (
     row_number,
     when,
 )
+from pyspark.sql.types import StringType
 from pyspark.sql.window import Window
 from typing import Union
 
@@ -112,7 +114,7 @@ def _aggregate_per_ga_and_brp_and_es(
             Colname.sum_quantity,
             lit(market_evaluation_point_type.value).alias(Colname.metering_point_type),
             lit(None if settlement_method is None else settlement_method.value)
-            .cast("string")
+            .cast(StringType)
             .alias(Colname.settlement_method),
             Colname.position,
         )

--- a/source/databricks/calculation-engine/package/calculation/energy/transformations/aggregation_result_formatter.py
+++ b/source/databricks/calculation-engine/package/calculation/energy/transformations/aggregation_result_formatter.py
@@ -14,6 +14,7 @@
 
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as f
+from pyspark.sql.types import StringType
 
 from package.common import assert_schema
 from package.constants import Colname
@@ -58,20 +59,20 @@ def create_dataframe_from_aggregation_result_schema(result: DataFrame) -> DataFr
 
 def _add_missing_nullable_columns(result: DataFrame) -> DataFrame:
     if Colname.to_grid_area not in result.columns:
-        result = result.withColumn(Colname.to_grid_area, f.lit(None).cast("string"))
+        result = result.withColumn(Colname.to_grid_area, f.lit(None).cast(StringType))
     if Colname.from_grid_area not in result.columns:
-        result = result.withColumn(Colname.from_grid_area, f.lit(None).cast("string"))
+        result = result.withColumn(Colname.from_grid_area, f.lit(None).cast(StringType))
     if Colname.balance_responsible_id not in result.columns:
         result = result.withColumn(
-            Colname.balance_responsible_id, f.lit(None).cast("string")
+            Colname.balance_responsible_id, f.lit(None).cast(StringType)
         )
     if Colname.energy_supplier_id not in result.columns:
         result = result.withColumn(
-            Colname.energy_supplier_id, f.lit(None).cast("string")
+            Colname.energy_supplier_id, f.lit(None).cast(StringType)
         )
     if Colname.settlement_method not in result.columns:
         result = result.withColumn(
-            Colname.settlement_method, f.lit(None).cast("string")
+            Colname.settlement_method, f.lit(None).cast(StringType)
         )
     if Colname.position not in result.columns:
         result = result.withColumn(Colname.position, f.lit(None).cast("integer"))

--- a/source/databricks/calculation-engine/package/calculation/energy/transformations/aggregation_result_formatter.py
+++ b/source/databricks/calculation-engine/package/calculation/energy/transformations/aggregation_result_formatter.py
@@ -14,7 +14,7 @@
 
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as f
-from pyspark.sql.types import StringType
+from pyspark.sql.types import StringType, IntegerType
 
 from package.common import assert_schema
 from package.constants import Colname

--- a/source/databricks/calculation-engine/package/calculation/energy/transformations/aggregation_result_formatter.py
+++ b/source/databricks/calculation-engine/package/calculation/energy/transformations/aggregation_result_formatter.py
@@ -59,20 +59,22 @@ def create_dataframe_from_aggregation_result_schema(result: DataFrame) -> DataFr
 
 def _add_missing_nullable_columns(result: DataFrame) -> DataFrame:
     if Colname.to_grid_area not in result.columns:
-        result = result.withColumn(Colname.to_grid_area, f.lit(None).cast(StringType))
+        result = result.withColumn(Colname.to_grid_area, f.lit(None).cast(StringType()))
     if Colname.from_grid_area not in result.columns:
-        result = result.withColumn(Colname.from_grid_area, f.lit(None).cast(StringType))
+        result = result.withColumn(
+            Colname.from_grid_area, f.lit(None).cast(StringType())
+        )
     if Colname.balance_responsible_id not in result.columns:
         result = result.withColumn(
-            Colname.balance_responsible_id, f.lit(None).cast(StringType)
+            Colname.balance_responsible_id, f.lit(None).cast(StringType())
         )
     if Colname.energy_supplier_id not in result.columns:
         result = result.withColumn(
-            Colname.energy_supplier_id, f.lit(None).cast(StringType)
+            Colname.energy_supplier_id, f.lit(None).cast(StringType())
         )
     if Colname.settlement_method not in result.columns:
         result = result.withColumn(
-            Colname.settlement_method, f.lit(None).cast(StringType)
+            Colname.settlement_method, f.lit(None).cast(StringType())
         )
     if Colname.position not in result.columns:
         result = result.withColumn(Colname.position, f.lit(None).cast("integer"))

--- a/source/databricks/calculation-engine/package/calculation/energy/transformations/aggregation_result_formatter.py
+++ b/source/databricks/calculation-engine/package/calculation/energy/transformations/aggregation_result_formatter.py
@@ -77,5 +77,5 @@ def _add_missing_nullable_columns(result: DataFrame) -> DataFrame:
             Colname.settlement_method, f.lit(None).cast(StringType())
         )
     if Colname.position not in result.columns:
-        result = result.withColumn(Colname.position, f.lit(None).cast("integer"))
+        result = result.withColumn(Colname.position, f.lit(None).cast(IntegerType()))
     return result

--- a/source/databricks/calculation-engine/package/calculation/energy/transformations/aggregation_result_formatter.py
+++ b/source/databricks/calculation-engine/package/calculation/energy/transformations/aggregation_result_formatter.py
@@ -11,34 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pyspark.sql import DataFrame, SparkSession
 
-from pyspark.sql.functions import lit
+from pyspark.sql import DataFrame
+import pyspark.sql.functions as f
+
+from package.common import assert_schema
 from package.constants import Colname
 from package.calculation.energy.schemas import aggregation_result_schema
 from package.codelists import QuantityQuality
 
 
-def __add_missing_nullable_columns(result: DataFrame) -> DataFrame:
-    if Colname.to_grid_area not in result.columns:
-        result = result.withColumn(Colname.to_grid_area, lit(None))
-    if Colname.from_grid_area not in result.columns:
-        result = result.withColumn(Colname.from_grid_area, lit(None))
-    if Colname.balance_responsible_id not in result.columns:
-        result = result.withColumn(Colname.balance_responsible_id, lit(None))
-    if Colname.energy_supplier_id not in result.columns:
-        result = result.withColumn(Colname.energy_supplier_id, lit(None))
-    if Colname.settlement_method not in result.columns:
-        result = result.withColumn(Colname.settlement_method, lit(None))
-    if Colname.position not in result.columns:
-        result = result.withColumn(Colname.position, lit(None))
-    return result
-
-
 def create_dataframe_from_aggregation_result_schema(result: DataFrame) -> DataFrame:
     "Fit result in a general DataFrame. This is used for all results and missing columns will be null."
 
-    result = __add_missing_nullable_columns(result)
+    result = _add_missing_nullable_columns(result)
     # Replaces None value with zero for sum_quantity
     result = result.na.fill(value=0, subset=[Colname.sum_quantity])
     # Replaces None value with QuantityQuality.MISSING for quality
@@ -46,20 +32,47 @@ def create_dataframe_from_aggregation_result_schema(result: DataFrame) -> DataFr
         value=QuantityQuality.MISSING.value, subset=[Colname.quality]
     )
 
-    # Create data frame from RDD in order to be able to apply the schema
-    return SparkSession.builder.getOrCreate().createDataFrame(
-        result.select(
-            Colname.grid_area,
-            Colname.to_grid_area,
-            Colname.from_grid_area,
-            Colname.balance_responsible_id,
-            Colname.energy_supplier_id,
-            Colname.time_window,
-            Colname.sum_quantity,
-            Colname.quality,
-            Colname.metering_point_type,
-            Colname.settlement_method,
-            Colname.position,
-        ).rdd,
+    assert_schema(
+        result.schema,
         aggregation_result_schema,
+        ignore_nullability=True,
+        ignore_column_order=True,
+        ignore_decimal_scale=True,
+        ignore_decimal_precision=True,
     )
+
+    return result.select(
+        Colname.grid_area,
+        Colname.to_grid_area,
+        Colname.from_grid_area,
+        Colname.balance_responsible_id,
+        Colname.energy_supplier_id,
+        Colname.time_window,
+        Colname.sum_quantity,
+        Colname.quality,
+        Colname.metering_point_type,
+        Colname.settlement_method,
+        Colname.position,
+    )
+
+
+def _add_missing_nullable_columns(result: DataFrame) -> DataFrame:
+    if Colname.to_grid_area not in result.columns:
+        result = result.withColumn(Colname.to_grid_area, f.lit(None).cast("string"))
+    if Colname.from_grid_area not in result.columns:
+        result = result.withColumn(Colname.from_grid_area, f.lit(None).cast("string"))
+    if Colname.balance_responsible_id not in result.columns:
+        result = result.withColumn(
+            Colname.balance_responsible_id, f.lit(None).cast("string")
+        )
+    if Colname.energy_supplier_id not in result.columns:
+        result = result.withColumn(
+            Colname.energy_supplier_id, f.lit(None).cast("string")
+        )
+    if Colname.settlement_method not in result.columns:
+        result = result.withColumn(
+            Colname.settlement_method, f.lit(None).cast("string")
+        )
+    if Colname.position not in result.columns:
+        result = result.withColumn(Colname.position, f.lit(None).cast("integer"))
+    return result

--- a/source/databricks/calculation-engine/package/calculation/energy/transformations/apply_grid_loss_adjustment.py
+++ b/source/databricks/calculation-engine/package/calculation/energy/transformations/apply_grid_loss_adjustment.py
@@ -77,15 +77,11 @@ def _apply_grid_loss_adjustment(
         "inner",
     ).select(
         result_df[Colname.grid_area],
-        result_df[Colname.to_grid_area],
-        result_df[Colname.from_grid_area],
         result_df[Colname.balance_responsible_id],
         result_df[Colname.energy_supplier_id],
         result_df[Colname.time_window],
         result_df[Colname.sum_quantity],
         result_df[Colname.quality],
-        result_df[Colname.metering_point_type],
-        result_df[Colname.settlement_method],
         grid_loss_result_df[Colname.sum_quantity].alias("grid_loss_sum_quantity"),
     )
 

--- a/source/databricks/calculation-engine/package/common/schemas.py
+++ b/source/databricks/calculation-engine/package/common/schemas.py
@@ -55,14 +55,14 @@ def assert_schema(
 
 def _assert_column_nullability(
     actual: StructField, expected: StructField, ignore_nullability: bool
-):
+) -> None:
     if not ignore_nullability and actual.nullable != expected.nullable:
         raise AssertionError(
             f"Expected column name '{expected.name}' to have nullable={expected.dataType}, but got nullable={actual.dataType}"
         )
 
 
-def _assert_column_name(actual, expected):
+def _assert_column_name(actual: StructField, expected: StructField) -> None:
     if actual.name != expected.name:
         raise AssertionError(
             f"Expected column name '{expected.name}', but found '{actual.name}'"
@@ -74,7 +74,7 @@ def _assert_column_datatype(
     expected: StructField,
     ignore_decimal_precision: bool,
     ignore_decimal_scale: bool,
-):
+) -> None:
     if actual.dataType == expected.dataType:
         return
 

--- a/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_flex_consumption.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_flex_consumption.py
@@ -23,9 +23,6 @@ from package.calculation.energy.aggregators import (
     aggregate_flex_consumption_ga_brp,
     aggregate_flex_consumption_ga,
 )
-from package.calculation.energy.transformations import (
-    create_dataframe_from_aggregation_result_schema,
-)
 from pyspark.sql.types import StructType, StringType, DecimalType, TimestampType
 from pyspark.sql import SparkSession, DataFrame
 from typing import Callable
@@ -53,7 +50,7 @@ def agg_flex_consumption_schema() -> StructType:
             .add(Colname.end, TimestampType()),
             False,
         )
-        .add(Colname.sum_quantity, DecimalType(20))
+        .add(Colname.sum_quantity, DecimalType(18, 3))
         .add(Colname.quality, StringType())
         .add(Colname.resolution, StringType())
         .add(Colname.metering_point_type, StringType())
@@ -106,7 +103,7 @@ def test_data_factory(
 def test_flex_consumption_calculation_per_ga_and_es(
     test_data_factory: Callable[..., DataFrame]
 ) -> None:
-    df = create_dataframe_from_aggregation_result_schema(test_data_factory())
+    df = test_data_factory()
     result = aggregate_flex_consumption_ga_es(df).sort(
         Colname.grid_area, Colname.energy_supplier_id, Colname.time_window
     )
@@ -123,7 +120,7 @@ def test_flex_consumption_calculation_per_ga_and_es(
 def test_flex_consumption_calculation_per_ga_and_brp(
     test_data_factory: Callable[..., DataFrame]
 ) -> None:
-    df = create_dataframe_from_aggregation_result_schema(test_data_factory())
+    df = test_data_factory()
     result = aggregate_flex_consumption_ga_brp(df).sort(
         Colname.grid_area, Colname.balance_responsible_id, Colname.time_window
     )
@@ -140,7 +137,7 @@ def test_flex_consumption_calculation_per_ga_and_brp(
 def test_flex_consumption_calculation_per_ga(
     test_data_factory: Callable[..., DataFrame]
 ) -> None:
-    df = create_dataframe_from_aggregation_result_schema(test_data_factory())
+    df = test_data_factory()
     result = aggregate_flex_consumption_ga(df).sort(
         Colname.grid_area, Colname.time_window
     )

--- a/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_flex_consumption_ga_brp_es.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_flex_consumption_ga_brp_es.py
@@ -11,8 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from decimal import Decimal
 from datetime import datetime
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.functions import col, window
+from typing import Callable
+import pytest
+import pandas as pd
+from pandas.core.frame import DataFrame as PandasDataFrame
+
+from package.common import assert_schema
 from package.constants import Colname
 from package.calculation.energy.aggregators import (
     aggregate_flex_consumption_ga_brp_es,
@@ -24,12 +33,6 @@ from package.codelists import (
     QuantityQuality,
 )
 from package.calculation.energy.schemas import aggregation_result_schema
-from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.functions import col, window
-from typing import Callable
-import pytest
-import pandas as pd
-from pandas.core.frame import DataFrame as PandasDataFrame
 
 
 # Default time series data point values
@@ -231,7 +234,13 @@ def test_returns_correct_schema(
     """
     df = time_series_row_factory()
     aggregated_df = aggregate_flex_consumption_ga_brp_es(df)
-    assert aggregated_df.schema == aggregation_result_schema
+    assert_schema(
+        aggregated_df.schema,
+        aggregation_result_schema,
+        ignore_nullability=True,
+        ignore_decimal_precision=True,
+        ignore_decimal_scale=True,
+    )
 
 
 def test_flex_consumption_test_filter_by_domain_is_present(

--- a/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_non_profiled_consumption.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_non_profiled_consumption.py
@@ -23,9 +23,6 @@ from package.calculation.energy.aggregators import (
     aggregate_non_profiled_consumption_ga_brp,
     aggregate_non_profiled_consumption_ga,
 )
-from package.calculation.energy.transformations import (
-    create_dataframe_from_aggregation_result_schema,
-)
 from pyspark.sql.types import StructType, StringType, DecimalType, TimestampType
 import pytest
 import pandas as pd
@@ -139,7 +136,7 @@ def agg_result_factory(
 def test_non_profiled_consumption_summarizes_correctly_on_grid_area_within_same_time_window(
     agg_result_factory: Callable[..., DataFrame],
 ) -> None:
-    consumption = create_dataframe_from_aggregation_result_schema(agg_result_factory())
+    consumption = agg_result_factory()
 
     aggregated_df = aggregate_non_profiled_consumption_ga(consumption).sort(
         Colname.grid_area, Colname.time_window
@@ -159,7 +156,7 @@ def test_non_profiled_consumption_summarizes_correctly_on_grid_area_within_same_
 def test_non_profiled_consumption_summarizes_correctly_on_grid_area_with_different_time_window(
     agg_result_factory: Callable[..., DataFrame],
 ) -> None:
-    consumption = create_dataframe_from_aggregation_result_schema(agg_result_factory())
+    consumption = agg_result_factory()
 
     aggregated_df = aggregate_non_profiled_consumption_ga(consumption).sort(
         Colname.grid_area, Colname.time_window
@@ -179,7 +176,7 @@ def test_non_profiled_consumption_summarizes_correctly_on_grid_area_with_differe
 def test_non_profiled_consumption_summarizes_correctly_on_grid_area_with_same_time_window_as_other_grid_area(
     agg_result_factory: Callable[..., DataFrame],
 ) -> None:
-    consumption = create_dataframe_from_aggregation_result_schema(agg_result_factory())
+    consumption = agg_result_factory()
 
     aggregated_df = aggregate_non_profiled_consumption_ga(consumption).sort(
         Colname.grid_area, Colname.time_window
@@ -199,7 +196,7 @@ def test_non_profiled_consumption_summarizes_correctly_on_grid_area_with_same_ti
 def test_non_profiled_consumption_calculation_per_ga_and_es(
     agg_result_factory: Callable[..., DataFrame]
 ) -> None:
-    consumption = create_dataframe_from_aggregation_result_schema(agg_result_factory())
+    consumption = agg_result_factory()
     aggregated_df = aggregate_non_profiled_consumption_ga_es(consumption).sort(
         Colname.grid_area, Colname.energy_supplier_id, Colname.time_window
     )
@@ -218,9 +215,7 @@ def test_non_profiled_consumption_calculation_per_ga_and_es(
 def test_non_profiled_consumption_calculation_per_ga_and_brp(
     agg_result_factory: Callable[..., DataFrame],
 ) -> None:
-    non_profiled_consumption = create_dataframe_from_aggregation_result_schema(
-        agg_result_factory()
-    )
+    non_profiled_consumption = agg_result_factory()
     aggregated_df = aggregate_non_profiled_consumption_ga_brp(
         non_profiled_consumption
     ).sort(Colname.grid_area, Colname.balance_responsible_id, Colname.time_window)
@@ -237,7 +232,7 @@ def test_non_profiled_consumption_calculation_per_ga_and_brp(
 def test_non_profiled_consumption_calculation_per_ga(
     agg_result_factory: Callable[..., DataFrame]
 ) -> None:
-    consumption = create_dataframe_from_aggregation_result_schema(agg_result_factory())
+    consumption = agg_result_factory()
     aggregated_df = aggregate_non_profiled_consumption_ga(consumption).sort(
         Colname.grid_area, Colname.time_window
     )

--- a/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_non_profiled_consumption_ga_brp_es.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_non_profiled_consumption_ga_brp_es.py
@@ -11,8 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from decimal import Decimal
 from datetime import datetime
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.functions import col, window
+from typing import Callable
+import pytest
+import pandas as pd
+from pandas.core.frame import DataFrame as PandasDataFrame
+
+from package.common import assert_schema
 from package.constants import Colname
 from package.calculation.energy.aggregators import (
     aggregate_non_profiled_consumption_ga_brp_es,
@@ -24,12 +33,6 @@ from package.codelists import (
     QuantityQuality,
 )
 from package.calculation.energy.schemas import aggregation_result_schema
-from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.functions import col, window
-from typing import Callable
-import pytest
-import pandas as pd
-from pandas.core.frame import DataFrame as PandasDataFrame
 
 # Default time series data point values
 default_point_type = MeteringPointType.CONSUMPTION.value
@@ -208,7 +211,13 @@ def test_consumption_supplier_aggregator_returns_correct_schema(
     """
     time_series = time_series_row_factory()
     aggregated_df = aggregate_non_profiled_consumption_ga_brp_es(time_series)
-    assert aggregated_df.schema == aggregation_result_schema
+    assert_schema(
+        aggregated_df.schema,
+        aggregation_result_schema,
+        ignore_nullability=True,
+        ignore_decimal_precision=True,
+        ignore_decimal_scale=True,
+    )
 
 
 def test_consumption_test_filter_by_domain_is_pressent(
@@ -238,4 +247,10 @@ def test_consumption_test_filter_by_domain_is_not_pressent(
 def test_expected_schema(time_series_row_factory: Callable[..., DataFrame]) -> None:
     time_series = time_series_row_factory()
     aggregated_df = aggregate_non_profiled_consumption_ga_brp_es(time_series)
-    assert aggregated_df.schema == aggregation_result_schema
+    assert_schema(
+        aggregated_df.schema,
+        aggregation_result_schema,
+        ignore_nullability=True,
+        ignore_decimal_precision=True,
+        ignore_decimal_scale=True,
+    )

--- a/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_production.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_production.py
@@ -24,9 +24,6 @@ from package.calculation.energy.aggregators import (
     aggregate_production_ga_brp,
     aggregate_production_ga,
 )
-from package.calculation.energy.transformations import (
-    create_dataframe_from_aggregation_result_schema,
-)
 from pyspark.sql.types import StructType, StringType, DecimalType, TimestampType
 import pytest
 import pandas as pd
@@ -107,7 +104,7 @@ def test_data_factory(
 def test_production_calculation_per_ga_and_es(
     test_data_factory: Callable[..., DataFrame]
 ) -> None:
-    df = create_dataframe_from_aggregation_result_schema(test_data_factory())
+    df = test_data_factory()
     result = aggregate_production_ga_es(df).sort(
         Colname.grid_area, Colname.energy_supplier_id
     )
@@ -124,7 +121,7 @@ def test_production_calculation_per_ga_and_es(
 def test_production_calculation_per_ga_and_brp(
     test_data_factory: Callable[..., DataFrame]
 ) -> None:
-    df = create_dataframe_from_aggregation_result_schema(test_data_factory())
+    df = test_data_factory()
     result = aggregate_production_ga_brp(df).sort(
         Colname.grid_area, Colname.balance_responsible_id
     )
@@ -141,9 +138,7 @@ def test_production_calculation_per_ga_and_brp(
 def test_production_calculation_per_ga(
     test_data_factory: Callable[..., DataFrame]
 ) -> None:
-    production_with_system_correction_and_grid_loss = (
-        create_dataframe_from_aggregation_result_schema(test_data_factory())
-    )
+    production_with_system_correction_and_grid_loss = test_data_factory()
     result = aggregate_production_ga(
         production_with_system_correction_and_grid_loss
     ).sort(Colname.grid_area)

--- a/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_production_ga_brp_es.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/aggregators/test_production_ga_brp_es.py
@@ -11,8 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from decimal import Decimal
 from datetime import datetime
+from pyspark.sql import DataFrame, SparkSession
+import pyspark.sql.functions as F
+from pyspark.sql.types import DecimalType
+import pytest
+from typing import Callable, Optional
+from pandas.core.frame import DataFrame as PandasDataFrame
+
+from package.common import assert_schema
 from package.constants import Colname
 from package.calculation.energy.aggregators import (
     aggregate_production_ga_brp_es,
@@ -24,12 +33,6 @@ from package.codelists import (
     QuantityQuality,
 )
 from package.calculation.energy.schemas import aggregation_result_schema
-from pyspark.sql import DataFrame, SparkSession
-import pyspark.sql.functions as F
-from pyspark.sql.types import DecimalType
-import pytest
-from typing import Callable, Optional
-from pandas.core.frame import DataFrame as PandasDataFrame
 
 minimum_quantity = Decimal("0.001")
 grid_area_code_805 = "805"
@@ -240,7 +243,13 @@ def test_production_aggregator_returns_correct_schema(
     """
     time_series = enriched_time_series_factory()
     aggregated_df = aggregate_production_ga_brp_es(time_series)
-    assert aggregated_df.schema == aggregation_result_schema
+    assert_schema(
+        aggregated_df.schema,
+        aggregation_result_schema,
+        ignore_nullability=True,
+        ignore_decimal_precision=True,
+        ignore_decimal_scale=True,
+    )
 
 
 def test_production_test_filter_by_domain_is_pressent(

--- a/source/databricks/calculation-engine/tests/calculation/energy/exchange_aggregators/test_net_exchange_grid_area_aggregation.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/exchange_aggregators/test_net_exchange_grid_area_aggregation.py
@@ -16,6 +16,8 @@ import pytest
 from decimal import Decimal
 import pandas as pd
 from datetime import datetime, timedelta
+
+from package.common import assert_schema
 from package.constants import Colname
 from package.calculation.energy.exchange_aggregators import (
     aggregate_net_exchange_per_ga,
@@ -203,7 +205,13 @@ def test_test_data_has_correct_row_count(enriched_time_series_data_frame):
 
 def test_exchange_aggregator_returns_correct_schema(aggregated_data_frame):
     """Check aggregation schema"""
-    assert aggregated_data_frame.schema == aggregation_result_schema
+    assert_schema(
+        aggregated_data_frame.schema,
+        aggregation_result_schema,
+        ignore_nullability=True,
+        ignore_decimal_precision=True,
+        ignore_decimal_scale=True,
+    )
 
 
 def test_exchange_has_correct_sign(aggregated_data_frame):

--- a/source/databricks/calculation-engine/tests/calculation/energy/exchange_aggregators/test_net_exchange_neighbour.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/exchange_aggregators/test_net_exchange_neighbour.py
@@ -16,14 +16,16 @@ import pytest
 from decimal import Decimal
 import pandas as pd
 from datetime import datetime, timedelta
+from pyspark.sql.types import StructType, StringType, DecimalType, TimestampType
+from pyspark.sql.functions import col, window
+
+from package.common import assert_schema
 from package.constants import Colname
 from package.calculation.energy.exchange_aggregators import (
     aggregate_net_exchange_per_neighbour_ga,
 )
 from package.codelists import MeteringPointType, QuantityQuality
 from package.calculation.energy.schemas import aggregation_result_schema
-from pyspark.sql.types import StructType, StringType, DecimalType, TimestampType
-from pyspark.sql.functions import col, window
 
 
 date_time_formatting_string = "%Y-%m-%dT%H:%M:%S%z"
@@ -222,4 +224,10 @@ def test_expected_schema(single_quarter_test_data):
     df = aggregate_net_exchange_per_neighbour_ga(single_quarter_test_data).orderBy(
         Colname.to_grid_area, Colname.from_grid_area, Colname.time_window
     )
-    assert df.schema == aggregation_result_schema
+    assert_schema(
+        df.schema,
+        aggregation_result_schema,
+        ignore_nullability=True,
+        ignore_decimal_precision=True,
+        ignore_decimal_scale=True,
+    )

--- a/source/databricks/calculation-engine/tests/calculation/energy/grid_loss_calculator/test_grid_loss_calculation.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/grid_loss_calculator/test_grid_loss_calculation.py
@@ -23,9 +23,6 @@ from package.codelists import (
 from package.calculation.energy.grid_loss_calculator import (
     calculate_grid_loss,
 )
-from package.calculation.energy.transformations import (
-    create_dataframe_from_aggregation_result_schema,
-)
 from pyspark.sql.types import StructType, StringType, DecimalType, TimestampType
 from pyspark.sql.functions import col
 from pyspark.sql import DataFrame, SparkSession
@@ -511,18 +508,10 @@ def agg_hourly_production_factory(
 def test_grid_loss_calculation(
     agg_result_factory: Callable[[AggregationMethod], DataFrame]
 ) -> None:
-    net_exchange_per_ga = create_dataframe_from_aggregation_result_schema(
-        agg_result_factory(AggregationMethod.NET_EXCHANGE)
-    )
-    non_profiled_consumption = create_dataframe_from_aggregation_result_schema(
-        agg_result_factory(AggregationMethod.HOURLY_CONSUMPTION)
-    )
-    flex_consumption = create_dataframe_from_aggregation_result_schema(
-        agg_result_factory(AggregationMethod.FLEX_CONSUMPTION)
-    )
-    production = create_dataframe_from_aggregation_result_schema(
-        agg_result_factory(AggregationMethod.PRODUCTION)
-    )
+    net_exchange_per_ga = agg_result_factory(AggregationMethod.NET_EXCHANGE)
+    non_profiled_consumption = agg_result_factory(AggregationMethod.HOURLY_CONSUMPTION)
+    flex_consumption = agg_result_factory(AggregationMethod.FLEX_CONSUMPTION)
+    production = agg_result_factory(AggregationMethod.PRODUCTION)
 
     result = calculate_grid_loss(
         net_exchange_per_ga, non_profiled_consumption, flex_consumption, production

--- a/source/databricks/calculation-engine/tests/calculation/energy/grid_loss_calculator/test_total_consumption.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/grid_loss_calculator/test_total_consumption.py
@@ -21,9 +21,6 @@ from package.codelists import (
 )
 
 from package.calculation.energy.grid_loss_calculator import calculate_total_consumption
-from package.calculation.energy.transformations import (
-    create_dataframe_from_aggregation_result_schema,
-)
 from pyspark.sql.types import StructType, StringType, DecimalType, TimestampType
 import pytest
 import pandas as pd
@@ -289,12 +286,8 @@ def agg_total_net_exchange_factory(spark, net_exchange_schema):
 
 
 def test_grid_area_total_consumption(agg_net_exchange_factory, agg_production_factory):
-    net_exchange_per_ga = create_dataframe_from_aggregation_result_schema(
-        agg_net_exchange_factory()
-    )
-    production_ga = create_dataframe_from_aggregation_result_schema(
-        agg_production_factory()
-    )
+    net_exchange_per_ga = agg_net_exchange_factory()
+    production_ga = agg_production_factory()
     aggregated_df = calculate_total_consumption(net_exchange_per_ga, production_ga)
     aggregated_df_collect = aggregated_df.collect()
     assert (
@@ -346,12 +339,8 @@ def test_aggregated_quality(
     ex_quality,
     expected_quality,
 ):
-    net_exchange_per_ga = create_dataframe_from_aggregation_result_schema(
-        agg_total_net_exchange_factory(ex_quality)
-    )
-    production_ga = create_dataframe_from_aggregation_result_schema(
-        agg_total_production_factory(prod_quality)
-    )
+    net_exchange_per_ga = agg_total_net_exchange_factory(ex_quality)
+    production_ga = agg_total_production_factory(prod_quality)
 
     result_df = calculate_total_consumption(net_exchange_per_ga, production_ga)
 

--- a/source/databricks/calculation-engine/tests/calculation/energy/transformations/test_adjust_flex_consumption.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/transformations/test_adjust_flex_consumption.py
@@ -19,9 +19,6 @@ from package.codelists import (
     QuantityQuality,
 )
 from package.calculation.energy.transformations import adjust_flex_consumption
-from package.calculation.energy.transformations import (
-    create_dataframe_from_aggregation_result_schema,
-)
 from pyspark.sql.functions import col
 from pyspark.sql.types import (
     StructType,
@@ -252,14 +249,8 @@ def test_grid_area_grid_loss_is_added_to_grid_loss_energy_responsible(
     positive_grid_loss_result_row_factory: Callable[..., DataFrame],
     grid_loss_sys_cor_row_factory: Callable[..., DataFrame],
 ) -> None:
-    flex_consumption = create_dataframe_from_aggregation_result_schema(
-        flex_consumption_result_row_factory(supplier="A")
-    )
-
-    positive_grid_loss = create_dataframe_from_aggregation_result_schema(
-        positive_grid_loss_result_row_factory()
-    )
-
+    flex_consumption = flex_consumption_result_row_factory(supplier="A")
+    positive_grid_loss = positive_grid_loss_result_row_factory()
     grid_loss_sys_cor_master_data = grid_loss_sys_cor_row_factory(supplier="A")
 
     result_df = adjust_flex_consumption(
@@ -279,14 +270,8 @@ def test_grid_area_grid_loss_is_not_added_to_non_grid_loss_energy_responsible(
     positive_grid_loss_result_row_factory: Callable[..., DataFrame],
     grid_loss_sys_cor_row_factory: Callable[..., DataFrame],
 ) -> None:
-    flex_consumption = create_dataframe_from_aggregation_result_schema(
-        flex_consumption_result_row_factory(supplier="A")
-    )
-
-    positive_grid_loss = create_dataframe_from_aggregation_result_schema(
-        positive_grid_loss_result_row_factory()
-    )
-
+    flex_consumption = flex_consumption_result_row_factory(supplier="A")
+    positive_grid_loss = positive_grid_loss_result_row_factory()
     grid_loss_sys_cor_master_data = grid_loss_sys_cor_row_factory(supplier="B")
 
     result_df = adjust_flex_consumption(
@@ -310,14 +295,8 @@ def test_result_dataframe_contains_same_number_of_results_with_same_energy_suppl
     fc_row_2 = flex_consumption_result_row_factory(supplier="B")
     fc_row_3 = flex_consumption_result_row_factory(supplier="C")
 
-    flex_consumption = create_dataframe_from_aggregation_result_schema(
-        fc_row_1.union(fc_row_2).union(fc_row_3)
-    )
-
-    positive_grid_loss = create_dataframe_from_aggregation_result_schema(
-        positive_grid_loss_result_row_factory()
-    )
-
+    flex_consumption = fc_row_1.union(fc_row_2).union(fc_row_3)
+    positive_grid_loss = positive_grid_loss_result_row_factory()
     grid_loss_sys_cor_master_data = grid_loss_sys_cor_row_factory(supplier="C")
 
     result_df = adjust_flex_consumption(
@@ -359,9 +338,7 @@ def test_correct_grid_loss_entry_is_used_to_determine_energy_responsible_for_the
         supplier="B", time_window=time_window_3
     )
 
-    flex_consumption = create_dataframe_from_aggregation_result_schema(
-        fc_row_1.union(fc_row_2).union(fc_row_3)
-    )
+    flex_consumption = fc_row_1.union(fc_row_2).union(fc_row_3)
 
     gagl_result_1 = Decimal(1)
     gagl_result_2 = Decimal(2)
@@ -377,9 +354,7 @@ def test_correct_grid_loss_entry_is_used_to_determine_energy_responsible_for_the
         time_window=time_window_3, positive_grid_loss=gagl_result_3
     )
 
-    positive_grid_loss = create_dataframe_from_aggregation_result_schema(
-        gagl_row_1.union(gagl_row_2).union(gagl_row_3)
-    )
+    positive_grid_loss = gagl_row_1.union(gagl_row_2).union(gagl_row_3)
 
     glsc_row_1 = grid_loss_sys_cor_row_factory(
         supplier="A", valid_from=time_window_1["start"], valid_to=time_window_1["end"]
@@ -423,13 +398,8 @@ def test_that_the_correct_metering_point_type_is_put_on_the_result(
     positive_grid_loss_result_row_factory: Callable[..., DataFrame],
     grid_loss_sys_cor_row_factory: Callable[..., DataFrame],
 ) -> None:
-    flex_consumption = create_dataframe_from_aggregation_result_schema(
-        flex_consumption_result_row_factory(supplier="A")
-    )
-
-    positive_grid_loss = create_dataframe_from_aggregation_result_schema(
-        positive_grid_loss_result_row_factory()
-    )
+    flex_consumption = flex_consumption_result_row_factory(supplier="A")
+    positive_grid_loss = positive_grid_loss_result_row_factory()
 
     grid_loss_sys_cor_master_data = grid_loss_sys_cor_row_factory(supplier="A")
 

--- a/source/databricks/calculation-engine/tests/calculation/energy/transformations/test_adjust_production.py
+++ b/source/databricks/calculation-engine/tests/calculation/energy/transformations/test_adjust_production.py
@@ -19,9 +19,6 @@ from package.codelists import (
     QuantityQuality,
 )
 from package.calculation.energy.transformations import adjust_production
-from package.calculation.energy.transformations import (
-    create_dataframe_from_aggregation_result_schema,
-)
 from pyspark.sql.functions import col
 from pyspark.sql.types import (
     StructType,
@@ -252,14 +249,8 @@ def test_grid_area_negative_grid_loss_is_added_to_grid_loss_responsible_energy_s
     negative_grid_loss_result_row_factory: Callable[..., DataFrame],
     sys_cor_row_factory: Callable[..., DataFrame],
 ) -> None:
-    production = create_dataframe_from_aggregation_result_schema(
-        hourly_production_result_row_factory(supplier="A")
-    )
-
-    negative_grid_loss = create_dataframe_from_aggregation_result_schema(
-        negative_grid_loss_result_row_factory()
-    )
-
+    production = hourly_production_result_row_factory(supplier="A")
+    negative_grid_loss = negative_grid_loss_result_row_factory()
     grid_loss_sys_cor_master_data = sys_cor_row_factory(supplier="A")
 
     result_df = adjust_production(
@@ -279,14 +270,8 @@ def test_grid_area_grid_loss_is_not_added_to_non_grid_loss_energy_responsible(
     negative_grid_loss_result_row_factory: Callable[..., DataFrame],
     sys_cor_row_factory: Callable[..., DataFrame],
 ) -> None:
-    production = create_dataframe_from_aggregation_result_schema(
-        hourly_production_result_row_factory(supplier="A")
-    )
-
-    negative_grid_loss = create_dataframe_from_aggregation_result_schema(
-        negative_grid_loss_result_row_factory()
-    )
-
+    production = hourly_production_result_row_factory(supplier="A")
+    negative_grid_loss = negative_grid_loss_result_row_factory()
     grid_loss_sys_cor_master_data = sys_cor_row_factory(supplier="B")
 
     result_df = adjust_production(
@@ -310,14 +295,8 @@ def test_result_dataframe_contains_same_number_of_results_with_same_energy_suppl
     hp_row_2 = hourly_production_result_row_factory(supplier="B")
     hp_row_3 = hourly_production_result_row_factory(supplier="C")
 
-    production = create_dataframe_from_aggregation_result_schema(
-        hp_row_1.union(hp_row_2).union(hp_row_3)
-    )
-
-    negative_grid_loss = create_dataframe_from_aggregation_result_schema(
-        negative_grid_loss_result_row_factory()
-    )
-
+    production = hp_row_1.union(hp_row_2).union(hp_row_3)
+    negative_grid_loss = negative_grid_loss_result_row_factory()
     grid_loss_sys_cor_master_data = sys_cor_row_factory(supplier="C")
 
     result_df = adjust_production(
@@ -359,9 +338,7 @@ def test_correct_negative_grid_loss_entry_is_used_to_determine_energy_responsibl
         supplier="B", time_window=time_window_3
     )
 
-    production = create_dataframe_from_aggregation_result_schema(
-        hp_row_1.union(hp_row_2).union(hp_row_3)
-    )
+    production = hp_row_1.union(hp_row_2).union(hp_row_3)
 
     gasc_result_1 = Decimal(1)
     gasc_result_2 = Decimal(2)
@@ -377,9 +354,7 @@ def test_correct_negative_grid_loss_entry_is_used_to_determine_energy_responsibl
         time_window=time_window_3, negative_grid_loss=gasc_result_3
     )
 
-    negative_grid_loss = create_dataframe_from_aggregation_result_schema(
-        gasc_row_1.union(gasc_row_2).union(gasc_row_3)
-    )
+    negative_grid_loss = gasc_row_1.union(gasc_row_2).union(gasc_row_3)
 
     sc_row_1 = sys_cor_row_factory(
         supplier="A", valid_from=time_window_1["start"], valid_to=time_window_1["end"]
@@ -423,14 +398,8 @@ def test_that_the_correct_metering_point_type_is_put_on_the_result(
     negative_grid_loss_result_row_factory: Callable[..., DataFrame],
     sys_cor_row_factory: Callable[..., DataFrame],
 ) -> None:
-    production = create_dataframe_from_aggregation_result_schema(
-        hourly_production_result_row_factory(supplier="A")
-    )
-
-    negative_grid_loss = create_dataframe_from_aggregation_result_schema(
-        negative_grid_loss_result_row_factory()
-    )
-
+    production = hourly_production_result_row_factory(supplier="A")
+    negative_grid_loss = negative_grid_loss_result_row_factory()
     grid_loss_sys_cor_master_data = sys_cor_row_factory(supplier="A")
 
     result_df = adjust_production(

--- a/source/databricks/calculation-engine/tests/common/test_schemas.py
+++ b/source/databricks/calculation-engine/tests/common/test_schemas.py
@@ -42,6 +42,12 @@ schema_with_other_column_order_and_nullability = t.StructType(
         t.StructField("foo", t.StringType(), True),
     ]
 )
+schema_with_other_datatype = t.StructType(
+    [
+        t.StructField("foo", t.StringType(), False),
+        t.StructField("bar", t.DecimalType(), False),
+    ]
+)
 
 
 @pytest.mark.parametrize(
@@ -86,10 +92,78 @@ def test__assert_schema__accepts_matching_schema(
     ],
 )
 def test__assert_schema__when_schema_does_not_match__raises(
-    actual: t.StringType,
+    actual: t.StructType,
     expected: t.StructType,
     ignore_column_order: bool,
     ignore_nullability: bool,
 ) -> None:
     with pytest.raises(AssertionError):
         assert_schema(actual, expected)
+
+
+def test__assert_schema__when_lenient_and_other_datatype__raises_assertion_error() -> (
+    None
+):
+    """Lenient refers to being as loose as possible in the check."""
+    with pytest.raises(AssertionError):
+        assert_schema(
+            any_schema,
+            schema_with_other_datatype,
+            ignore_nullability=True,
+            ignore_column_order=True,
+            ignore_decimal_scale=True,
+            ignore_decimal_precision=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "expected_decimal, ignore_precision, ignore_scale",
+    [
+        (t.DecimalType(17, 2), False, False),
+        (t.DecimalType(17, 3), False, False),
+        (t.DecimalType(18, 2), False, False),
+        (t.DecimalType(17, 3), False, True),
+        (t.DecimalType(18, 2), True, False),
+    ],
+)
+def test__assert_schema__when_invalid_decimal_type__raises_assertion_error(
+    expected_decimal: t.DecimalType,
+    ignore_precision: bool,
+    ignore_scale: bool,
+) -> None:
+    actual = t.StructType([t.StructField("d", t.DecimalType(18, 3), False)])
+    expected = t.StructType([t.StructField("d", expected_decimal, False)])
+
+    with pytest.raises(AssertionError):
+        assert_schema(
+            actual,
+            expected,
+            ignore_decimal_scale=ignore_scale,
+            ignore_decimal_precision=ignore_precision,
+        )
+
+
+@pytest.mark.parametrize(
+    "expected_decimal, ignore_precision, ignore_scale",
+    [
+        (t.DecimalType(17, 2), True, True),
+        (t.DecimalType(18, 3), False, False),
+        (t.DecimalType(17, 3), True, False),
+        (t.DecimalType(18, 2), False, True),
+    ],
+)
+def test__assert_schema__when_decimal_type_should_be_accepted__does_not_raise(
+    expected_decimal: t.DecimalType,
+    ignore_precision: bool,
+    ignore_scale: bool,
+) -> None:
+    actual = t.StructType([t.StructField("d", t.DecimalType(18, 3), False)])
+    expected = t.StructType([t.StructField("d", expected_decimal, False)])
+
+    # Act and assert (implicitly asserts that no error is raised)
+    assert_schema(
+        actual,
+        expected,
+        ignore_decimal_scale=ignore_scale,
+        ignore_decimal_precision=ignore_precision,
+    )


### PR DESCRIPTION
- Stop using production function `create_dataframe_from_aggregation_result_schema` to generate test data.
- Improve schema checking.

The final goal in future PRs is to get rid of `create_dataframe_from_aggregation_result_schema`.