### PR TITLE
feat: Add currency to contracts for wholesale results

### DIFF
--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/AmountPerChargeResultProducedV1.cs
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/AmountPerChargeResultProducedV1.cs
@@ -24,7 +24,7 @@ public partial class AmountPerChargeResultProducedV1 : IEventMessage
     /// </summary>
     public const string EventName = "AmountPerChargeResultProducedV1";
 
-    public const int EventMinorVersion = 1;
+    public const int EventMinorVersion = 2;
 
     string IEventMessage.EventName => EventName;
 

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Factories/AmountPerChargeResultProducedV1Factory.cs
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Factories/AmountPerChargeResultProducedV1Factory.cs
@@ -45,6 +45,7 @@ public class AmountPerChargeResultProducedV1Factory : IAmountPerChargeResultProd
             QuantityUnit = QuantityUnitMapper.MapQuantityUnit(result.QuantityUnit),
             MeteringPointType = MeteringPointTypeMapper.MapMeteringPointType(result.MeteringPointType),
             SettlementMethod = SettlementMethodMapper.MapSettlementMethod(result.SettlementMethod),
+            Currency = AmountPerChargeResultProducedV1.Types.Currency.Dkk,
             IsTax = result.IsTax,
         };
 

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Factories/MonthlyAmountPerChargeResultProducedV1Factory.cs
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Factories/MonthlyAmountPerChargeResultProducedV1Factory.cs
@@ -45,6 +45,7 @@ public class MonthlyAmountPerChargeResultProducedV1Factory : IMonthlyAmountPerCh
             ChargeOwnerId = result.ChargeOwnerId,
             QuantityUnit = QuantityUnitMapper.MapQuantityUnit(result.QuantityUnit),
             IsTax = result.IsTax,
+            Currency = MonthlyAmountPerChargeResultProducedV1.Types.Currency.Dkk,
             Amount = result.TimeSeriesPoints.Single().Amount,
         };
 

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/MonthlyAmountPerChargeResultProducedV1.cs
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/MonthlyAmountPerChargeResultProducedV1.cs
@@ -24,7 +24,7 @@ public partial class MonthlyAmountPerChargeResultProducedV1 : IEventMessage
     /// </summary>
     public const string EventName = "MonthlyAmountPerChargeResultProducedV1";
 
-    public const int EventMinorVersion = 1;
+    public const int EventMinorVersion = 2;
 
     string IEventMessage.EventName => EventName;
 

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/amount_per_charge_result_produced_v1.proto
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/amount_per_charge_result_produced_v1.proto
@@ -49,28 +49,28 @@ message AmountPerChargeResultProducedV1 {
 
   string grid_area_code = 5;
 
-  string energy_supplier_id = 9;
+  string energy_supplier_id = 6;
 
-  string charge_code = 10;
+  string charge_code = 7;
 
-  ChargeType charge_type = 11;
+  ChargeType charge_type = 8;
 
-  string charge_owner_id = 12;
+  string charge_owner_id = 9;
 
-  Resolution resolution = 13;
+  Resolution resolution = 10;
 
-  QuantityUnit quantity_unit = 14;
+  QuantityUnit quantity_unit = 11;
 
-  MeteringPointType metering_point_type = 15;
+  MeteringPointType metering_point_type = 12;
 
   /*
    * Settlement method is only set when metering point type is 'METERING_POINT_TYPE_CONSUMPTION'.
    */
-  optional SettlementMethod settlement_method = 16;
+  optional SettlementMethod settlement_method = 13;
 
-  bool is_tax = 17;
+  bool is_tax = 14;
 
-  repeated TimeSeriesPoint time_series_points = 20;
+  repeated TimeSeriesPoint time_series_points = 15;
 
    // ---------------------------- NESTED TYPES BELOW ----------------------------------------
 
@@ -80,10 +80,10 @@ message AmountPerChargeResultProducedV1 {
      * Read more at https://protobuf.dev/programming-guides/style/#enums.
      */
     CALCULATION_TYPE_UNSPECIFIED = 0;
-    CALCULATION_TYPE_WHOLESALE_FIXING = 3;
-    CALCULATION_TYPE_FIRST_CORRECTION_SETTLEMENT = 4;
-    CALCULATION_TYPE_SECOND_CORRECTION_SETTLEMENT = 5;
-    CALCULATION_TYPE_THIRD_CORRECTION_SETTLEMENT = 6;
+    CALCULATION_TYPE_WHOLESALE_FIXING = 1;
+    CALCULATION_TYPE_FIRST_CORRECTION_SETTLEMENT = 2;
+    CALCULATION_TYPE_SECOND_CORRECTION_SETTLEMENT = 3;
+    CALCULATION_TYPE_THIRD_CORRECTION_SETTLEMENT = 4;
   }
 
   enum ChargeType {
@@ -131,7 +131,7 @@ message AmountPerChargeResultProducedV1 {
     QUANTITY_QUALITY_ESTIMATED = 1;
     QUANTITY_QUALITY_MEASURED = 2;
     QUANTITY_QUALITY_MISSING = 3;
-    QUANTITY_QUALITY_CALCULATED = 5;
+    QUANTITY_QUALITY_CALCULATED = 4;
   }
 
   /*

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/amount_per_charge_result_produced_v1.proto
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/amount_per_charge_result_produced_v1.proto
@@ -70,7 +70,9 @@ message AmountPerChargeResultProducedV1 {
 
   bool is_tax = 14;
 
-  repeated TimeSeriesPoint time_series_points = 15;
+  Currency currency = 15;
+
+  repeated TimeSeriesPoint time_series_points = 16;
 
    // ---------------------------- NESTED TYPES BELOW ----------------------------------------
 
@@ -155,6 +157,11 @@ message AmountPerChargeResultProducedV1 {
     SETTLEMENT_METHOD_UNSPECIFIED = 0;
     SETTLEMENT_METHOD_FLEX = 1;
     SETTLEMENT_METHOD_NON_PROFILED = 2;
+  }
+
+  enum Currency {
+    CURRENCY_UNSPECIFIED = 0;
+    CURRENCY_DKK = 1;
   }
 
   message TimeSeriesPoint {

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/monthly_amount_per_charge_result_produced_v1.proto
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/monthly_amount_per_charge_result_produced_v1.proto
@@ -61,10 +61,12 @@ message MonthlyAmountPerChargeResultProducedV1 {
 
   bool is_tax = 11;
 
+  Currency currency = 12;
+
   /*
    * 6 digit scale decimal value of the amount.
    */
-  optional DecimalValue amount = 12;
+  optional DecimalValue amount = 13;
 
   // ---------------------------- NESTED TYPES BELOW ----------------------------------------
 
@@ -85,6 +87,11 @@ message MonthlyAmountPerChargeResultProducedV1 {
     CHARGE_TYPE_FEE = 1;
     CHARGE_TYPE_TARIFF = 2;
     CHARGE_TYPE_SUBSCRIPTION = 3;
+  }
+
+  enum Currency {
+    CURRENCY_UNSPECIFIED = 0;
+    CURRENCY_DKK = 1;
   }
 
   enum QuantityUnit {

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/monthly_amount_per_charge_result_produced_v1.proto
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/monthly_amount_per_charge_result_produced_v1.proto
@@ -47,24 +47,24 @@ message MonthlyAmountPerChargeResultProducedV1 {
    */
   google.protobuf.Timestamp period_end_utc = 4;
 
-  string grid_area_code = 8;
+  string grid_area_code = 5;
 
-  string energy_supplier_id = 9;
+  string energy_supplier_id = 6;
 
-  string charge_code = 10;
+  string charge_code = 7;
 
-  ChargeType charge_type = 11;
+  ChargeType charge_type = 8;
 
-  string charge_owner_id = 12;
+  string charge_owner_id = 9;
 
-  QuantityUnit quantity_unit = 14;
+  QuantityUnit quantity_unit = 10;
 
-  bool is_tax = 15;
+  bool is_tax = 11;
 
   /*
    * 6 digit scale decimal value of the amount.
    */
-  optional DecimalValue amount = 20;
+  optional DecimalValue amount = 12;
 
   // ---------------------------- NESTED TYPES BELOW ----------------------------------------
 
@@ -74,10 +74,10 @@ message MonthlyAmountPerChargeResultProducedV1 {
      * Read more at https://protobuf.dev/programming-guides/style/#enums.
      */
     CALCULATION_TYPE_UNSPECIFIED = 0;
-    CALCULATION_TYPE_WHOLESALE_FIXING = 3;
-    CALCULATION_TYPE_FIRST_CORRECTION_SETTLEMENT = 4;
-    CALCULATION_TYPE_SECOND_CORRECTION_SETTLEMENT = 5;
-    CALCULATION_TYPE_THIRD_CORRECTION_SETTLEMENT = 6;
+    CALCULATION_TYPE_WHOLESALE_FIXING = 1;
+    CALCULATION_TYPE_FIRST_CORRECTION_SETTLEMENT = 2;
+    CALCULATION_TYPE_SECOND_CORRECTION_SETTLEMENT = 3;
+    CALCULATION_TYPE_THIRD_CORRECTION_SETTLEMENT = 4;
   }
 
   enum ChargeType {

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/total_monthly_amount_result_produced_v1.proto
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/total_monthly_amount_result_produced_v1.proto
@@ -47,13 +47,13 @@ message TotalMonthlyAmountResultProducedV1 {
    */
   google.protobuf.Timestamp period_end_utc = 4;
 
-  string grid_area_code = 8;
+  string grid_area_code = 5;
 
-  string energy_supplier_id = 9;
+  string energy_supplier_id = 6;
 
-  optional string charge_owner_id = 12;
+  optional string charge_owner_id = 7;
 
-  optional DecimalValue amount = 20;
+  optional DecimalValue amount = 8;
 
   // ---------------------------- NESTED TYPES BELOW ----------------------------------------
 
@@ -63,9 +63,9 @@ message TotalMonthlyAmountResultProducedV1 {
      * Read more at https://protobuf.dev/programming-guides/style/#enums.
      */
     CALCULATION_TYPE_UNSPECIFIED = 0;
-    CALCULATION_TYPE_WHOLESALE_FIXING = 3;
-    CALCULATION_TYPE_FIRST_CORRECTION_SETTLEMENT = 4;
-    CALCULATION_TYPE_SECOND_CORRECTION_SETTLEMENT = 5;
-    CALCULATION_TYPE_THIRD_CORRECTION_SETTLEMENT = 6;
+    CALCULATION_TYPE_WHOLESALE_FIXING = 1;
+    CALCULATION_TYPE_FIRST_CORRECTION_SETTLEMENT = 2;
+    CALCULATION_TYPE_SECOND_CORRECTION_SETTLEMENT = 3;
+    CALCULATION_TYPE_THIRD_CORRECTION_SETTLEMENT = 4;
   }
 }

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/total_monthly_amount_result_produced_v1.proto
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/total_monthly_amount_result_produced_v1.proto
@@ -53,7 +53,9 @@ message TotalMonthlyAmountResultProducedV1 {
 
   optional string charge_owner_id = 7;
 
-  optional DecimalValue amount = 8;
+  Currency currency = 8;
+
+  optional DecimalValue amount = 9;
 
   // ---------------------------- NESTED TYPES BELOW ----------------------------------------
 
@@ -67,5 +69,10 @@ message TotalMonthlyAmountResultProducedV1 {
     CALCULATION_TYPE_FIRST_CORRECTION_SETTLEMENT = 2;
     CALCULATION_TYPE_SECOND_CORRECTION_SETTLEMENT = 3;
     CALCULATION_TYPE_THIRD_CORRECTION_SETTLEMENT = 4;
+  }
+
+  enum Currency {
+    CURRENCY_UNSPECIFIED = 0;
+    CURRENCY_DKK = 1;
   }
 }

--- a/source/dotnet/wholesale-api/Events/Events.UnitTests/Infrastructure/IntegrationEvents/Factories/AmountPerChargeResultProducedV1FactoryTests.cs
+++ b/source/dotnet/wholesale-api/Events/Events.UnitTests/Infrastructure/IntegrationEvents/Factories/AmountPerChargeResultProducedV1FactoryTests.cs
@@ -123,6 +123,7 @@ public class AmountPerChargeResultProducedV1FactoryTests
             MeteringPointType = AmountPerChargeResultProducedV1.Types.MeteringPointType.Production,
             SettlementMethod = AmountPerChargeResultProducedV1.Types.SettlementMethod.Unspecified,
             IsTax = wholesaleResult.IsTax,
+            Currency = AmountPerChargeResultProducedV1.Types.Currency.Dkk,
         };
 
         var qualities = new List<AmountPerChargeResultProducedV1.Types.QuantityQuality>

--- a/source/dotnet/wholesale-api/Events/Events.UnitTests/Infrastructure/IntegrationEvents/Factories/MonthlyAmountPerChargeResultProducedV1FactoryTests.cs
+++ b/source/dotnet/wholesale-api/Events/Events.UnitTests/Infrastructure/IntegrationEvents/Factories/MonthlyAmountPerChargeResultProducedV1FactoryTests.cs
@@ -140,6 +140,7 @@ public class MonthlyAmountPerChargeResultProducedV1FactoryTests
             ChargeType = MonthlyAmountPerChargeResultProducedV1.Types.ChargeType.Tariff,
             ChargeOwnerId = wholesaleResult.ChargeOwnerId,
             IsTax = wholesaleResult.IsTax,
+            Currency = MonthlyAmountPerChargeResultProducedV1.Types.Currency.Dkk,
             Amount = wholesaleResult.TimeSeriesPoints.Single().Amount,
         };
 

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Wholesale Contracts Release notes
 
+## Version 5.1.0
+
+Added 'Currency' to 'AmountPerChargeResultProducedV1' and 'MonthlyAmountPerChargeResultProducedV1
+
 ## Version 5.0.0
 
 Updated produced events to use an interface `IEventMessage` for exposing `EventName` and `EventMinorVersion`.

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Tests/AmountPerChargeResultProducedV1Tests.cs
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Tests/AmountPerChargeResultProducedV1Tests.cs
@@ -63,7 +63,7 @@ public class AmountPerChargeResultProducedV1Tests
         Assert.Equal(LastKnownContentOfContract, actualContent, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
     }
 
-    private const int LastKnownMinorEventVersion = 1;
+    private const int LastKnownMinorEventVersion = 2;
     private const string LastKnownContentOfContract = @"/* Copyright 2020 Energinet DataHub A/S
  *
  * Licensed under the Apache License, Version 2.0 (the ""License2"");

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Tests/AmountPerChargeResultProducedV1Tests.cs
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Tests/AmountPerChargeResultProducedV1Tests.cs
@@ -115,28 +115,30 @@ message AmountPerChargeResultProducedV1 {
 
   string grid_area_code = 5;
 
-  string energy_supplier_id = 9;
+  string energy_supplier_id = 6;
 
-  string charge_code = 10;
+  string charge_code = 7;
 
-  ChargeType charge_type = 11;
+  ChargeType charge_type = 8;
 
-  string charge_owner_id = 12;
+  string charge_owner_id = 9;
 
-  Resolution resolution = 13;
+  Resolution resolution = 10;
 
-  QuantityUnit quantity_unit = 14;
+  QuantityUnit quantity_unit = 11;
 
-  MeteringPointType metering_point_type = 15;
+  MeteringPointType metering_point_type = 12;
 
   /*
    * Settlement method is only set when metering point type is 'METERING_POINT_TYPE_CONSUMPTION'.
    */
-  optional SettlementMethod settlement_method = 16;
+  optional SettlementMethod settlement_method = 13;
 
-  bool is_tax = 17;
+  bool is_tax = 14;
 
-  repeated TimeSeriesPoint time_series_points = 20;
+  Currency currency = 15;
+
+  repeated TimeSeriesPoint time_series_points = 16;
 
    // ---------------------------- NESTED TYPES BELOW ----------------------------------------
 
@@ -146,10 +148,10 @@ message AmountPerChargeResultProducedV1 {
      * Read more at https://protobuf.dev/programming-guides/style/#enums.
      */
     CALCULATION_TYPE_UNSPECIFIED = 0;
-    CALCULATION_TYPE_WHOLESALE_FIXING = 3;
-    CALCULATION_TYPE_FIRST_CORRECTION_SETTLEMENT = 4;
-    CALCULATION_TYPE_SECOND_CORRECTION_SETTLEMENT = 5;
-    CALCULATION_TYPE_THIRD_CORRECTION_SETTLEMENT = 6;
+    CALCULATION_TYPE_WHOLESALE_FIXING = 1;
+    CALCULATION_TYPE_FIRST_CORRECTION_SETTLEMENT = 2;
+    CALCULATION_TYPE_SECOND_CORRECTION_SETTLEMENT = 3;
+    CALCULATION_TYPE_THIRD_CORRECTION_SETTLEMENT = 4;
   }
 
   enum ChargeType {
@@ -197,7 +199,7 @@ message AmountPerChargeResultProducedV1 {
     QUANTITY_QUALITY_ESTIMATED = 1;
     QUANTITY_QUALITY_MEASURED = 2;
     QUANTITY_QUALITY_MISSING = 3;
-    QUANTITY_QUALITY_CALCULATED = 5;
+    QUANTITY_QUALITY_CALCULATED = 4;
   }
 
   /*
@@ -221,6 +223,11 @@ message AmountPerChargeResultProducedV1 {
     SETTLEMENT_METHOD_UNSPECIFIED = 0;
     SETTLEMENT_METHOD_FLEX = 1;
     SETTLEMENT_METHOD_NON_PROFILED = 2;
+  }
+
+  enum Currency {
+    CURRENCY_UNSPECIFIED = 0;
+    CURRENCY_DKK = 1;
   }
 
   message TimeSeriesPoint {

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Tests/MonthlyAmountPerChargeResultProducedV1Tests.cs
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Tests/MonthlyAmountPerChargeResultProducedV1Tests.cs
@@ -63,7 +63,7 @@ public class MonthlyAmountPerChargeResultProducedV1Tests
         Assert.Equal(LastKnownContentOfContract, actualContent, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
     }
 
-    private const int LastKnownMinorEventVersion = 1;
+    private const int LastKnownMinorEventVersion = 2;
     private const string LastKnownContentOfContract = @"/* Copyright 2020 Energinet DataHub A/S
  *
  * Licensed under the Apache License, Version 2.0 (the ""License2"");

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Tests/MonthlyAmountPerChargeResultProducedV1Tests.cs
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Tests/MonthlyAmountPerChargeResultProducedV1Tests.cs
@@ -113,24 +113,26 @@ message MonthlyAmountPerChargeResultProducedV1 {
    */
   google.protobuf.Timestamp period_end_utc = 4;
 
-  string grid_area_code = 8;
+  string grid_area_code = 5;
 
-  string energy_supplier_id = 9;
+  string energy_supplier_id = 6;
 
-  string charge_code = 10;
+  string charge_code = 7;
 
-  ChargeType charge_type = 11;
+  ChargeType charge_type = 8;
 
-  string charge_owner_id = 12;
+  string charge_owner_id = 9;
 
-  QuantityUnit quantity_unit = 14;
+  QuantityUnit quantity_unit = 10;
 
-  bool is_tax = 15;
+  bool is_tax = 11;
+
+  Currency currency = 12;
 
   /*
    * 6 digit scale decimal value of the amount.
    */
-  optional DecimalValue amount = 20;
+  optional DecimalValue amount = 13;
 
   // ---------------------------- NESTED TYPES BELOW ----------------------------------------
 
@@ -140,10 +142,10 @@ message MonthlyAmountPerChargeResultProducedV1 {
      * Read more at https://protobuf.dev/programming-guides/style/#enums.
      */
     CALCULATION_TYPE_UNSPECIFIED = 0;
-    CALCULATION_TYPE_WHOLESALE_FIXING = 3;
-    CALCULATION_TYPE_FIRST_CORRECTION_SETTLEMENT = 4;
-    CALCULATION_TYPE_SECOND_CORRECTION_SETTLEMENT = 5;
-    CALCULATION_TYPE_THIRD_CORRECTION_SETTLEMENT = 6;
+    CALCULATION_TYPE_WHOLESALE_FIXING = 1;
+    CALCULATION_TYPE_FIRST_CORRECTION_SETTLEMENT = 2;
+    CALCULATION_TYPE_SECOND_CORRECTION_SETTLEMENT = 3;
+    CALCULATION_TYPE_THIRD_CORRECTION_SETTLEMENT = 4;
   }
 
   enum ChargeType {
@@ -151,6 +153,11 @@ message MonthlyAmountPerChargeResultProducedV1 {
     CHARGE_TYPE_FEE = 1;
     CHARGE_TYPE_TARIFF = 2;
     CHARGE_TYPE_SUBSCRIPTION = 3;
+  }
+
+  enum Currency {
+    CURRENCY_UNSPECIFIED = 0;
+    CURRENCY_DKK = 1;
   }
 
   enum QuantityUnit {

--- a/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
@@ -33,7 +33,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Wholesale.Contracts</PackageId>
-    <PackageVersion>5.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>5.1.0$(VersionSuffix)</PackageVersion>
     <Title>Wholesale Contracts</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
Currency is now added to the contract for AmountPerChargeResultProducedV1 and MonthlyAmountPerChargeResultProducedV1. The wholesale domain expect everything to be in DKK, so the currency is hard coded in the factories that create the events.

Also, the protobuf files have been modified so that there are no 'jumps' in the increments of the indices in the proto. This is a breaking change, but since there are still no consumers to the event it has it will simply be bumped as a minor instead (to avoid all the complexity of major bumping).