### PR TITLE
refac: Remove period & settlement version from request accepted message

### DIFF
--- a/source/dotnet/wholesale-api/Edi.UnitTests/AggregatedTimeSeriesRequestAcceptedMessageFactoryTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/AggregatedTimeSeriesRequestAcceptedMessageFactoryTests.cs
@@ -32,12 +32,12 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactoryTests
     private readonly string _energySupplierId = "es_id";
     private readonly string _balanceResponsibleId = "br_id";
     private readonly string _fromGridArea = "123";
-    private readonly Instant _periodStart = SystemClock.Instance.GetCurrentInstant();
-    private readonly Instant _periodEnd = SystemClock.Instance.GetCurrentInstant();
+    private readonly Instant _periodStart = Instant.FromUtc(2020, 12, 31, 23, 0);
+    private readonly Instant _periodEnd = Instant.FromUtc(2021, 1, 1, 23, 0);
     private readonly TimeSeriesType _timeSeriesType = TimeSeriesType.Production;
 
     [Fact]
-    public void Create_WithCalculationResultFromTotalProductionPerGridArea_CreatesAcceptedEdiMessage()
+    public void Create_WithCalculationResultFromTotalProductionPerGridArea_CreatesCorrectAcceptedEdiMessage()
     {
         // Arrange
         var expectedAcceptedSubject = nameof(AggregatedTimeSeriesRequestAccepted);
@@ -56,8 +56,18 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactoryTests
         var responseBody = AggregatedTimeSeriesRequestAccepted.Parser.ParseFrom(response.Body);
         responseBody.GridArea.Should().Be(_gridArea);
         responseBody.TimeSeriesType.Should().Be(Energinet.DataHub.Edi.Responses.TimeSeriesType.Production);
-        responseBody.Period.StartOfPeriod.Should().Be(new Timestamp() { Seconds = _periodStart.ToUnixTimeSeconds() });
-        responseBody.Period.EndOfPeriod.Should().Be(new Timestamp() { Seconds = _periodEnd.ToUnixTimeSeconds() });
+
+        var timeSeriesOrdered = responseBody.TimeSeriesPoints.OrderBy(ts => ts.Time).ToList();
+        var earliestTimestamp = timeSeriesOrdered.First();
+        var latestTimestamp = timeSeriesOrdered.Last();
+
+        var periodStartTimestamp = new Timestamp() { Seconds = _periodStart.ToUnixTimeSeconds() };
+        var periodEndTimestamp = new Timestamp() { Seconds = _periodEnd.ToUnixTimeSeconds() };
+        earliestTimestamp.Time.Should().BeGreaterThanOrEqualTo(periodStartTimestamp)
+            .And.BeLessThan(periodEndTimestamp);
+        latestTimestamp.Time.Should().BeLessThan(periodEndTimestamp)
+            .And.BeGreaterOrEqualTo(earliestTimestamp.Time);
+
         responseBody.TimeSeriesPoints.Count.Should().Be(energyResult.TimeSeriesPoints.Length);
     }
 

--- a/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
+++ b/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
@@ -19,18 +19,11 @@ import "google/protobuf/timestamp.proto";
 option csharp_namespace = "Energinet.DataHub.Edi.Responses";
 
 message AggregatedTimeSeriesRequestAccepted {
-  string settlement_version = 1;
-  string grid_area = 2;
-  QuantityUnit quantity_unit = 3;
-  Period period = 4;
-  repeated TimeSeriesPoint time_series_points = 5;
-  TimeSeriesType time_series_type = 6;
-}
-
-message Period {
-  google.protobuf.Timestamp start_of_period = 1;
-  google.protobuf.Timestamp end_of_period = 2;
-  Resolution resolution = 3;
+    string grid_area = 1;
+    QuantityUnit quantity_unit = 2;
+    repeated TimeSeriesPoint time_series_points = 3;
+    TimeSeriesType time_series_type = 4;
+    Resolution resolution = 5;
 }
 
 message TimeSeriesPoint {

--- a/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactory.cs
+++ b/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactory.cs
@@ -18,7 +18,6 @@ using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResul
 using Energinet.DataHub.Wholesale.EDI.Mappers;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
-using PeriodContract = Energinet.DataHub.Edi.Responses.Period;
 using TimeSeriesPoint = Energinet.DataHub.Edi.Responses.TimeSeriesPoint;
 
 namespace Energinet.DataHub.Wholesale.EDI.Factories;
@@ -43,20 +42,13 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactory
     {
         var points = CreateTimeSeriesPoints(energyResult);
 
-        var period = new PeriodContract()
-        {
-            StartOfPeriod = new Timestamp() { Seconds = energyResult.PeriodStart.ToUnixTimeSeconds(), },
-            EndOfPeriod = new Timestamp() { Seconds = energyResult.PeriodEnd.ToUnixTimeSeconds(), },
-            Resolution = Resolution.Pt15M,
-        };
-
         return new AggregatedTimeSeriesRequestAccepted()
         {
             GridArea = energyResult.GridArea,
             QuantityUnit = QuantityUnit.Kwh,
-            Period = period,
             TimeSeriesPoints = { points },
             TimeSeriesType = CalculationTimeSeriesTypeMapper.MapTimeSeriesTypeFromCalculationsResult(energyResult.TimeSeriesType),
+            Resolution = Resolution.Pt15M,
         };
     }
 


### PR DESCRIPTION
Remove Period & Settlement Version from `AggregatedTimeSeriesRequestAccepted`, since they are already stored in EDI

EDI PR: https://github.com/Energinet-DataHub/opengeh-edi/pull/592