### PR TITLE
chore: Remove unused dependencies

### DIFF
--- a/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
@@ -29,9 +29,6 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.3.5" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.3.5" />
-    <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
-    <PackageReference Include="Energinet.DataHub.MeteringPoints.IntegrationEvents" Version="1.0.4" />
-    <PackageReference Include="Energinet.DataHub.MessageHub.Core" Version="3.4.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />


### PR DESCRIPTION
This PR removes a few unused dependencies in `WebApi.IntegrationTests`. They probably originate from a copy of IntegrationTests in the archived Charges domain ;-)