### PR TITLE
Cleanup NuGet packages

### DIFF
--- a/source/dotnet/Directory.Build.props
+++ b/source/dotnet/Directory.Build.props
@@ -13,17 +13,10 @@
   See also: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#search-scope
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.6.40">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
+    <!--
+    IMPORTANT: Do NOT add NuGet package dependencies in this file, except for "StyleCop.Analyzers".
+    -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/database-migration/DatabaseMigration.csproj
+++ b/source/dotnet/database-migration/DatabaseMigration.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -15,52 +15,45 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <AssemblyName>Energinet.DataHub.Wholesale.DatabaseMigration</AssemblyName>
-        <RootNamespace>Energinet.DataHub.Wholesale.DatabaseMigration</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>Energinet.DataHub.Wholesale.DatabaseMigration</AssemblyName>
+    <RootNamespace>Energinet.DataHub.Wholesale.DatabaseMigration</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <None Remove="Scripts\202302091300_Add_ProcessType_column_To_Batch.sql" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Remove="Scripts\202302091300_Add_ProcessType_column_To_Batch.sql" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <EmbeddedResource Include="Scripts\202302031200_Drop_MessageHub.sql" />
-      <EmbeddedResource Include="Scripts\202206161400_Create_Batch_Table.sql" />
-      <EmbeddedResource Include="Scripts\202206281330_Create_MessageHub_Process_Table.sql" />
-      <EmbeddedResource Include="Scripts\202208111100_Add_Batch_RunId.sql" />
-      <EmbeddedResource Include="Scripts\202207141500_Add_Process_BatchId.sql" />
-      <EmbeddedResource Include="Scripts\202209071400_Add_Batch_Period.sql" />
-      <EmbeddedResource Include="Scripts\202209131440_Alter_Batch_Period.sql" />
-      <EmbeddedResource Include="Scripts\202209191000_Add_Batch_Execution_Time.sql" />
-      <EmbeddedResource Include="Scripts\202210261230_Add_IsBatchDataDownloadAvailable.sql" />
-      <EmbeddedResource Include="Scripts\202301241200_Rename_To_Batch_AreSettlementReportsCreated.sql" />
-      <EmbeddedResource Include="Scripts\202302091300_Add_ProcessType_column_To_Batch.sql" />
-      <EmbeddedResource Include="Scripts\202302031300_Fix_Batch_PeriodEnds.sql" />
-      <EmbeddedResource Include="Scripts\202302020800_Rename_RunId_To_CalculationId.sql" />
-      <EmbeddedResource Include="Scripts\202303081500_Create_Outbox_Table.sql" />
-      <EmbeddedResource Include="Scripts\202304041500_Add_CreatedByUserId_to_Batch.sql" />
-      <EmbeddedResource Include="Scripts\202305161700_Add_Integration_Events_Module.sql" />
-      <EmbeddedResource Include="Scripts\202305241400_Remove_Outbox_Table.sql" />
-      <EmbeddedResource Include="Scripts\202305260800_Add_BatchCompleted_PublishedTime.sql" />
-      <EmbeddedResource Include="Scripts\202305261500_Add_Batch_CreatedTime.sql" />
-    </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Scripts\202302031200_Drop_MessageHub.sql" />
+    <EmbeddedResource Include="Scripts\202206161400_Create_Batch_Table.sql" />
+    <EmbeddedResource Include="Scripts\202206281330_Create_MessageHub_Process_Table.sql" />
+    <EmbeddedResource Include="Scripts\202208111100_Add_Batch_RunId.sql" />
+    <EmbeddedResource Include="Scripts\202207141500_Add_Process_BatchId.sql" />
+    <EmbeddedResource Include="Scripts\202209071400_Add_Batch_Period.sql" />
+    <EmbeddedResource Include="Scripts\202209131440_Alter_Batch_Period.sql" />
+    <EmbeddedResource Include="Scripts\202209191000_Add_Batch_Execution_Time.sql" />
+    <EmbeddedResource Include="Scripts\202210261230_Add_IsBatchDataDownloadAvailable.sql" />
+    <EmbeddedResource Include="Scripts\202301241200_Rename_To_Batch_AreSettlementReportsCreated.sql" />
+    <EmbeddedResource Include="Scripts\202302091300_Add_ProcessType_column_To_Batch.sql" />
+    <EmbeddedResource Include="Scripts\202302031300_Fix_Batch_PeriodEnds.sql" />
+    <EmbeddedResource Include="Scripts\202302020800_Rename_RunId_To_CalculationId.sql" />
+    <EmbeddedResource Include="Scripts\202303081500_Create_Outbox_Table.sql" />
+    <EmbeddedResource Include="Scripts\202304041500_Add_CreatedByUserId_to_Batch.sql" />
+    <EmbeddedResource Include="Scripts\202305161700_Add_Integration_Events_Module.sql" />
+    <EmbeddedResource Include="Scripts\202305241400_Remove_Outbox_Table.sql" />
+    <EmbeddedResource Include="Scripts\202305260800_Add_BatchCompleted_PublishedTime.sql" />
+    <EmbeddedResource Include="Scripts\202305261500_Add_Batch_CreatedTime.sql" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="dbup-sqlserver" Version="5.0.8" />
-      <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-      <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
-      <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="dbup-sqlserver" Version="5.0.8" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/source/dotnet/database-migration/DatabaseMigration.csproj
+++ b/source/dotnet/database-migration/DatabaseMigration.csproj
@@ -49,7 +49,6 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="dbup-sqlserver" Version="5.0.37" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>

--- a/source/dotnet/database-migration/DatabaseMigration.csproj
+++ b/source/dotnet/database-migration/DatabaseMigration.csproj
@@ -48,9 +48,9 @@ limitations under the License.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-sqlserver" Version="5.0.8" />
+    <PackageReference Include="dbup-sqlserver" Version="5.0.37" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/domain-tests/DomainTests.csproj
+++ b/source/dotnet/domain-tests/DomainTests.csproj
@@ -36,11 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/domain-tests/DomainTests.csproj
+++ b/source/dotnet/domain-tests/DomainTests.csproj
@@ -23,8 +23,8 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -32,7 +32,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NSwag.MSBuild" Version="13.19.0">
+    <PackageReference Include="NSwag.MSBuild" Version="13.20.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/domain-tests/DomainTests.csproj
+++ b/source/dotnet/domain-tests/DomainTests.csproj
@@ -12,7 +12,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.2" />
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />

--- a/source/dotnet/wholesale-api/Batches/Batches.Application/Batches.Application.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.Application/Batches.Application.csproj
@@ -9,11 +9,7 @@
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="8.1.1" />
     <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="8.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Batches/Batches.Infrastructure/Batches.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.Infrastructure/Batches.Infrastructure.csproj
@@ -7,11 +7,7 @@
     <PackageReference Include="Energinet.DataHub.Core.Databricks.Jobs" Version="7.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.13" />
     <PackageReference Include="NodaTime" Version="3.1.9" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Batches/Batches.IntegrationTests/Batches.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.IntegrationTests/Batches.IntegrationTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.5.1" />

--- a/source/dotnet/wholesale-api/Batches/Batches.IntegrationTests/Batches.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.IntegrationTests/Batches.IntegrationTests.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-      <AssemblyName>Energinet.DataHub.Wholesale.Batches.IntegrationTests</AssemblyName>
-      <RootNamespace>Energinet.DataHub.Wholesale.Batches.IntegrationTests</RootNamespace>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Energinet.DataHub.Wholesale.Batches.IntegrationTests</AssemblyName>
+    <RootNamespace>Energinet.DataHub.Wholesale.Batches.IntegrationTests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
@@ -21,11 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Batches/Batches.IntegrationTests/Batches.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.IntegrationTests/Batches.IntegrationTests.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.1.0" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Batches/Batches.Interfaces/Batches.Interfaces.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.Interfaces/Batches.Interfaces.csproj
@@ -5,11 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.1.9" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Batches/Batches.UnitTests/Batches.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.UnitTests/Batches.UnitTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />

--- a/source/dotnet/wholesale-api/Batches/Batches.UnitTests/Batches.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.UnitTests/Batches.UnitTests.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />
-    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.1.0" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Batches/Batches.UnitTests/Batches.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Batches/Batches.UnitTests/Batches.UnitTests.csproj
@@ -1,43 +1,39 @@
-<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-      <AssemblyName>Energinet.DataHub.Wholesale.Batches.UnitTests</AssemblyName>
-      <RootNamespace>Energinet.DataHub.Wholesale.Batches.UnitTests</RootNamespace>
-      <IsPackable>false</IsPackable>
-      <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
-    <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
-      <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
-      <PackageReference Include="FluentAssertions" Version="6.11.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-      <PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />
-      <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
-      <PackageReference Include="xunit" Version="2.5.1" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-      <PackageReference Include="coverlet.collector" Version="6.0.0">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-      <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\..\Test.Core\Test.Core.csproj" />
-      <ProjectReference Include="..\Batches.Infrastructure\Batches.Infrastructure.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <EmbeddedResource Include="..\..\..\..\databricks\calculation_engine\contracts\calculation-job-parameters-reference.txt">
-        <Link>Infrastructure\Calculations\calculation-job-parameters-reference.txt</Link>
-      </EmbeddedResource>
-    </ItemGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Energinet.DataHub.Wholesale.Batches.UnitTests</AssemblyName>
+    <RootNamespace>Energinet.DataHub.Wholesale.Batches.UnitTests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Test.Core\Test.Core.csproj" />
+    <ProjectReference Include="..\Batches.Infrastructure\Batches.Infrastructure.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\..\..\databricks\calculation_engine\contracts\calculation-job-parameters-reference.txt">
+      <Link>Infrastructure\Calculations\calculation-job-parameters-reference.txt</Link>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Application/CalculationResults.Application.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Application/CalculationResults.Application.csproj
@@ -7,11 +7,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults.Infrastructure.csproj
@@ -11,11 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NodaTime" Version="3.1.9" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
@@ -1,55 +1,51 @@
-<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-      <AssemblyName>Energinet.DataHub.Wholesale.CalculationResults.IntegrationTests</AssemblyName>
-      <RootNamespace>Energinet.DataHub.Wholesale.CalculationResults.IntegrationTests</RootNamespace>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Energinet.DataHub.Wholesale.CalculationResults.IntegrationTests</AssemblyName>
+    <RootNamespace>Energinet.DataHub.Wholesale.CalculationResults.IntegrationTests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
-      <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
-      <PackageReference Include="FluentAssertions" Version="6.11.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-      <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
-      <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-      <PackageReference Include="xunit" Version="2.5.1" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-      <PackageReference Include="coverlet.collector" Version="6.0.0">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-      <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\..\database-migration\DatabaseMigration.csproj" />
-      <ProjectReference Include="..\..\Test.Core\Test.Core.csproj" />
-      <ProjectReference Include="..\CalculationResults.Infrastructure\CalculationResults.Infrastructure.csproj" />
-      <ProjectReference Include="..\CalculationResults.Interfaces\CalculationResults.Interfaces.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\database-migration\DatabaseMigration.csproj" />
+    <ProjectReference Include="..\..\Test.Core\Test.Core.csproj" />
+    <ProjectReference Include="..\CalculationResults.Infrastructure\CalculationResults.Infrastructure.csproj" />
+    <ProjectReference Include="..\CalculationResults.Interfaces\CalculationResults.Interfaces.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <None Update="integrationtest.local.settings.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="integrationtest.local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
-    <ItemGroup>
-      <EmbeddedResource Include="..\..\..\..\databricks\calculation_engine\package\datamigration\migration_scripts\*.sql">
-		<Link>migration_sql_scripts\%(RecursiveDir)%(Filename)%(Extension)</Link>
-		   <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </EmbeddedResource>
-     </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\..\..\databricks\calculation_engine\package\datamigration\migration_scripts\*.sql">
+      <Link>migration_sql_scripts\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults.Interfaces.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults.Interfaces.csproj
@@ -5,11 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.1.9" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
@@ -1,52 +1,45 @@
-<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-      <AssemblyName>Energinet.DataHub.Wholesale.CalculationResults.UnitTests</AssemblyName>
-      <RootNamespace>Energinet.DataHub.Wholesale.CalculationResults.UnitTests</RootNamespace>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Energinet.DataHub.Wholesale.CalculationResults.UnitTests</AssemblyName>
+    <RootNamespace>Energinet.DataHub.Wholesale.CalculationResults.UnitTests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="FluentAssertions" Version="6.11.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-      <PackageReference Include="Moq" Version="4.18.4" />
-      <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-      <PackageReference Include="xunit" Version="2.5.1" />
-      <PackageReference Include="YamlDotNet" Version="13.1.1" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-      <PackageReference Include="coverlet.collector" Version="6.0.0">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
-  
-    <ItemGroup>
-      <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="YamlDotNet" Version="13.1.1" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-      <EmbeddedResource Include="..\..\..\..\databricks\calculation_engine\contracts\**">
-        <Link>DeltaTableContracts\%(RecursiveDir)%(Filename)%(Extension)</Link>
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </EmbeddedResource>
-    </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\..\..\databricks\calculation_engine\contracts\**">
+      <Link>DeltaTableContracts\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\Test.Core\Test.Core.csproj" />
-      <ProjectReference Include="..\CalculationResults.Infrastructure\CalculationResults.Infrastructure.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <Folder Include="Interfaces" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Test.Core\Test.Core.csproj" />
+    <ProjectReference Include="..\CalculationResults.Infrastructure\CalculationResults.Infrastructure.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Interfaces" />
+  </ItemGroup>
 </Project>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
@@ -9,12 +9,12 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="YamlDotNet" Version="13.1.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="YamlDotNet" Version="13.7.1" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/source/dotnet/wholesale-api/Common/Common.csproj
+++ b/source/dotnet/wholesale-api/Common/Common.csproj
@@ -23,13 +23,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Microsoft.Azure.Databricks.Client" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="xunit" Version="2.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Energinet.DataHub.Wholesale.Edi.UnitTests</AssemblyName>
     <RootNamespace>Energinet.DataHub.Wholesale.Edi.UnitTests</RootNamespace>
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Edi/Edi.csproj
+++ b/source/dotnet/wholesale-api/Edi/Edi.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.2" />
     <PackageReference Include="NodaTime.Serialization.Protobuf" Version="2.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.25.0" />
     <PackageReference Include="Grpc.Tools" Version="2.59.0" PrivateAssets="All" />

--- a/source/dotnet/wholesale-api/Edi/Edi.csproj
+++ b/source/dotnet/wholesale-api/Edi/Edi.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-      <AssemblyName>Energinet.DataHub.Wholesale.Edi</AssemblyName>
-      <RootNamespace>Energinet.DataHub.Wholesale.Edi</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyName>Energinet.DataHub.Wholesale.Edi</AssemblyName>
+    <RootNamespace>Energinet.DataHub.Wholesale.Edi</RootNamespace>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.1" />
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.23.4" />
     <PackageReference Include="Grpc.Tools" Version="2.57.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Edi/Edi.csproj
+++ b/source/dotnet/wholesale-api/Edi/Edi.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.1" />
     <PackageReference Include="NodaTime.Serialization.Protobuf" Version="2.0.1" />
-    <PackageReference Include="Google.Protobuf" Version="3.23.4" />
-    <PackageReference Include="Grpc.Tools" Version="2.57.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.25.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.59.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>

--- a/source/dotnet/wholesale-api/Events/Events.Application/Events.Application.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.Application/Events.Application.csproj
@@ -9,12 +9,8 @@
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Events/Events.Application/Events.Application.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.Application/Events.Application.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="8.1.1" />
     <PackageReference Include="Energinet.DataHub.Core.Logging" Version="3.1.1" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="3.1.1" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="3.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Energinet.DataHub.Wholesale.Events.Infrastructure</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.2" />
     <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.16.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="8.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.13" />

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
@@ -9,9 +9,9 @@
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="8.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.13" />
     <PackageReference Include="NodaTime.Serialization.Protobuf" Version="2.0.1" />
-    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.23.4" />
-    <PackageReference Include="Grpc.Tools" Version="2.57.0" PrivateAssets="All" />
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.1.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.25.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.59.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
@@ -13,11 +13,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.23.4" />
     <PackageReference Include="Grpc.Tools" Version="2.57.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Events/Events.IntegrationTests/Events.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.IntegrationTests/Events.IntegrationTests.csproj
@@ -9,9 +9,9 @@
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.1.0" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Events/Events.IntegrationTests/Events.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.IntegrationTests/Events.IntegrationTests.csproj
@@ -1,41 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-      <AssemblyName>Energinet.DataHub.Wholesale.Events.IntegrationTests</AssemblyName>
-      <RootNamespace>Energinet.DataHub.Wholesale.Events.IntegrationTests</RootNamespace>
-    </PropertyGroup>
-    <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
-      <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
-      <PackageReference Include="FluentAssertions" Version="6.12.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-      <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
-      <PackageReference Include="xunit" Version="2.5.1" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-      <PackageReference Include="coverlet.collector" Version="6.0.0">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-      <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\..\..\database-migration\DatabaseMigration.csproj" />
-      <ProjectReference Include="..\..\Test.Core\Test.Core.csproj" />
-      <ProjectReference Include="..\Events.Infrastructure\Events.Infrastructure.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <None Update="integrationtest.local.settings.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
+  <PropertyGroup>
+    <AssemblyName>Energinet.DataHub.Wholesale.Events.IntegrationTests</AssemblyName>
+    <RootNamespace>Energinet.DataHub.Wholesale.Events.IntegrationTests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\database-migration\DatabaseMigration.csproj" />
+    <ProjectReference Include="..\..\Test.Core\Test.Core.csproj" />
+    <ProjectReference Include="..\Events.Infrastructure\Events.Infrastructure.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="integrationtest.local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/source/dotnet/wholesale-api/Events/Events.UnitTests/Events.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.UnitTests/Events.UnitTests.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />
-    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Events/Events.UnitTests/Events.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.UnitTests/Events.UnitTests.csproj
@@ -1,39 +1,35 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-      <AssemblyName>Energinet.DataHub.Wholesale.Events.UnitTests</AssemblyName>
-      <RootNamespace>Energinet.DataHub.Wholesale.Events.UnitTests</RootNamespace>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
-    <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
-      <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
-      <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
-      <PackageReference Include="FluentAssertions" Version="6.12.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-      <PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />
-      <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
-      <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-      <PackageReference Include="xunit" Version="2.5.1" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-      <PackageReference Include="coverlet.collector" Version="6.0.0">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-      <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\..\Test.Core\Test.Core.csproj" />
-      <ProjectReference Include="..\Events.Infrastructure\Events.Infrastructure.csproj" />
-    </ItemGroup>
+  <PropertyGroup>
+    <AssemblyName>Energinet.DataHub.Wholesale.Events.UnitTests</AssemblyName>
+    <RootNamespace>Energinet.DataHub.Wholesale.Events.UnitTests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Test.Core\Test.Core.csproj" />
+    <ProjectReference Include="..\Events.Infrastructure\Events.Infrastructure.csproj" />
+  </ItemGroup>
 </Project>

--- a/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
+++ b/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
@@ -30,11 +30,7 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
+++ b/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
@@ -18,7 +18,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.5.1" />

--- a/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
+++ b/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
@@ -20,9 +20,9 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.1.0" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
@@ -30,11 +30,11 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="4.4.2" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.10" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
@@ -42,7 +42,7 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -61,13 +61,6 @@ limitations under the License.
     <None Update="integrationtest.local.settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi/TestControllers/Test1Controller.cs
+++ b/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi/TestControllers/Test1Controller.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Asp.Versioning;
 using Energinet.DataHub.Wholesale.WebApi.V3;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi/TestControllers/Test2Controller.cs
+++ b/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi/TestControllers/Test2Controller.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Asp.Versioning;
 using Energinet.DataHub.Wholesale.WebApi.V3;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi.UnitTests.csproj
@@ -38,10 +38,10 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="4.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi.UnitTests.csproj
@@ -49,14 +49,7 @@ limitations under the License.
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/dotnet/wholesale-api/WebApi/ConfigureSwaggerOptions.cs
+++ b/source/dotnet/wholesale-api/WebApi/ConfigureSwaggerOptions.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Asp.Versioning.ApiExplorer;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;

--- a/source/dotnet/wholesale-api/WebApi/Startup.cs
+++ b/source/dotnet/wholesale-api/WebApi/Startup.cs
@@ -14,6 +14,8 @@
 
 using System.Reflection;
 using System.Text.Json.Serialization;
+using Asp.Versioning;
+using Asp.Versioning.ApiExplorer;
 using Energinet.DataHub.Core.App.Common.Diagnostics.HealthChecks;
 using Energinet.DataHub.Core.App.FunctionApp.Middleware.CorrelationId;
 using Energinet.DataHub.Core.App.WebApp.Authentication;
@@ -30,8 +32,6 @@ using Energinet.DataHub.Wholesale.WebApi.Configuration;
 using Energinet.DataHub.Wholesale.WebApi.Configuration.Options;
 using Energinet.DataHub.Wholesale.WebApi.HealthChecks;
 using Energinet.DataHub.Wholesale.WebApi.HealthChecks.DataLake;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.Azure;
 using Microsoft.OpenApi.Models;
 
@@ -87,14 +87,13 @@ public class Startup
             config.AddSecurityRequirement(securityRequirement);
         });
 
-        serviceCollection.AddApiVersioning(config =>
+        var apiVersioningBuilder = serviceCollection.AddApiVersioning(config =>
         {
             config.DefaultApiVersion = new ApiVersion(3, 0);
             config.AssumeDefaultVersionWhenUnspecified = true;
             config.ReportApiVersions = true;
         });
-
-        serviceCollection.AddVersionedApiExplorer(setup =>
+        apiVersioningBuilder.AddApiExplorer(setup =>
         {
             setup.GroupNameFormat = "'v'VVV";
             setup.SubstituteApiVersionInUrl = true;

--- a/source/dotnet/wholesale-api/WebApi/V3/Batch/BatchController.cs
+++ b/source/dotnet/wholesale-api/WebApi/V3/Batch/BatchController.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.ComponentModel.DataAnnotations;
+using Asp.Versioning;
 using Energinet.DataHub.Core.App.Common.Abstractions.Users;
 using Energinet.DataHub.Wholesale.Batches.Interfaces;
 using Energinet.DataHub.Wholesale.Common.Security;
@@ -67,7 +68,7 @@ public class BatchController : V3ControllerBase
     [MapToApiVersion(Version)]
     [Produces("application/json", Type = typeof(BatchDto))]
     [Authorize(Roles = Permissions.CalculationsManage)]
-    public async Task<IActionResult> GetAsync([FromRoute]Guid batchId)
+    public async Task<IActionResult> GetAsync([FromRoute] Guid batchId)
     {
         return Ok(await _batchesClient.GetAsync(batchId).ConfigureAwait(false));
     }

--- a/source/dotnet/wholesale-api/WebApi/V3/SettlementReport/SettlementReportController.cs
+++ b/source/dotnet/wholesale-api/WebApi/V3/SettlementReport/SettlementReportController.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.ComponentModel.DataAnnotations;
+using Asp.Versioning;
 using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.SettlementReports;
 using Energinet.DataHub.Wholesale.WebApi.V3.Batch;
 using Microsoft.AspNetCore.Authorization;

--- a/source/dotnet/wholesale-api/WebApi/V3/V3ControllerBase.cs
+++ b/source/dotnet/wholesale-api/WebApi/V3/V3ControllerBase.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Energinet.DataHub.Wholesale.WebApi.V3;

--- a/source/dotnet/wholesale-api/WebApi/WebApi.csproj
+++ b/source/dotnet/wholesale-api/WebApi/WebApi.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -29,7 +29,6 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="8.1.1" />
     <PackageReference Include="Energinet.DataHub.Core.Databricks.Jobs" Version="7.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.Databricks.SqlStatementExecution" Version="7.0.1" />
-    <PackageReference Include="Energinet.DataHub.Core.Logging.LoggingMiddleware " Version="3.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />

--- a/source/dotnet/wholesale-api/WebApi/WebApi.csproj
+++ b/source/dotnet/wholesale-api/WebApi/WebApi.csproj
@@ -32,9 +32,9 @@ limitations under the License.
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.13" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="7.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="7.0.13" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Energinet.DataHub.Core.Logging.LoggingMiddleware" Version="3.1.1" />

--- a/source/dotnet/wholesale-api/WebApi/WebApi.csproj
+++ b/source/dotnet/wholesale-api/WebApi/WebApi.csproj
@@ -33,9 +33,9 @@ limitations under the License.
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.13" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="7.0.10" />
-    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Energinet.DataHub.Core.Logging.LoggingMiddleware" Version="3.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">

--- a/source/dotnet/wholesale-api/WebApi/WebApi.csproj
+++ b/source/dotnet/wholesale-api/WebApi/WebApi.csproj
@@ -24,14 +24,14 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" Version="7.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="7.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="7.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.Common.Security" Version="8.1.1" />
     <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="8.1.1" />
     <PackageReference Include="Energinet.DataHub.Core.Databricks.Jobs" Version="7.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.Databricks.SqlStatementExecution" Version="7.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.13" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="7.0.13" />

--- a/source/dotnet/wholesale-api/WebApi/WebApi.csproj
+++ b/source/dotnet/wholesale-api/WebApi/WebApi.csproj
@@ -38,8 +38,8 @@ limitations under the License.
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="7.0.10" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Update="Energinet.DataHub.Core.Logging.LoggingMiddleware" Version="3.1.1" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
+    <PackageReference Include="Energinet.DataHub.Core.Logging.LoggingMiddleware" Version="3.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -50,13 +50,6 @@ limitations under the License.
     <ProjectReference Include="..\Common\Common.csproj" />
     <ProjectReference Include="..\CalculationResults\CalculationResults.Infrastructure\CalculationResults.Infrastructure.csproj" />
     <ProjectReference Include="..\Events\Events.Infrastructure\Events.Infrastructure.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Wholesale Contracts Release notes
 
+## Version 5.2.0
+
+- Bump versions of NuGet package dependencies.
+
 ## Version 5.1.0
 
 Added 'Currency' to 'AmountPerChargeResultProducedV1' and 'MonthlyAmountPerChargeResultProducedV1

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Tests/Contracts.Tests.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Tests/Contracts.Tests.csproj
@@ -1,42 +1,46 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-        <PackageReference Include="xunit" Version="2.6.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Contracts\Contracts.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <Content Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\Protos\amount_per_charge_result_produced_v1.proto">
-        <Link>amount_per_charge_result_produced_v1.proto</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <Content Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\Protos\calculation_result_completed.proto">
-        <Link>calculation_result_completed.proto</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <Content Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\Protos\energy_result_produced_v1.proto">
-        <Link>energy_result_produced_v1.proto</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <Content Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\Protos\monthly_amount_per_charge_result_produced_v1.proto">
-        <Link>monthly_amount_per_charge_result_produced_v1.proto</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Contracts\Contracts.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\Protos\amount_per_charge_result_produced_v1.proto">
+      <Link>amount_per_charge_result_produced_v1.proto</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\Protos\calculation_result_completed.proto">
+      <Link>calculation_result_completed.proto</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\Protos\energy_result_produced_v1.proto">
+      <Link>energy_result_produced_v1.proto</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\Protos\monthly_amount_per_charge_result_produced_v1.proto">
+      <Link>monthly_amount_per_charge_result_produced_v1.proto</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Tests/Contracts.Tests.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Tests/Contracts.Tests.csproj
@@ -5,14 +5,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.10.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="xunit" Version="2.6.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
@@ -31,16 +31,16 @@ limitations under the License.
         Is shown in Azure DevOps artifacts Release Notes section.
       -->
     <PackageReleaseNotes>
-        [Release Notes](https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/dotnet/Packages/Contracts.Documentation/release-notes/release-notes.md)
-        [Documentation](https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/dotnet/Packages/Contracts.Documentation/documentation.md)
+      [Release Notes](https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/dotnet/Packages/Contracts.Documentation/release-notes/release-notes.md)
+      [Documentation](https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/dotnet/Packages/Contracts.Documentation/documentation.md)
     </PackageReleaseNotes>
     <!-- PackageDescription:
         Is shown in GitHub packages "About this package" section,
         and in Visual Studio package manager view.
       -->
     <PackageDescription>
-        [Release Notes](https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/dotnet/Packages/Contracts.Documentation/release-notes/release-notes.md)
-        [Documentation](https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/dotnet/Packages/Contracts.Documentation/documentation.md)
+      [Release Notes](https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/dotnet/Packages/Contracts.Documentation/release-notes/release-notes.md)
+      [Documentation](https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/dotnet/Packages/Contracts.Documentation/documentation.md)
     </PackageDescription>
     <Description>A package containing contracts for integrations with the wholesale domain in Energinet.DataHub.</Description>
     <PackageTags>energinet;datahub;wholesale</PackageTags>

--- a/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
@@ -19,18 +19,6 @@ limitations under the License.
     <RootNamespace>Energinet.DataHub.Wholesale.Contracts</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.22.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.52.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.5.22">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Wholesale.Contracts</PackageId>
     <PackageVersion>5.1.0$(VersionSuffix)</PackageVersion>
@@ -71,6 +59,15 @@ limitations under the License.
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.22.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.52.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.5.22">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
   <ItemGroup>
     <Protobuf Include="../../wholesale-api/Events/Events.Infrastructure/IntegrationEvents/Protos/*.proto">

--- a/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
@@ -21,7 +21,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Wholesale.Contracts</PackageId>
-    <PackageVersion>5.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>5.2.0$(VersionSuffix)</PackageVersion>
     <Title>Wholesale Contracts</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>
@@ -61,9 +61,9 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.22.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.52.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.5.22">
+    <PackageReference Include="Google.Protobuf" Version="3.25.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.59.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- [x] Remove NuGet package dependencies from `Directory.Build.props`.
- [x] Remove direct use of NuGet package Microsoft.CodeAnalysis.NetAnalyzers (default enabled from .NET 5)
- [x] Update use of NuGet package Microsoft.VisualStudio.Threading.Analyzers to "include" instead of "update"
- [x] Bump NuGet package dependencies to latest versions, **except** Databricks packages (because Alexander is working on this in a separate PR).

# Important
Notice we could not fix the following:
![image](https://github.com/Energinet-DataHub/opengeh-wholesale/assets/51327761/ce73e498-f774-4d6c-a7c7-475fc1bb0083)

Because its used by "db-up":
![image](https://github.com/Energinet-DataHub/opengeh-wholesale/assets/51327761/596dfd36-ea55-49a3-9f9a-01d60b37e1ac)

Part of: https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/team-mandalorian/69