### PR TITLE
feat: Aggregated measure data can respond with multiple messages

### DIFF
--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Infrastructure/RequestCalculationResult/RequestCalculationResultQueriesTests.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Infrastructure/RequestCalculationResult/RequestCalculationResultQueriesTests.cs
@@ -36,7 +36,9 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
     private const string SecondQuantity = "2.222";
     private const string ThirdQuantity = "3.333";
     private const string FourthQuantity = "4.444";
-    private const string GridAreaCode = "301";
+    private const string GridAreaCodeA = "301";
+    private const string GridAreaCodeB = "201";
+    private const string GridAreaCodeC = "101";
     private readonly DatabricksSqlStatementApiFixture _fixture;
 
     public RequestCalculationResultQueriesTests(DatabricksSqlStatementApiFixture fixture)
@@ -52,7 +54,7 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         Mock<ILogger<RequestCalculationResultQueries>> requestCalculationResultQueriesLoggerMock)
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeA;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
@@ -70,10 +72,12 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         var sut = new RequestCalculationResultQueries(sqlStatementClient, deltaTableOptions, requestCalculationResultQueriesLoggerMock.Object);
 
         // Act
-        var actual = await sut.GetAsync(request);
+        var result = await sut.GetAsync(request).ToListAsync();
 
         // Assert
-        actual.Should().NotBeNull();
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+        var actual = result.First();
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.PeriodStart.Should().Be(startOfPeriodFilter);
         actual.PeriodEnd.Should().Be(endOfPeriodFilter);
@@ -106,10 +110,11 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         var sut = new RequestCalculationResultQueries(sqlStatementClient, deltaTableOptions, requestCalculationResultQueriesLoggerMock.Object);
 
         // Act
-        var actual = await sut.GetAsync(request);
+        var result = await sut.GetAsync(request).ToListAsync();
 
         // Assert
-        actual.Should().BeNull();
+        result.Should().NotBeNull();
+        result.Should().HaveCount(0);
     }
 
     [Theory]
@@ -120,7 +125,7 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         Mock<ILogger<RequestCalculationResultQueries>> requestCalculationResultQueriesLoggerMock)
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeA;
         var energySupplierIdFilter = "4321987654321";
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -140,9 +145,12 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         var sut = new RequestCalculationResultQueries(sqlStatementClient, deltaTableOptions, requestCalculationResultQueriesLoggerMock.Object);
 
         // Act
-        var actual = await sut.GetAsync(request);
+        var result = await sut.GetAsync(request).ToListAsync();
 
         // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+        var actual = result.First();
         actual.Should().NotBeNull();
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.PeriodStart.Should().Be(startOfPeriodFilter);
@@ -164,7 +172,7 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         Mock<ILogger<RequestCalculationResultQueries>> requestCalculationResultQueriesLoggerMock)
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeA;
         var energySupplierId = "badId";
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -184,10 +192,11 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         var sut = new RequestCalculationResultQueries(sqlStatementClient, deltaTableOptions, requestCalculationResultQueriesLoggerMock.Object);
 
         // Act
-        var actual = await sut.GetAsync(request);
+        var result = await sut.GetAsync(request).ToListAsync();
 
         // Assert
-        actual.Should().BeNull();
+        result.Should().NotBeNull();
+        result.Should().HaveCount(0);
     }
 
     [Theory]
@@ -198,7 +207,7 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         Mock<ILogger<RequestCalculationResultQueries>> requestCalculationResultQueriesLoggerMock)
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeA;
         var balanceResponsibleIdFilter = "1234567891234";
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -218,10 +227,12 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         var sut = new RequestCalculationResultQueries(sqlStatementClient, deltaTableOptions, requestCalculationResultQueriesLoggerMock.Object);
 
         // Act
-        var actual = await sut.GetAsync(request);
+        var result = await sut.GetAsync(request).ToListAsync();
 
         // Assert
-        actual.Should().NotBeNull();
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+        var actual = result.First();
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.PeriodStart.Should().Be(startOfPeriodFilter);
         actual.PeriodEnd.Should().Be(endOfPeriodFilter);
@@ -242,7 +253,7 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         Mock<ILogger<RequestCalculationResultQueries>> requestCalculationResultQueriesLoggerMock)
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeA;
         var balanceResponsibleIdFilter = "1234567891234";
         var energySupplierIdFilter = "4321987654321";
         var timeSeriesTypeFilter = TimeSeriesType.Production;
@@ -264,10 +275,12 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         var sut = new RequestCalculationResultQueries(sqlStatementClient, deltaTableOptions, requestCalculationResultQueriesLoggerMock.Object);
 
         // Act
-        var actual = await sut.GetAsync(request);
+        var result = await sut.GetAsync(request).ToListAsync();
 
         // Assert
-        actual.Should().NotBeNull();
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+        var actual = result.First();
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.PeriodStart.Should().Be(startOfPeriodFilter);
         actual.PeriodEnd.Should().Be(endOfPeriodFilter);
@@ -281,11 +294,52 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
             .Equal(ThirdQuantity);
     }
 
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task GetAsync_RequestFromEnergySupplierPerBalanceResponsibleTotalProduction_ReturnsTwoResult(
+        Mock<IHttpClientFactory> httpClientFactoryMock,
+        Mock<ILogger<SqlStatusResponseParser>> loggerMock,
+        Mock<ILogger<RequestCalculationResultQueries>> requestCalculationResultQueriesLoggerMock)
+    {
+        // Arrange
+        var balanceResponsibleIdFilter = "1234567891234";
+        var energySupplierIdFilter = "4321987654321";
+        var timeSeriesTypeFilter = TimeSeriesType.Production;
+        var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
+        var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
+        var deltaTableOptions = _fixture.DatabricksSchemaManager.DeltaTableOptions;
+        await AddCreatedRowsInArbitraryOrderAsync(deltaTableOptions);
+        var sqlStatementClient = _fixture.CreateSqlStatementClient(
+            httpClientFactoryMock,
+            loggerMock,
+            new Mock<ILogger<DatabricksSqlStatementClient>>());
+        var request = CreateRequest(
+            timeSeriesType: timeSeriesTypeFilter,
+            startOfPeriod: startOfPeriodFilter,
+            endOfPeriod: endOfPeriodFilter,
+            energySupplierId: energySupplierIdFilter,
+            balanceResponsibleId: balanceResponsibleIdFilter);
+        var sut = new RequestCalculationResultQueries(sqlStatementClient, deltaTableOptions, requestCalculationResultQueriesLoggerMock.Object);
+
+        // Act
+        var actual = await sut.GetAsync(request).ToListAsync();
+
+        // Assert
+        actual.Should().NotBeNull();
+        actual.Should().HaveCount(3);
+        actual.Select(result => result.GridArea).Should().Equal(GridAreaCodeC, GridAreaCodeB, GridAreaCodeA);
+        actual.Should().AllSatisfy(energyResult => energyResult.TimeSeriesType.Should().Be(timeSeriesTypeFilter));
+        actual.Should().AllSatisfy(energyResult => energyResult.PeriodStart.Should().Be(startOfPeriodFilter));
+        actual.Should().AllSatisfy(energyResult => energyResult.PeriodEnd.Should().Be(endOfPeriodFilter));
+        actual.Should().AllSatisfy(energyResult => energyResult.EnergySupplierId.Should().Be(energySupplierIdFilter));
+        actual.Should().AllSatisfy(energyResult => energyResult.BalanceResponsibleId.Should().Be(balanceResponsibleIdFilter));
+    }
+
     private EnergyResultQuery CreateRequest(
         TimeSeriesType? timeSeriesType = null,
         Instant? startOfPeriod = null,
         Instant? endOfPeriod = null,
-        string gridArea = "101",
+        string? gridArea = null,
         string? energySupplierId = null,
         string? balanceResponsibleId = null)
     {
@@ -305,21 +359,29 @@ public class RequestCalculationResultQueriesTests : IClassFixture<DatabricksSqlS
         const string firstHour = "2022-01-01T01:00:00.000Z";
         const string secondHour = "2022-01-01T02:00:00.000Z";
         const string thirdHour = "2022-01-01T03:00:00.000Z";
+        const string fourthHour = "2022-01-01T04:00:00.000Z";
         const string energySupplier = "4321987654321";
         const string balanceResponsibleId = "1234567891234";
-        var row1 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCode, quantity: FirstQuantity);
-        var row2 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondHour, gridArea: GridAreaCode, quantity: SecondQuantity);
+        var row1 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCodeA, quantity: FirstQuantity);
+        var row2 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondHour, gridArea: GridAreaCodeA, quantity: SecondQuantity);
 
-        var row3 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: secondHour, gridArea: GridAreaCode, quantity: ThirdQuantity, batchExecutionTimeStart: "2022-03-12T03:00:00.000Z");
-        var row4 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: thirdHour, gridArea: GridAreaCode, quantity: FourthQuantity, batchExecutionTimeStart: "2022-03-12T03:00:00.000Z");
+        var row3 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: secondHour, gridArea: GridAreaCodeA, quantity: ThirdQuantity, batchExecutionTimeStart: "2022-03-12T03:00:00.000Z");
+        var row4 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: thirdHour, gridArea: GridAreaCodeA, quantity: FourthQuantity, batchExecutionTimeStart: "2022-03-12T03:00:00.000Z");
 
-        var row5 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCode, quantity: FirstQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndGridArea, energySupplierId: energySupplier);
-        var row6 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: secondHour, gridArea: GridAreaCode, quantity: SecondQuantity, aggregationLevel: DeltaTableAggregationLevel.BalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId);
+        var row5 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCodeA, quantity: FirstQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndGridArea, energySupplierId: energySupplier);
+        var row6 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: secondHour, gridArea: GridAreaCodeA, quantity: SecondQuantity, aggregationLevel: DeltaTableAggregationLevel.BalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId);
 
-        var row7 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondHour, gridArea: GridAreaCode, quantity: ThirdQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId, energySupplierId: energySupplier);
+        var row7 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCodeA, quantity: ThirdQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId, energySupplierId: energySupplier);
+        var row8 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: thirdHour, gridArea: GridAreaCodeB, quantity: FourthQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId, energySupplierId: energySupplier);
+
+        var row9 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCodeC, quantity: FirstQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea);
+        var row10 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondHour, gridArea: GridAreaCodeC, quantity: SecondQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea);
+
+        var row11 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondHour, gridArea: GridAreaCodeC, quantity: ThirdQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId, energySupplierId: energySupplier);
+        var row12 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: fourthHour, gridArea: GridAreaCodeB, quantity: FourthQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId, energySupplierId: energySupplier);
 
         // mix up the order of the rows
-        var rows = new List<IReadOnlyCollection<string>> { row1, row2, row3, row4, row5, row6, row7 };
+        var rows = new List<IReadOnlyCollection<string>> { row1, row2, row3, row4, row5, row6, row7, row8, row9, row10, row11, row12 };
         await _fixture.DatabricksSchemaManager.EmptyAsync(options.Value.ENERGY_RESULTS_TABLE_NAME);
         await _fixture.DatabricksSchemaManager.InsertAsync<EnergyResultColumnNames>(options.Value.ENERGY_RESULTS_TABLE_NAME, rows);
     }

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults/IRequestCalculationResultQueries.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults/IRequestCalculationResultQueries.cs
@@ -21,5 +21,5 @@ public interface IRequestCalculationResultQueries
     /// <summary>
     /// Gets all result for a given request.
     /// </summary>
-    Task<EnergyResult?> GetAsync(EnergyResultQuery query);
+    IAsyncEnumerable<EnergyResult> GetAsync(EnergyResultQuery query);
 }

--- a/source/dotnet/wholesale-api/Edi.UnitTests/AggregatedTimeSeriesRequestResponseMessageFactoryTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/AggregatedTimeSeriesRequestResponseMessageFactoryTests.cs
@@ -24,7 +24,7 @@ using TimeSeriesType = Energinet.DataHub.Wholesale.CalculationResults.Interfaces
 
 namespace Energinet.DataHub.Wholesale.EDI.UnitTests;
 
-public class AggregatedTimeSeriesRequestAcceptedMessageFactoryTests
+public class AggregatedTimeSeriesRequestResponseMessageFactoryTests
 {
     private readonly Guid _batchId = Guid.NewGuid();
     private readonly Guid _id = Guid.NewGuid();
@@ -40,12 +40,12 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactoryTests
     public void Create_WithCalculationResultFromTotalProductionPerGridArea_CreatesAcceptedEdiMessage()
     {
         // Arrange
-        var expectedAcceptedSubject = nameof(AggregatedTimeSeriesRequestAccepted);
+        var expectedAcceptedSubject = nameof(AggregatedTimeSeriesRequestResponseMessage);
         var expectedReferenceId = "123456789";
         var energyResult = CreateEnergyResult();
 
         // Act
-        var response = AggregatedTimeSeriesRequestAcceptedMessageFactory.Create(energyResult, expectedReferenceId);
+        var response = AggregatedTimeSeriesRequestResponseMessageFactory.Create(energyResult, expectedReferenceId);
 
         // Assert
         response.Should().NotBeNull();
@@ -53,7 +53,7 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactoryTests
         response.ApplicationProperties["ReferenceId"].ToString().Should().Be(expectedReferenceId);
         response.Subject.Should().Be(expectedAcceptedSubject);
 
-        var responseBody = AggregatedTimeSeriesRequestAccepted.Parser.ParseFrom(response.Body);
+        var responseBody = AggregatedTimeSeriesRequestResponseMessage.Parser.ParseFrom(response.Body);
         responseBody.GridArea.Should().Be(_gridArea);
         responseBody.TimeSeriesType.Should().Be(Energinet.DataHub.Edi.Responses.TimeSeriesType.Production);
         responseBody.Period.StartOfPeriod.Should().Be(new Timestamp() { Seconds = _periodStart.ToUnixTimeSeconds() });

--- a/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestReceipt.proto
+++ b/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestReceipt.proto
@@ -1,0 +1,24 @@
+﻿/* Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+option csharp_namespace = "Energinet.DataHub.Edi.Responses";
+
+message AggregatedTimeSeriesRequestReceipt {
+    // A list of all the grid areas for which the receiver
+    // of AggregatedTimeSeriesRequestResponseMessage should have received data for
+    repeated string grid_areas = 1;
+}

--- a/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestResponseMessage.proto
+++ b/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestResponseMessage.proto
@@ -18,7 +18,7 @@ import "google/protobuf/timestamp.proto";
 
 option csharp_namespace = "Energinet.DataHub.Edi.Responses";
 
-message AggregatedTimeSeriesRequestAccepted {
+message AggregatedTimeSeriesRequestResponseMessage {
   string settlement_version = 1;
   string grid_area = 2;
   QuantityUnit quantity_unit = 3;

--- a/source/dotnet/wholesale-api/Edi/Edi.csproj
+++ b/source/dotnet/wholesale-api/Edi/Edi.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestReceiptMessageFactory.cs
+++ b/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestReceiptMessageFactory.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Azure.Messaging.ServiceBus;
+using Energinet.DataHub.Edi.Responses;
+using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults.Model.EnergyResults;
+using Google.Protobuf;
+
+namespace Energinet.DataHub.Wholesale.EDI.Factories;
+
+public class AggregatedTimeSeriesRequestReceiptMessageFactory
+{
+    public static ServiceBusMessage Create(List<EnergyResult> energyResults, string referenceId)
+    {
+        var body = CreateReceiptMessage(energyResults);
+
+        var message = new ServiceBusMessage()
+        {
+            Body = new BinaryData(body.ToByteArray()),
+            Subject = body.GetType().Name,
+        };
+
+        message.ApplicationProperties.Add("ReferenceId", referenceId);
+        return message;
+    }
+
+    private static IMessage CreateReceiptMessage(IReadOnlyList<EnergyResult> energyResults)
+    {
+        var response = new AggregatedTimeSeriesRequestReceipt();
+        response.GridAreas.AddRange(energyResults.Select(result => result.GridArea));
+        return response;
+    }
+}

--- a/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestResponseMessageFactory.cs
+++ b/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestResponseMessageFactory.cs
@@ -23,7 +23,7 @@ using TimeSeriesPoint = Energinet.DataHub.Edi.Responses.TimeSeriesPoint;
 
 namespace Energinet.DataHub.Wholesale.EDI.Factories;
 
-public class AggregatedTimeSeriesRequestAcceptedMessageFactory
+public static class AggregatedTimeSeriesRequestResponseMessageFactory
 {
     public static ServiceBusMessage Create(EnergyResult calculationResult, string referenceId)
     {
@@ -39,7 +39,7 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactory
         return message;
     }
 
-    private static AggregatedTimeSeriesRequestAccepted CreateAcceptedResponse(EnergyResult energyResult)
+    private static AggregatedTimeSeriesRequestResponseMessage CreateAcceptedResponse(EnergyResult energyResult)
     {
         var points = CreateTimeSeriesPoints(energyResult);
 
@@ -50,7 +50,7 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactory
             Resolution = Resolution.Pt15M,
         };
 
-        return new AggregatedTimeSeriesRequestAccepted()
+        return new AggregatedTimeSeriesRequestResponseMessage()
         {
             GridArea = energyResult.GridArea,
             QuantityUnit = QuantityUnit.Kwh,

--- a/source/dotnet/wholesale-api/Edi/Mappers/CalculationTimeSeriesTypeMapper.cs
+++ b/source/dotnet/wholesale-api/Edi/Mappers/CalculationTimeSeriesTypeMapper.cs
@@ -48,17 +48,17 @@ public static class CalculationTimeSeriesTypeMapper
             CalculationTimeSeriesType.FlexConsumption => TimeSeriesTypeContract.FlexConsumption,
             CalculationTimeSeriesType.NetExchangePerGa => TimeSeriesTypeContract.NetExchangePerGa,
             CalculationTimeSeriesType.GridLoss => throw new NotSupportedTimeSeriesTypeException(
-                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestAccepted response."),
+                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestResponseMessage response."),
             CalculationTimeSeriesType.TempProduction => throw new NotSupportedTimeSeriesTypeException(
-                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestAccepted response."),
+                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestResponseMessage response."),
             CalculationTimeSeriesType.NegativeGridLoss => throw new NotSupportedTimeSeriesTypeException(
-                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestAccepted response."),
+                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestResponseMessage response."),
             CalculationTimeSeriesType.PositiveGridLoss => throw new NotSupportedTimeSeriesTypeException(
-                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestAccepted response."),
+                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestResponseMessage response."),
             CalculationTimeSeriesType.TempFlexConsumption => throw new NotSupportedTimeSeriesTypeException(
-                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestAccepted response."),
+                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestResponseMessage response."),
             CalculationTimeSeriesType.NetExchangePerNeighboringGa => throw new NotSupportedTimeSeriesTypeException(
-                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestAccepted response."),
+                $"{timeSeriesType} is not a supported TimeSeriesType For AggregatedTimeSeriesRequestResponseMessage response."),
 
             _ => throw new ArgumentOutOfRangeException(
                 nameof(timeSeriesType),


### PR DESCRIPTION
This changes the structure of the aggregated measure data request.
The changes will result in, that the "one request -> one response" pattern is changed to a "one request -> multiple responses + a receipt" pattern

This change is needed. Sice an energy supplier and a balance responsible needs the option to request data from all grid areas where they are active. 
And a metered data responsible needs to request data on multiple time series types.  