### PR TITLE
feat: Balance Responsible validation on Aggregarted Time Serie Request

### DIFF
--- a/source/dotnet/wholesale-api/Edi.UnitTests/Builders/AggregatedTimeSeriesRequestBuilder.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Builders/AggregatedTimeSeriesRequestBuilder.cs
@@ -29,6 +29,7 @@ public class AggregatedTimeSeriesRequestBuilder
     private string _requestedByActorRoleId;
     private string _requestedByActorId;
     private string? _settlementMethod;
+    private string? _balanceResponsibleId;
 
     private AggregatedTimeSeriesRequestBuilder()
     {
@@ -62,6 +63,9 @@ public class AggregatedTimeSeriesRequestBuilder
         if (_energySupplierId != null)
             request.EnergySupplierId = _energySupplierId;
 
+        if (_balanceResponsibleId != null)
+            request.BalanceResponsibleId = _balanceResponsibleId;
+
         if (_settlementMethod != null)
             request.SettlementMethod = _settlementMethod;
 
@@ -86,11 +90,15 @@ public class AggregatedTimeSeriesRequestBuilder
         return this;
     }
 
-    public AggregatedTimeSeriesRequestBuilder WithRequestedByActor(string actorRoleId, string actorId)
+    public AggregatedTimeSeriesRequestBuilder WithRequestedByActor(string actorId)
     {
-        _requestedByActorRoleId = actorRoleId;
         _requestedByActorId = actorId;
+        return this;
+    }
 
+    public AggregatedTimeSeriesRequestBuilder WithRequestedByActorRole(string actorRoleCode)
+    {
+        _requestedByActorRoleId = actorRoleCode;
         return this;
     }
 
@@ -104,6 +112,12 @@ public class AggregatedTimeSeriesRequestBuilder
     {
         _settlementMethod = settlementMethod;
 
+        return this;
+    }
+
+    public AggregatedTimeSeriesRequestBuilder WithBalanceResponsibleId(string? balanceResponsibleId)
+    {
+        _balanceResponsibleId = balanceResponsibleId;
         return this;
     }
 }

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/AggregatedTimeSeriesRequestValidatorTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/AggregatedTimeSeriesRequestValidatorTests.cs
@@ -14,6 +14,7 @@
 
 using Energinet.DataHub.Edi.Requests;
 using Energinet.DataHub.Wholesale.Edi.Models;
+using Energinet.DataHub.Wholesale.EDI.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.EDI.Validation;
 using Energinet.DataHub.Wholesale.EDI.Validation.AggregatedTimeSerie;
 using Energinet.DataHub.Wholesale.EDI.Validation.AggregatedTimeSerie.Rules;
@@ -31,6 +32,7 @@ public class AggregatedTimeSeriesRequestValidatorTests
     private static readonly PeriodValidationRule _periodValidator = new(DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!, SystemClock.Instance);
     private static readonly MeteringPointTypeValidationRule _meteringPointTypeValidationRule = new();
     private static readonly EnergySupplierFieldValidationRule _energySupplierFieldValidationRule = new();
+    private static readonly BalanceResponsibleValidationRule _balanceResponsibleValidationRule = new();
     private static readonly SettlementMethodValidationRule _settlementMethodValidationRule = new();
     private readonly IValidator<AggregatedTimeSeriesRequest> _sut = new AggregatedTimeSeriesRequestValidator(
         new IValidationRule<AggregatedTimeSeriesRequest>[]
@@ -39,6 +41,7 @@ public class AggregatedTimeSeriesRequestValidatorTests
             _energySupplierFieldValidationRule,
             _meteringPointTypeValidationRule,
             _settlementMethodValidationRule,
+            _balanceResponsibleValidationRule,
         });
 
     [Fact]

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
@@ -25,6 +25,8 @@ public class BalanceResponsibleValidatorTest
     private const string BalanceResponsibleRole = "DDK";
     private const string ValidGlnNumber = "qwertyuiopasd"; // Must be 13 characters to be a valid GLN
     private const string ValidEicNumber = "qwertyuiopasdfgh"; // Must be 16 characters to be a valid GLN
+    private static readonly ValidationError _invalidBalanceResponsible = new("Feltet BalanceResponsibleParty skal være udfyldt med et valid GLN/EIC når en balanceansvarlig anmoder om data / BalanceResponsibleParty must be submitted with a valid GLN/EIC when a balance responsible requests data", "E18");
+    private static readonly ValidationError _mismatchedBalanceResponsibleInHeaderAndMessage = new("BalanceResponsibleParty i besked stemmer ikke overenes med balanceansvarlig anmoder i header / BalanceResponsibleParty in message does not correspond with balance responsible in header", "E18");
 
     private readonly BalanceResponsibleValidationRule _sut = new();
 
@@ -81,8 +83,8 @@ public class BalanceResponsibleValidatorTest
         errors.Should().ContainSingle();
 
         var error = errors.First();
-        error.Message.Should().Be(ValidationError.InvalidBalanceResponsible.Message);
-        error.ErrorCode.Should().Be(ValidationError.InvalidBalanceResponsible.ErrorCode);
+        error.Message.Should().Be(_invalidBalanceResponsible.Message);
+        error.ErrorCode.Should().Be(_invalidBalanceResponsible.ErrorCode);
     }
 
     [Fact]
@@ -103,8 +105,8 @@ public class BalanceResponsibleValidatorTest
         errors.Should().ContainSingle();
 
         var error = errors.First();
-        error.Message.Should().Be(ValidationError.MismatchedBalanceResponsibleInHeaderAndMessage.Message);
-        error.ErrorCode.Should().Be(ValidationError.MismatchedBalanceResponsibleInHeaderAndMessage.ErrorCode);
+        error.Message.Should().Be(_mismatchedBalanceResponsibleInHeaderAndMessage.Message);
+        error.ErrorCode.Should().Be(_mismatchedBalanceResponsibleInHeaderAndMessage.ErrorCode);
     }
 
     [Fact]
@@ -125,12 +127,12 @@ public class BalanceResponsibleValidatorTest
         errors.Should().ContainSingle();
 
         var error = errors.First();
-        error.Message.Should().Be(ValidationError.InvalidBalanceResponsible.Message);
-        error.ErrorCode.Should().Be(ValidationError.InvalidBalanceResponsible.ErrorCode);
+        error.Message.Should().Be(_invalidBalanceResponsible.Message);
+        error.ErrorCode.Should().Be(_invalidBalanceResponsible.ErrorCode);
     }
 
     [Fact]
-    public void Validate_WhenRequesterIsNotBalanceResponsibleAndMissingBalanceResponsibleField_NoValidationError()
+    public void Validate_WhenRequesterIsNotBalanceResponsibleAndMissingBalanceResponsibleField_ReturnsNoValidationError()
     {
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
@@ -67,7 +67,7 @@ public class BalanceResponsibleValidatorTest
     }
 
     [Fact]
-    public void Validate_WhenRequesterIsBalanceResponsibleAndMissingBalanceResponsibleField_ReturnsExceptedValidationError()
+    public void Validate_WhenRequesterIsBalanceResponsibleAndMissingBalanceResponsibleField_ReturnsExpectedValidationError()
     {
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder
@@ -88,7 +88,7 @@ public class BalanceResponsibleValidatorTest
     }
 
     [Fact]
-    public void Validate_WhenRequesterIsBalanceResponsibleAndBalanceResponsibleFieldNotEqualRequestedById_ReturnsExceptedValidationError()
+    public void Validate_WhenRequesterIsBalanceResponsibleAndBalanceResponsibleFieldNotEqualRequestedById_ReturnsExpectedValidationError()
     {
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder
@@ -110,7 +110,7 @@ public class BalanceResponsibleValidatorTest
     }
 
     [Fact]
-    public void Validate_WhenRequesterIsBalanceResponsibleAndInvalidBalanceResponsibleField_ReturnsExceptedValidationError()
+    public void Validate_WhenRequesterIsBalanceResponsibleAndInvalidBalanceResponsibleField_ReturnsExpectedValidationError()
     {
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
@@ -103,8 +103,8 @@ public class BalanceResponsibleValidatorTest
         errors.Should().ContainSingle();
 
         var error = errors.First();
-        error.Message.Should().Be(ValidationError.InvalidBalanceResponsible.Message);
-        error.ErrorCode.Should().Be(ValidationError.InvalidBalanceResponsible.ErrorCode);
+        error.Message.Should().Be(ValidationError.MismatchedBalanceResponsibleInHeaderAndMessage.Message);
+        error.ErrorCode.Should().Be(ValidationError.MismatchedBalanceResponsibleInHeaderAndMessage.ErrorCode);
     }
 
     [Fact]

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
@@ -1,0 +1,147 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Wholesale.EDI.UnitTests.Builders;
+using Energinet.DataHub.Wholesale.EDI.Validation;
+using Energinet.DataHub.Wholesale.EDI.Validation.AggregatedTimeSerie.Rules;
+using FluentAssertions;
+using Xunit;
+
+namespace Energinet.DataHub.Wholesale.EDI.UnitTests.Validators;
+
+public class BalanceResponsibleValidatorTest
+{
+    private const string BalanceResponsibleRole = "DDK";
+    private const string ValidGlnNumber = "qwertyuiopasd"; // Must be 13 characters to be a valid GLN
+    private const string ValidEicNumber = "qwertyuiopasdfgh"; // Must be 16 characters to be a valid GLN
+
+    private readonly BalanceResponsibleValidationRule _sut = new();
+
+    [Fact]
+    public void Validate_WhenRequesterIsBalanceResponsibleAndBalanceResponsibleFieldIsValidGlnNumber_ReturnsNoValidationErrors()
+    {
+        // Arrange
+        var message = AggregatedTimeSeriesRequestBuilder
+            .AggregatedTimeSeriesRequest()
+            .WithRequestedByActor(ValidGlnNumber)
+            .WithRequestedByActorRole(BalanceResponsibleRole)
+            .WithBalanceResponsibleId(ValidGlnNumber)
+            .Build();
+
+        // Act
+        var errors = _sut.Validate(message);
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_WhenRequesterIsBalanceResponsibleAndBalanceResponsibleFieldIsValidEicNumber_ReturnsNoValidationErrors()
+    {
+        // Arrange
+        var message = AggregatedTimeSeriesRequestBuilder
+            .AggregatedTimeSeriesRequest()
+            .WithRequestedByActor(ValidEicNumber)
+            .WithRequestedByActorRole(BalanceResponsibleRole)
+            .WithBalanceResponsibleId(ValidEicNumber)
+            .Build();
+
+        // Act
+        var errors = _sut.Validate(message);
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_WhenRequesterIsBalanceResponsibleAndMissingBalanceResponsibleField_ReturnsExceptedValidationError()
+    {
+        // Arrange
+        var message = AggregatedTimeSeriesRequestBuilder
+            .AggregatedTimeSeriesRequest()
+            .WithRequestedByActor(ValidGlnNumber)
+            .WithRequestedByActorRole(BalanceResponsibleRole)
+            .Build();
+
+        // Act
+        var errors = _sut.Validate(message);
+
+        // Assert
+        errors.Should().ContainSingle();
+
+        var error = errors.First();
+        error.Message.Should().Be(ValidationError.InvalidBalanceResponsible.Message);
+        error.ErrorCode.Should().Be(ValidationError.InvalidBalanceResponsible.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_WhenRequesterIsBalanceResponsibleAndBalanceResponsibleFieldNotEqualRequestedById_ReturnsExceptedValidationError()
+    {
+        // Arrange
+        var message = AggregatedTimeSeriesRequestBuilder
+            .AggregatedTimeSeriesRequest()
+            .WithRequestedByActor(ValidGlnNumber)
+            .WithRequestedByActorRole(BalanceResponsibleRole)
+            .WithBalanceResponsibleId(ValidEicNumber)
+            .Build();
+
+        // Act
+        var errors = _sut.Validate(message);
+
+        // Assert
+        errors.Should().ContainSingle();
+
+        var error = errors.First();
+        error.Message.Should().Be(ValidationError.InvalidBalanceResponsible.Message);
+        error.ErrorCode.Should().Be(ValidationError.InvalidBalanceResponsible.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_WhenRequesterIsBalanceResponsibleAndInvalidBalanceResponsibleField_ReturnsExceptedValidationError()
+    {
+        // Arrange
+        var message = AggregatedTimeSeriesRequestBuilder
+            .AggregatedTimeSeriesRequest()
+            .WithRequestedByActor(ValidGlnNumber)
+            .WithRequestedByActorRole(BalanceResponsibleRole)
+            .WithBalanceResponsibleId("invalid-format")
+            .Build();
+
+        // Act
+        var errors = _sut.Validate(message);
+
+        // Assert
+        errors.Should().ContainSingle();
+
+        var error = errors.First();
+        error.Message.Should().Be(ValidationError.InvalidBalanceResponsible.Message);
+        error.ErrorCode.Should().Be(ValidationError.InvalidBalanceResponsible.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_WhenRequesterIsNotBalanceResponsibleAndMissingBalanceResponsibleField_NoValidationError()
+    {
+        // Arrange
+        var message = AggregatedTimeSeriesRequestBuilder
+            .AggregatedTimeSeriesRequest()
+            .WithRequestedByActor(ValidGlnNumber)
+            .Build();
+
+        // Act
+        var errors = _sut.Validate(message);
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+}

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/EnergySupplierValidatorTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/EnergySupplierValidatorTest.cs
@@ -140,7 +140,8 @@ public class EnergySupplierValidatorTest
     {
         var message = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
-            .WithRequestedByActor(isRequestedByEnergySupplier ? EnergySupplierActorRole : "unknown-role-id", requestedById)
+            .WithRequestedByActor(requestedById)
+            .WithRequestedByActorRole(isRequestedByEnergySupplier ? EnergySupplierActorRole : "unknown-role-id")
             .WithEnergySupplierId(energySupplierId)
             .Build();
 

--- a/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequest.proto
+++ b/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequest.proto
@@ -30,6 +30,7 @@ message AggregatedTimeSeriesRequest {
   optional string energy_supplier_id = 8;
   string requested_by_actor_id = 9;
   string requested_by_actor_role = 10;
+  optional string balance_responsible_id = 11;
 }
 
 message Period {

--- a/source/dotnet/wholesale-api/Edi/EdiRegistration.cs
+++ b/source/dotnet/wholesale-api/Edi/EdiRegistration.cs
@@ -41,5 +41,6 @@ public static class EdiRegistration
         serviceCollection.AddSingleton<IValidationRule<AggregatedTimeSeriesRequest>, PeriodValidationRule>();
         serviceCollection.AddSingleton<IValidationRule<AggregatedTimeSeriesRequest>, MeteringPointTypeValidationRule>();
         serviceCollection.AddSingleton<IValidationRule<AggregatedTimeSeriesRequest>, EnergySupplierFieldValidationRule>();
+        serviceCollection.AddSingleton<IValidationRule<AggregatedTimeSeriesRequest>, BalanceResponsibleValidationRule>();
     }
 }

--- a/source/dotnet/wholesale-api/Edi/Validation/ActorNumberValidationHelper.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/ActorNumberValidationHelper.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.Wholesale.EDI.Validation;
+
+public static class ActorNumberValidationHelper
+{
+    public static bool IsValidGlnNumber(string actorNumber)
+    {
+        return actorNumber.Length == 13;
+    }
+
+    public static bool IsValidEicNumber(string actorNumber)
+    {
+        return actorNumber.Length == 16;
+    }
+}

--- a/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSerie/Rules/BalanceResponsibleValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSerie/Rules/BalanceResponsibleValidationRule.cs
@@ -19,19 +19,21 @@ namespace Energinet.DataHub.Wholesale.EDI.Validation.AggregatedTimeSerie.Rules;
 public class BalanceResponsibleValidationRule : IValidationRule<AggregatedTimeSeriesRequest>
 {
     private const string BalanceResponsibleRole = "DDK";
+    private static readonly ValidationError _invalidBalanceResponsible = new("Feltet BalanceResponsibleParty skal være udfyldt med et valid GLN/EIC når en balanceansvarlig anmoder om data / BalanceResponsibleParty must be submitted with a valid GLN/EIC when a balance responsible requests data", "E18");
+    private static readonly ValidationError _mismatchedBalanceResponsibleInHeaderAndMessage = new("BalanceResponsibleParty i besked stemmer ikke overenes med balanceansvarlig anmoder i header / BalanceResponsibleParty in message does not correspond with balance responsible in header", "E18");
 
     public IList<ValidationError> Validate(AggregatedTimeSeriesRequest subject)
     {
         if (subject.RequestedByActorRole == BalanceResponsibleRole)
         {
             if (string.IsNullOrWhiteSpace(subject.BalanceResponsibleId))
-                return new List<ValidationError>() { ValidationError.InvalidBalanceResponsible };
+                return new List<ValidationError>() { _invalidBalanceResponsible };
 
             if (!IsValidActorRoleFormat(subject.BalanceResponsibleId))
-                return new List<ValidationError>() { ValidationError.InvalidBalanceResponsible };
+                return new List<ValidationError>() { _invalidBalanceResponsible };
 
             if (!subject.RequestedByActorId.Equals(subject.BalanceResponsibleId, StringComparison.OrdinalIgnoreCase))
-                return new List<ValidationError>() { ValidationError.MismatchedBalanceResponsibleInHeaderAndMessage };
+                return new List<ValidationError>() { _mismatchedBalanceResponsibleInHeaderAndMessage };
         }
 
         return new List<ValidationError>();

--- a/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSerie/Rules/BalanceResponsibleValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSerie/Rules/BalanceResponsibleValidationRule.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Edi.Requests;
+
+namespace Energinet.DataHub.Wholesale.EDI.Validation.AggregatedTimeSerie.Rules;
+
+public class BalanceResponsibleValidationRule : IValidationRule<AggregatedTimeSeriesRequest>
+{
+    private const string BalanceResponsibleRole = "DDK";
+    private static readonly IList<ValidationError> _validationError = new List<ValidationError>
+    {
+        ValidationError.InvalidBalanceResponsible,
+    };
+
+    public IList<ValidationError> Validate(AggregatedTimeSeriesRequest subject)
+    {
+        if (subject.RequestedByActorRole == BalanceResponsibleRole)
+        {
+            if (string.IsNullOrWhiteSpace(subject.BalanceResponsibleId))
+                return _validationError;
+
+            if (!IsValidActorRoleFormat(subject.BalanceResponsibleId))
+                return _validationError;
+
+            if (!subject.RequestedByActorId.Equals(subject.BalanceResponsibleId, StringComparison.OrdinalIgnoreCase))
+                return _validationError;
+        }
+
+        return new List<ValidationError>();
+    }
+
+    private static bool IsValidActorRoleFormat(string energySupplierId)
+    {
+        var isValidGlnNumber = energySupplierId.Length == 13;
+        var isValidEicNumber = energySupplierId.Length == 16;
+
+        return isValidGlnNumber || isValidEicNumber;
+    }
+}

--- a/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSerie/Rules/BalanceResponsibleValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSerie/Rules/BalanceResponsibleValidationRule.cs
@@ -19,23 +19,19 @@ namespace Energinet.DataHub.Wholesale.EDI.Validation.AggregatedTimeSerie.Rules;
 public class BalanceResponsibleValidationRule : IValidationRule<AggregatedTimeSeriesRequest>
 {
     private const string BalanceResponsibleRole = "DDK";
-    private static readonly IList<ValidationError> _validationError = new List<ValidationError>
-    {
-        ValidationError.InvalidBalanceResponsible,
-    };
 
     public IList<ValidationError> Validate(AggregatedTimeSeriesRequest subject)
     {
         if (subject.RequestedByActorRole == BalanceResponsibleRole)
         {
             if (string.IsNullOrWhiteSpace(subject.BalanceResponsibleId))
-                return _validationError;
+                return new List<ValidationError>() { ValidationError.InvalidBalanceResponsible };
 
             if (!IsValidActorRoleFormat(subject.BalanceResponsibleId))
-                return _validationError;
+                return new List<ValidationError>() { ValidationError.InvalidBalanceResponsible };
 
             if (!subject.RequestedByActorId.Equals(subject.BalanceResponsibleId, StringComparison.OrdinalIgnoreCase))
-                return _validationError;
+                return new List<ValidationError>() { ValidationError.MismatchedBalanceResponsibleInHeaderAndMessage };
         }
 
         return new List<ValidationError>();

--- a/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSerie/Rules/BalanceResponsibleValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSerie/Rules/BalanceResponsibleValidationRule.cs
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Edi.Requests;
+using Energinet.DataHub.Wholesale.EDI.Models;
+using AggregatedTimeSeriesRequest = Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest;
 
 namespace Energinet.DataHub.Wholesale.EDI.Validation.AggregatedTimeSerie.Rules;
 
 public class BalanceResponsibleValidationRule : IValidationRule<AggregatedTimeSeriesRequest>
 {
-    private const string BalanceResponsibleRole = "DDK";
     private static readonly ValidationError _invalidBalanceResponsible = new("Feltet BalanceResponsibleParty skal være udfyldt med et valid GLN/EIC når en balanceansvarlig anmoder om data / BalanceResponsibleParty must be submitted with a valid GLN/EIC when a balance responsible requests data", "E18");
     private static readonly ValidationError _mismatchedBalanceResponsibleInHeaderAndMessage = new("BalanceResponsibleParty i besked stemmer ikke overenes med balanceansvarlig anmoder i header / BalanceResponsibleParty in message does not correspond with balance responsible in header", "E18");
 
     public IList<ValidationError> Validate(AggregatedTimeSeriesRequest subject)
     {
-        if (subject.RequestedByActorRole == BalanceResponsibleRole)
+        if (subject.RequestedByActorRole == ActorRoleCode.BalanceResponsibleParty)
         {
             if (string.IsNullOrWhiteSpace(subject.BalanceResponsibleId))
                 return new List<ValidationError>() { _invalidBalanceResponsible };

--- a/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSerie/Rules/EnergySupplierValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSerie/Rules/EnergySupplierValidationRule.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.ComponentModel;
 using Energinet.DataHub.Wholesale.EDI.Models;
 using AggregatedTimeSeriesRequest = Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest;
 
@@ -42,10 +41,7 @@ public class EnergySupplierValidationRule : IValidationRule<AggregatedTimeSeries
 
     private static bool IsValidEnergySupplierIdFormat(string energySupplierId)
     {
-        var isValidGlnNumber = energySupplierId.Length == 13;
-        var isValidEicNumber = energySupplierId.Length == 16;
-
-        return isValidGlnNumber || isValidEicNumber;
+        return ActorNumberValidationHelper.IsValidGlnNumber(energySupplierId) || ActorNumberValidationHelper.IsValidEicNumber(energySupplierId);
     }
 
     private static bool RequestedByIdEqualsEnergySupplier(string requestedByActorId, string energySupplierId)

--- a/source/dotnet/wholesale-api/Edi/Validation/ValidationError.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/ValidationError.cs
@@ -26,10 +26,8 @@ public sealed class ValidationError
     public static readonly ValidationError InvalidMeteringPointType = new("Metering point type skal være en af følgende: {PropertyName} / Metering point type has to be one of the following: {PropertyName}", "D18");
     public static readonly ValidationError InvalidEnergySupplierField = new("Feltet EnergySupplier skal være udfyldt med et valid GLN/EIC nummer når en elleverandør anmoder om data / EnergySupplier must be submitted with a valid GLN/EIC number when an energy supplier requests data", "E16");
     public static readonly ValidationError InvalidSettlementMethod = new("SettlementMethod kan kun benyttes i kombination med E17 og skal være enten D01 og E02 / SettlementMethod can only be used in combination with E17 and must be either D01 or E02", "D15");
-    public static readonly ValidationError InvalidBalanceResponsible = new("Feltet BalanceResponsibleParty skal være udfyldt med et valid GLN/EIC når en balanceansvarlig anmoder om data / BalanceResponsibleParty must be submitted with a valid GLN/EIC when a balance responsible requests data", "E18");
-    public static readonly ValidationError MismatchedBalanceResponsibleInHeaderAndMessage = new("BalanceResponsibleParty i besked stemmer ikke overenes med balanceansvarlig anmoder i header / BalanceResponsibleParty in message does not correspond with balance responsible in header", "E18");
 
-    private ValidationError(string message, string errorCode)
+    public ValidationError(string message, string errorCode)
     {
         Message = message;
         ErrorCode = errorCode;

--- a/source/dotnet/wholesale-api/Edi/Validation/ValidationError.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/ValidationError.cs
@@ -26,6 +26,7 @@ public sealed class ValidationError
     public static readonly ValidationError InvalidMeteringPointType = new("Metering point type skal være en af følgende: {PropertyName} / Metering point type has to be one of the following: {PropertyName}", "D18");
     public static readonly ValidationError InvalidEnergySupplierField = new("Feltet EnergySupplier skal være udfyldt med et valid GLN/EIC nummer når en elleverandør anmoder om data / EnergySupplier must be submitted with a valid GLN/EIC number when an energy supplier requests data", "E16");
     public static readonly ValidationError InvalidSettlementMethod = new("SettlementMethod kan kun benyttes i kombination med E17 og skal være enten D01 og E02 / SettlementMethod can only be used in combination with E17 and must be either D01 or E02", "D15");
+    public static readonly ValidationError InvalidBalanceResponsible = new("Feltet BalanceResponsibleParty skal være udfyldt med et valid GLN/EIC når en balanceansvarlig anmoder om data / BalanceResponsibleParty must be submitted with a valid GLN/EIC when a balance responsible requests data", "E18");
 
     private ValidationError(string message, string errorCode)
     {

--- a/source/dotnet/wholesale-api/Edi/Validation/ValidationError.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/ValidationError.cs
@@ -27,6 +27,7 @@ public sealed class ValidationError
     public static readonly ValidationError InvalidEnergySupplierField = new("Feltet EnergySupplier skal være udfyldt med et valid GLN/EIC nummer når en elleverandør anmoder om data / EnergySupplier must be submitted with a valid GLN/EIC number when an energy supplier requests data", "E16");
     public static readonly ValidationError InvalidSettlementMethod = new("SettlementMethod kan kun benyttes i kombination med E17 og skal være enten D01 og E02 / SettlementMethod can only be used in combination with E17 and must be either D01 or E02", "D15");
     public static readonly ValidationError InvalidBalanceResponsible = new("Feltet BalanceResponsibleParty skal være udfyldt med et valid GLN/EIC når en balanceansvarlig anmoder om data / BalanceResponsibleParty must be submitted with a valid GLN/EIC when a balance responsible requests data", "E18");
+    public static readonly ValidationError MismatchedBalanceResponsibleInHeaderAndMessage = new("BalanceResponsibleParty i besked stemmer ikke overenes med balanceansvarlig anmoder i header / BalanceResponsibleParty in message does not correspond with balance responsible in header", "E18");
 
     private ValidationError(string message, string errorCode)
     {


### PR DESCRIPTION
Add balance responsible validation to AggregatedTimeSeriesRequest, which validates that the balance responsible field is correct, if the request is sent by an balance responsible

Tasks: 
- [x] update AggregatedTimeSeriesRequest contract with Balance Responsible id
- [x] Implement validation rule which validates the following:
  - [x] if sender role is balanceansvarlig, the balanceResponsibleParty present and a valid GLN/EIC format.
  - [x] Then balanceResponsibleParty must match senderNumber
 
Story: 
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/12

References:
https://github.com/Energinet-DataHub/opengeh-edi/pull/566