### PR TITLE
test: aggregate_net_exchange_per_neighbour_ga qualities

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/energy/exchange_aggregators.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/exchange_aggregators.py
@@ -30,10 +30,11 @@ exchange_out_to_grid_area = "ExOut_ToGridArea"
 exchange_out_from_grid_area = "ExOut_FromGridArea"
 
 
-# Function to aggregate net exchange per neighbouring grid areas
 def aggregate_net_exchange_per_neighbour_ga(
     quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
 ) -> EnergyResults:
+    """Function to aggregate net exchange per neighbouring grid areas."""
+
     df = quarterly_metering_point_time_series.df.where(
         F.col(Colname.metering_point_type) == MeteringPointType.EXCHANGE.value
     )
@@ -58,24 +59,56 @@ def aggregate_net_exchange_per_neighbour_ga(
     )
 
     from_qualities = "from_qualities"
+    to_time_window = "to_time_window"
+    from_time_window = "from_time_window"
+
+    # Workaround for ambiguous "time_window" column in select after join
+    exchange_to = exchange_to.withColumnRenamed(Colname.time_window, to_time_window)
+    exchange_from = exchange_from.withColumnRenamed(
+        Colname.time_window, from_time_window
+    )
+
     exchange = (
-        exchange_to.join(exchange_from, [Colname.time_window], "inner")
-        .where(
-            exchange_to[exchange_in_to_grid_area]
-            == exchange_from[exchange_out_from_grid_area]
+        # Outer self join: Outer is required as we must support cases where only metering point(s)
+        # in one direction between two neighboring grid areas exist
+        exchange_to.join(
+            exchange_from,
+            (exchange_to[to_time_window] == exchange_from[from_time_window])
+            & (
+                exchange_to[exchange_in_to_grid_area]
+                == exchange_from[exchange_out_from_grid_area]
+            )
+            & (
+                exchange_to[exchange_in_from_grid_area]
+                == exchange_from[exchange_out_to_grid_area]
+            ),
+            "outer",
         )
-        .where(
-            exchange_to[exchange_in_from_grid_area]
-            == exchange_from[exchange_out_to_grid_area]
-        )
+        # Since both exchange_from or exchange_to can be missing we need to coalesce all columns
         .select(
-            exchange_to["*"],
-            exchange_from[from_sum],
-            exchange_from[Colname.qualities].alias(from_qualities),
+            F.coalesce(
+                exchange_to[to_time_window], exchange_from[from_time_window]
+            ).alias(Colname.time_window),
+            F.coalesce(
+                exchange_to[exchange_in_to_grid_area],
+                exchange_from[exchange_out_from_grid_area],
+            ).alias(Colname.to_grid_area),
+            F.coalesce(
+                exchange_to[exchange_in_from_grid_area],
+                exchange_from[exchange_out_to_grid_area],
+            ).alias(Colname.from_grid_area),
+            F.coalesce(exchange_to[to_sum], F.lit(0)).alias(to_sum),
+            F.coalesce(exchange_from[from_sum], F.lit(0)).alias(from_sum),
+            F.coalesce(exchange_from[Colname.qualities], F.array()).alias(
+                from_qualities
+            ),
+            F.coalesce(exchange_to[Colname.qualities], F.array()).alias(
+                Colname.qualities
+            ),
         )
+        # Calculate netto sum between neighboring grid areas
         .withColumn(Colname.sum_quantity, F.col(to_sum) - F.col(from_sum))
-        .withColumnRenamed(exchange_in_to_grid_area, Colname.to_grid_area)
-        .withColumnRenamed(exchange_in_from_grid_area, Colname.from_grid_area)
+        # Finally select the result columns
         .select(
             Colname.to_grid_area,
             Colname.from_grid_area,

--- a/source/databricks/calculation_engine/package/calculation/preparation/transformations/metering_point_time_series.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/transformations/metering_point_time_series.py
@@ -27,8 +27,6 @@ from package.calculation_input.schemas import (
 )
 
 
-# TODO BJM: Settle on name: Basis data ts? Enriched ts? Metering point ts? Other?
-#           And update file names, suts, variables etc
 def get_metering_point_time_series(
     raw_time_series_points_df: DataFrame,
     metering_point_periods_df: DataFrame,
@@ -36,7 +34,10 @@ def get_metering_point_time_series(
     period_end_datetime: datetime,
 ) -> DataFrame:
     """
-    Get enriched time-series points - both for metering points with hourly and quarterly resolution.
+    Get metering point time-series points - both for metering points with hourly and quarterly resolution.
+    All missing time series points for a given metering point is added with quantity=0 and quality=MISSING.
+    Thus, there will be no missing points for a given metering point when it's connected. It may, however, not be
+    connected for the entire period of the calculation.
     """
     assert_schema(raw_time_series_points_df.schema, time_series_point_schema)
     assert_schema(metering_point_periods_df.schema, metering_point_period_schema)

--- a/source/databricks/calculation_engine/tests/calculation/energy/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga.py
@@ -72,9 +72,6 @@ class TestWhenValidInput:
         # Act
         actual = sut(metering_point_time_series)
 
-        metering_point_time_series.df.show()
-        actual.df.show()
-
         # Assert
         actual_rows = actual.df.collect()
         assert len(actual_rows) == 2

--- a/source/databricks/calculation_engine/tests/calculation/energy/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga.py
@@ -1,0 +1,82 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from pyspark.sql import SparkSession
+
+from package.calculation.energy.exchange_aggregators import (
+    aggregate_net_exchange_per_neighbour_ga as sut,
+)
+import tests.calculation.energy.quarterly_metering_point_time_series_factories as factories
+from package.codelists import QuantityQuality
+from package.constants import Colname
+
+
+class TestWhenValidInput:
+    @pytest.mark.parametrize(
+        "from_ga_qualities, to_ga_qualities, expected_qualities",
+        [
+            # Case where no "from" metering point exists
+            ([], [QuantityQuality.ESTIMATED], [QuantityQuality.ESTIMATED]),
+            # Case where no "to" metering point exists
+            ([QuantityQuality.ESTIMATED], [], [QuantityQuality.ESTIMATED]),
+            (
+                [QuantityQuality.ESTIMATED],
+                [QuantityQuality.ESTIMATED],
+                [QuantityQuality.ESTIMATED],
+            ),
+            (
+                [QuantityQuality.ESTIMATED, QuantityQuality.ESTIMATED],
+                [],
+                [QuantityQuality.ESTIMATED],
+            ),
+            (
+                [QuantityQuality.ESTIMATED, QuantityQuality.MISSING],
+                [QuantityQuality.ESTIMATED, QuantityQuality.CALCULATED],
+                [
+                    QuantityQuality.CALCULATED,
+                    QuantityQuality.ESTIMATED,
+                    QuantityQuality.MISSING,
+                ],
+            ),
+        ],
+    )
+    def test_returns_distinct_qualities_from_both_to_and_from_ga(
+        self,
+        spark: SparkSession,
+        from_ga_qualities: list[QuantityQuality],
+        to_ga_qualities: list[QuantityQuality],
+        expected_qualities: list[QuantityQuality],
+    ) -> None:
+        # Arrange
+        rows = [
+            *[factories.create_to_row(quality=quality) for quality in to_ga_qualities],
+            *[
+                factories.create_from_row(quality=quality)
+                for quality in from_ga_qualities
+            ],
+        ]
+        metering_point_time_series = factories.create(spark, rows)
+        expected_qualities = sorted([q.value for q in expected_qualities])
+
+        # Act
+        actual = sut(metering_point_time_series)
+
+        metering_point_time_series.df.show()
+        actual.df.show()
+
+        # Assert
+        actual_rows = actual.df.collect()
+        assert len(actual_rows) == 2
+        assert sorted(actual_rows[0][Colname.qualities]) == expected_qualities
+        assert sorted(actual_rows[1][Colname.qualities]) == expected_qualities

--- a/source/databricks/calculation_engine/tests/calculation/energy/quarterly_metering_point_time_series_factories.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/quarterly_metering_point_time_series_factories.py
@@ -1,0 +1,122 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+from decimal import Decimal
+
+from pyspark.sql import Row, SparkSession
+
+from package.calculation.preparation.quarterly_metering_point_time_series import (
+    QuarterlyMeteringPointTimeSeries,
+    _quarterly_metering_point_time_series_schema,
+)
+from package.codelists import MeteringPointType, QuantityQuality
+from package.constants import Colname
+
+DEFAULT_GRID_AREA = "100"
+DEFAULT_NEIGHBOUR_GRID_AREA = "200"
+DEFAULT_OBSERVATION_TIME = datetime.datetime.now()
+DEFAULT_QUANTITY = Decimal("999.123456")
+DEFAULT_QUALITY = QuantityQuality.MEASURED
+DEFAULT_METERING_POINT_ID = "1234567890123"
+DEFAULT_METERING_POINT_TYPE = MeteringPointType.CONSUMPTION
+
+
+def create_row(
+    grid_area: str = DEFAULT_GRID_AREA,
+    to_grid_area: str = None,
+    from_grid_area: str = None,
+    metering_point_id: str = DEFAULT_METERING_POINT_ID,
+    metering_point_type: MeteringPointType = DEFAULT_METERING_POINT_TYPE,
+    observation_time: datetime = DEFAULT_OBSERVATION_TIME,
+    quantity: int | Decimal = DEFAULT_QUANTITY,
+    quality: QuantityQuality = DEFAULT_QUALITY,
+) -> Row:
+    if isinstance(quantity, int):
+        quantity = Decimal(quantity)
+
+    row = {
+        Colname.grid_area: grid_area,
+        Colname.to_grid_area: to_grid_area,
+        Colname.from_grid_area: from_grid_area,
+        Colname.metering_point_id: metering_point_id,
+        Colname.metering_point_type: metering_point_type.value,
+        Colname.observation_time: observation_time,
+        Colname.quantity: quantity,
+        Colname.quality: quality.value,
+        Colname.energy_supplier_id: None,
+        Colname.balance_responsible_id: None,
+        Colname.settlement_method: None,
+        Colname.time_window: {
+            Colname.start: observation_time,
+            Colname.end: observation_time + datetime.timedelta(minutes=15),
+        },
+    }
+
+    return Row(**row)
+
+
+def create_from_row(
+    grid_area: str = DEFAULT_GRID_AREA,
+    to_grid_area: str = DEFAULT_NEIGHBOUR_GRID_AREA,
+    metering_point_id: str = DEFAULT_METERING_POINT_ID,
+    observation_time: datetime = DEFAULT_OBSERVATION_TIME,
+    quantity: int | Decimal = DEFAULT_QUANTITY,
+    quality: QuantityQuality = DEFAULT_QUALITY,
+) -> Row:
+    """Create a row representing exchange leaving the (default) grid area."""
+    return create_row(
+        grid_area=grid_area,
+        to_grid_area=to_grid_area,
+        from_grid_area=grid_area,
+        metering_point_id=metering_point_id,
+        metering_point_type=MeteringPointType.EXCHANGE,
+        observation_time=observation_time,
+        quantity=quantity,
+        quality=quality,
+    )
+
+
+def create_to_row(
+    grid_area: str = DEFAULT_GRID_AREA,
+    from_grid_area: str = DEFAULT_NEIGHBOUR_GRID_AREA,
+    metering_point_id: str = DEFAULT_METERING_POINT_ID,
+    observation_time: datetime = DEFAULT_OBSERVATION_TIME,
+    quantity: int | Decimal = DEFAULT_QUANTITY,
+    quality: QuantityQuality = DEFAULT_QUALITY,
+) -> Row:
+    """Create a row representing exchange entering the grid area."""
+    return create_row(
+        grid_area=grid_area,
+        to_grid_area=grid_area,
+        from_grid_area=from_grid_area,
+        metering_point_id=metering_point_id,
+        metering_point_type=MeteringPointType.EXCHANGE,
+        observation_time=observation_time,
+        quantity=quantity,
+        quality=quality,
+    )
+
+
+def create(
+    spark: SparkSession, data: None | Row | list[Row] = None
+) -> QuarterlyMeteringPointTimeSeries:
+    if data is None:
+        data = [create_row()]
+    elif isinstance(data, Row):
+        data = [data]
+    df = spark.createDataFrame(
+        data, schema=_quarterly_metering_point_time_series_schema
+    )
+    return QuarterlyMeteringPointTimeSeries(df)


### PR DESCRIPTION
According to SME (updated in decision log in Confluence) we must support cases where only exchange metering point(s) of neighboring grid areas in one direction exist. Support for this is added in this PR in addition to tests of aggregated distinct qualities.