### PR TITLE
test: added contract test of charge type

### DIFF
--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/Infrastructure/SqlStatements/Mappers/WholesaleResult/ChargeTypeMapperTests.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/Infrastructure/SqlStatements/Mappers/WholesaleResult/ChargeTypeMapperTests.cs
@@ -15,12 +15,22 @@
 using Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.SqlStatements.Mappers;
 using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults.Model.WholesaleResults;
 using FluentAssertions;
+using Test.Core;
 using Xunit;
 
 namespace Energinet.DataHub.Wholesale.CalculationResults.UnitTests.Infrastructure.SqlStatements.Mappers.WholesaleResult
 {
     public class ChargeTypeMapperTests
     {
+        private const string DocumentPath = "DeltaTableContracts.enums.charge-type.json";
+
+        [Fact]
+        public async Task ChargeType_Matches_Contract()
+        {
+            await using var stream = EmbeddedResources.GetStream<Root>(DocumentPath);
+            await ContractComplianceTestHelper.VerifyEnumCompliesWithContractAsync<ChargeType>(stream);
+        }
+
         [Theory]
         [InlineData("fee", ChargeType.Fee)]
         [InlineData("subscription", ChargeType.Subscription)]


### PR DESCRIPTION
Added a test that compares the charge type contract against the model. 


https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/green-energy-hub/476