### PR TITLE
refac: Improve test output from domain tests fixtures

### DIFF
--- a/source/dotnet/domain-tests/DomainTests.csproj
+++ b/source/dotnet/domain-tests/DomainTests.csproj
@@ -50,6 +50,9 @@
     <None Update="domaintest.local.settings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/source/dotnet/domain-tests/DomainTestsBase.cs
+++ b/source/dotnet/domain-tests/DomainTestsBase.cs
@@ -24,7 +24,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
     /// </summary>
     /// <typeparam name="TFixture">A xUnit fixture that implements <see cref="IAsyncLifetime"/>.</typeparam>
     public abstract class DomainTestsBase<TFixture> : IClassFixture<LazyFixtureFactory<TFixture>>, IAsyncLifetime
-        where TFixture : IAsyncLifetime, new()
+        where TFixture : LazyFixtureBase
     {
         /// <summary>
         /// Any fixture given in the constructor is always created and initialized by xUnit,

--- a/source/dotnet/domain-tests/DomainTestsBase.cs
+++ b/source/dotnet/domain-tests/DomainTestsBase.cs
@@ -22,16 +22,16 @@ namespace Energinet.DataHub.Wholesale.DomainTests
     /// Simplify the implementation of domain tests for which we only want to perform the
     /// test setup phase if they should actually be executed.
     /// </summary>
-    /// <typeparam name="TFixture">A xUnit fixture that implements <see cref="IAsyncLifetime"/>.</typeparam>
-    public abstract class DomainTestsBase<TFixture> : IClassFixture<LazyFixtureFactory<TFixture>>, IAsyncLifetime
-        where TFixture : LazyFixtureBase
+    /// <typeparam name="TLazyFixture">A xUnit fixture that inherits from <see cref="LazyFixtureBase"/>.</typeparam>
+    public abstract class DomainTestsBase<TLazyFixture> : IClassFixture<LazyFixtureFactory<TLazyFixture>>, IAsyncLifetime
+        where TLazyFixture : LazyFixtureBase
     {
         /// <summary>
-        /// Any fixture given in the constructor is always created and initialized by xUnit,
-        /// even if no test is executed. For this reason we use a factory to handle lazy initialization
-        /// of the fixture, which means we only perform the initialization if we actually execute any test.
+        /// Any fixture given in the constructor is always created and initialized by xUnit, even if no test is executed
+        /// in the test class. For this reason we use a factory to handle lazy initialization of the fixture, which means
+        /// we only perform the initialization if we actually execute any test.
         /// </summary>
-        public DomainTestsBase(LazyFixtureFactory<TFixture> lazyFixtureFactory)
+        public DomainTestsBase(LazyFixtureFactory<TLazyFixture> lazyFixtureFactory)
         {
             LazyFixtureFactory = lazyFixtureFactory;
         }
@@ -40,9 +40,9 @@ namespace Energinet.DataHub.Wholesale.DomainTests
         /// This property only contains a value if any test is executed.
         /// </summary>
         [NotNull]
-        protected TFixture? Fixture { get; set; }
+        protected TLazyFixture? Fixture { get; set; }
 
-        private LazyFixtureFactory<TFixture> LazyFixtureFactory { get; }
+        private LazyFixtureFactory<TLazyFixture> LazyFixtureFactory { get; }
 
         /// <summary>
         /// This method only gets called by xUnit if any test is executed.

--- a/source/dotnet/domain-tests/Fixtures/AuthorizedClientFixture.cs
+++ b/source/dotnet/domain-tests/Fixtures/AuthorizedClientFixture.cs
@@ -17,7 +17,6 @@ using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using Energinet.DataHub.Wholesale.DomainTests.Clients.v3;
 using Moq;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
@@ -64,7 +63,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
             WholesaleClient = await CreateWholesaleClientAsync();
             await CreateTopicSubscriptionAsync();
             Receiver = CreateServiceBusReceiver();
-            Output = new AuthorizedClientFixtureOutput(WholesaleClient, Receiver);
+            Output = new AuthorizedClientFixtureOutput(DiagnosticMessageSink, WholesaleClient, Receiver);
             await Output.InitializeAsync();
         }
 

--- a/source/dotnet/domain-tests/Fixtures/AuthorizedClientFixtureOutput.cs
+++ b/source/dotnet/domain-tests/Fixtures/AuthorizedClientFixtureOutput.cs
@@ -18,6 +18,7 @@ using Energinet.DataHub.Core.TestCommon;
 using Energinet.DataHub.Wholesale.Contracts.Events;
 using Energinet.DataHub.Wholesale.Contracts.IntegrationEvents;
 using Energinet.DataHub.Wholesale.DomainTests.Clients.v3;
+using Xunit.Abstractions;
 using ProcessType = Energinet.DataHub.Wholesale.DomainTests.Clients.v3.ProcessType;
 
 namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
@@ -27,11 +28,13 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
     /// </summary>
     public sealed class AuthorizedClientFixtureOutput
     {
+        private readonly IMessageSink _diagnosticMessageSink;
         private readonly WholesaleClient_V3 _wholesaleClient;
         private readonly ServiceBusReceiver _receiver;
 
-        public AuthorizedClientFixtureOutput(WholesaleClient_V3 wholesaleClient, ServiceBusReceiver receiver)
+        public AuthorizedClientFixtureOutput(IMessageSink diagnosticMessageSink, WholesaleClient_V3 wholesaleClient, ServiceBusReceiver receiver)
         {
+            _diagnosticMessageSink = diagnosticMessageSink;
             _wholesaleClient = wholesaleClient;
             _receiver = receiver;
         }
@@ -109,7 +112,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
                 defaultTimeout,
                 defaultDelay);
             stopwatch.Stop();
-            Console.WriteLine($"LOOK AT ME: Calculation took {stopwatch.Elapsed} to complete for calculationId {calculationId}");
+            _diagnosticMessageSink.OnMessage(new Xunit.Sdk.DiagnosticMessage($"LOOK AT ME: Calculation took '{stopwatch.Elapsed}' to complete for calculationId '{calculationId}'."));
             return isCompleted;
         }
 
@@ -135,10 +138,10 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
 
             stopwatch.Stop();
 
-            Console.WriteLine($"LOOK AT ME: the loop took {stopwatch.Elapsed} to complete and received {CalculationResultCompletedFromBalanceFixing.Count} messages");
+            _diagnosticMessageSink.OnMessage(new Xunit.Sdk.DiagnosticMessage($"LOOK AT ME: the loop took '{stopwatch.Elapsed}' to complete and received '{CalculationResultCompletedFromBalanceFixing.Count}' messages."));
             if (stopwatch.Elapsed >= TimeSpan.FromMinutes(15))
             {
-                Console.WriteLine("LOOK AT ME: No messages received within the 15 minute time limit, and the loop was stopped.");
+                _diagnosticMessageSink.OnMessage(new Xunit.Sdk.DiagnosticMessage("LOOK AT ME: No messages received within the 15 minute time limit, and the loop was stopped."));
             }
         }
 

--- a/source/dotnet/domain-tests/Fixtures/LazyFixtureBase.cs
+++ b/source/dotnet/domain-tests/Fixtures/LazyFixtureBase.cs
@@ -18,21 +18,21 @@ using Xunit.Abstractions;
 namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
 {
     /// <summary>
-    /// Base class for lazy fixtures which can be constructed by <see cref="LazyFixtureFactory{TFixture}"/>.
+    /// Base class for lazy fixtures which should be constructed using <see cref="LazyFixtureFactory{TFixture}"/>.
     /// </summary>
     public abstract class LazyFixtureBase : IAsyncLifetime
     {
         /// <summary>
-        /// Create test fixture.
+        /// Create lazy fixture.
         /// </summary>
-        /// <param name="diagnosticMessageSink">Used for writing messages to the output from test fixtures.</param>
-        public LazyFixtureBase(IMessageSink diagnosticMessageSink)
+        /// <param name="diagnosticMessageSink">Used for writing messages to the output from xUnit fixtures.</param>
+        protected LazyFixtureBase(IMessageSink diagnosticMessageSink)
         {
             DiagnosticMessageSink = diagnosticMessageSink;
         }
 
         /// <summary>
-        /// Can be used from test fixtures for writing messages to output.
+        /// Can be used from xUnit fixtures for writing messages to output.
         /// Messages are only written if the test runner has been configured to do so.
         /// See details at https://xunit.net/docs/capturing-output#output-in-extensions
         /// </summary>

--- a/source/dotnet/domain-tests/Fixtures/LazyFixtureBase.cs
+++ b/source/dotnet/domain-tests/Fixtures/LazyFixtureBase.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
+{
+    /// <summary>
+    /// Base class for lazy fixtures which can be constructed by <see cref="LazyFixtureFactory{TFixture}"/>.
+    /// </summary>
+    public abstract class LazyFixtureBase : IAsyncLifetime
+    {
+        /// <summary>
+        /// Create test fixture.
+        /// </summary>
+        /// <param name="diagnosticMessageSink">Used for writing messages to the output from test fixtures.</param>
+        public LazyFixtureBase(IMessageSink diagnosticMessageSink)
+        {
+            DiagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        /// <summary>
+        /// Can be used from test fixtures for writing messages to output.
+        /// Messages are only written if the test runner has been configured to do so.
+        /// See details at https://xunit.net/docs/capturing-output#output-in-extensions
+        /// </summary>
+        protected IMessageSink DiagnosticMessageSink { get; }
+
+        public Task InitializeAsync()
+        {
+            return OnInitializeAsync();
+        }
+
+        public Task DisposeAsync()
+        {
+            return OnDisposeAsync();
+        }
+
+        protected abstract Task OnInitializeAsync();
+
+        protected abstract Task OnDisposeAsync();
+    }
+}

--- a/source/dotnet/domain-tests/Fixtures/LazyFixtureFactory.cs
+++ b/source/dotnet/domain-tests/Fixtures/LazyFixtureFactory.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Reflection;
 using Nito.AsyncEx;
 using Xunit;
 using Xunit.Abstractions;

--- a/source/dotnet/domain-tests/Fixtures/LazyFixtureFactory.cs
+++ b/source/dotnet/domain-tests/Fixtures/LazyFixtureFactory.cs
@@ -66,7 +66,14 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
 
         private static async Task<TFixture> PrepareFixtureAsync(IMessageSink diagnosticMessageSink)
         {
-            var fixture = new TFixture(diagnosticMessageSink);
+            var fixtureType = typeof(TFixture);
+            diagnosticMessageSink.OnMessage(new DiagnosticMessage($"Creating LazyFixture of type '{fixtureType.FullName}'."));
+
+            if (Activator.CreateInstance(fixtureType, diagnosticMessageSink) is not TFixture fixture)
+            {
+                throw new InvalidOperationException($"Could not create LazyFixture of type '{fixtureType.FullName}'.");
+            }
+
             await fixture.InitializeAsync();
 
             return fixture;

--- a/source/dotnet/domain-tests/Fixtures/UnauthorizedClientFixture.cs
+++ b/source/dotnet/domain-tests/Fixtures/UnauthorizedClientFixture.cs
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
 {
-    public sealed class UnauthorizedClientFixture : IAsyncLifetime
+    public sealed class UnauthorizedClientFixture : LazyFixtureBase
     {
-        public UnauthorizedClientFixture()
+        public UnauthorizedClientFixture(IMessageSink diagnosticMessageSink)
+            : base(diagnosticMessageSink)
         {
             var configuration = new WholesaleDomainConfiguration();
             UnauthorizedHttpClient = new HttpClient
@@ -29,12 +31,12 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
 
         public HttpClient UnauthorizedHttpClient { get; }
 
-        Task IAsyncLifetime.InitializeAsync()
+        protected override Task OnInitializeAsync()
         {
             return Task.CompletedTask;
         }
 
-        Task IAsyncLifetime.DisposeAsync()
+        protected override Task OnDisposeAsync()
         {
             UnauthorizedHttpClient.Dispose();
 

--- a/source/dotnet/domain-tests/xunit.runner.json
+++ b/source/dotnet/domain-tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true
+}


### PR DESCRIPTION
Support use of IMessageSink (see https://xunit.net/docs/capturing-output#output-in-extensions) from domain tests fixtures to be able to log to output without using "Console.WriteLine".

Example of output from build log:
![image](https://github.com/Energinet-DataHub/opengeh-wholesale/assets/51327761/3001e2c6-f557-4722-95d7-03330224fbaa)

Example of output from log in VS 2022:
![image](https://github.com/Energinet-DataHub/opengeh-wholesale/assets/51327761/97f37eb5-ae3d-4251-be0c-e2ce4f51fde2)

Read about xUnit output here: https://xunit.net/docs/capturing-output#output-in-extensions