### PR TITLE
refac: Settlement domain test to BDD style

### DIFF
--- a/source/dotnet/domain-tests/Fixtures/CalculationScenario.cs
+++ b/source/dotnet/domain-tests/Fixtures/CalculationScenario.cs
@@ -15,14 +15,13 @@
 using Energinet.DataHub.Wholesale.Contracts.Events;
 using Energinet.DataHub.Wholesale.Contracts.IntegrationEvents;
 using Energinet.DataHub.Wholesale.DomainTests.Clients.v3;
-using Energinet.DataHub.Wholesale.Events.Infrastructure.IntegrationEvents;
 
 namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
 {
     public class CalculationScenario
     {
         public BatchRequestDto CalculationInput { get; set; }
-            = new BatchRequestDto();
+            = new();
 
         public IList<string> SubscribedIntegrationEventNames { get; }
             = new List<string>();

--- a/source/dotnet/domain-tests/Fixtures/Orderers/PriorityOrderer.cs
+++ b/source/dotnet/domain-tests/Fixtures/Orderers/PriorityOrderer.cs
@@ -56,7 +56,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures.Orderers
         {
             return dictionary.TryGetValue(key, out var result)
                 ? result
-                : (dictionary[key] = new TValue());
+                : dictionary[key] = new TValue();
         }
     }
 }

--- a/source/dotnet/domain-tests/Fixtures/SettlementDownloadInput.cs
+++ b/source/dotnet/domain-tests/Fixtures/SettlementDownloadInput.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Wholesale.DomainTests.Clients.v3;
+
+namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures;
+
+public class SettlementDownloadInput
+{
+    public IList<string> GridAreaCodes { get; } = new List<string>();
+
+    public ProcessType ProcessType { get; set; }
+
+    public DateTimeOffset CalculationPeriodStart { get; set; }
+
+    public DateTimeOffset CalculationPeriodEnd { get; set; }
+}

--- a/source/dotnet/domain-tests/Fixtures/SettlementReportScenarioFixture.cs
+++ b/source/dotnet/domain-tests/Fixtures/SettlementReportScenarioFixture.cs
@@ -52,7 +52,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
             return fileResponse;
         }
 
-        public async Task<string[]> SplitEntryIntoLines(ZipArchiveEntry entry)
+        public async Task<string[]> SplitEntryIntoLinesAsync(ZipArchiveEntry entry)
         {
             using var stringReader = new StreamReader(entry.Open());
             var content = await stringReader.ReadToEndAsync();

--- a/source/dotnet/domain-tests/Fixtures/SettlementReportScenarioFixture.cs
+++ b/source/dotnet/domain-tests/Fixtures/SettlementReportScenarioFixture.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO.Compression;
+using Energinet.DataHub.Wholesale.DomainTests.Clients.v3;
+using Energinet.DataHub.Wholesale.DomainTests.Fixtures.Configuration;
+using Energinet.DataHub.Wholesale.DomainTests.Fixtures.Extensions;
+using Energinet.DataHub.Wholesale.DomainTests.Fixtures.LazyFixture;
+using Xunit.Abstractions;
+
+namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
+{
+    public sealed class SettlementReportScenarioFixture : LazyFixtureBase
+    {
+        public SettlementReportScenarioFixture(IMessageSink diagnosticMessageSink)
+            : base(diagnosticMessageSink)
+        {
+            Configuration = new WholesaleDomainConfiguration();
+            ScenarioState = new SettlementReportScenarioState();
+        }
+
+        public SettlementReportScenarioState ScenarioState { get; }
+
+        /// <summary>
+        /// The actual client is not created until <see cref="OnInitializeAsync"/> has been called by the base class.
+        /// </summary>
+        private WholesaleClient_V3 WholesaleClient { get; set; } = null!;
+
+        private WholesaleDomainConfiguration Configuration { get; }
+
+        public async Task<FileResponse> StartDownloadingAsync(SettlementDownloadInput settlementDownloadInput)
+        {
+            var fileResponse = await WholesaleClient.DownloadAsync(
+                settlementDownloadInput.GridAreaCodes,
+                settlementDownloadInput.ProcessType,
+                settlementDownloadInput.CalculationPeriodStart,
+                settlementDownloadInput.CalculationPeriodEnd);
+            DiagnosticMessageSink.WriteDiagnosticMessage($"Downloading settlement report for " +
+                                                         $"grid area codes {string.Join(", ", settlementDownloadInput.GridAreaCodes.ToArray())} and" +
+                                                         $" process type {settlementDownloadInput.ProcessType} started.");
+            return fileResponse;
+        }
+
+        public async Task<string[]> SplitEntryIntoLines(ZipArchiveEntry entry)
+        {
+            using var stringReader = new StreamReader(entry.Open());
+            var content = await stringReader.ReadToEndAsync();
+            var lines = content.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            return lines;
+        }
+
+        protected override async Task OnInitializeAsync()
+        {
+            WholesaleClient = await WholesaleClientFactory.CreateWholesaleClientAsync(Configuration, useAuthentication: true);
+        }
+
+        protected override Task OnDisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+ }
+}

--- a/source/dotnet/domain-tests/Fixtures/SettlementReportScenarioState.cs
+++ b/source/dotnet/domain-tests/Fixtures/SettlementReportScenarioState.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Compression;
+using Energinet.DataHub.Wholesale.DomainTests.Clients.v3;
+
+namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures;
+
+public class SettlementReportScenarioState
+{
+    public SettlementDownloadInput SettlementDownloadInput { get; } = new();
+
+    [NotNull]
+    public FileResponse? SettlementReportFile { get; set; }
+
+    [NotNull]
+    public ZipArchive? CompressedSettlementReport { get; set; }
+
+    [NotNull]
+    public ZipArchiveEntry? Entry { get; set; }
+}

--- a/source/dotnet/domain-tests/SettlementFeatureTests.cs
+++ b/source/dotnet/domain-tests/SettlementFeatureTests.cs
@@ -65,7 +65,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
 
             [Priority(3)]
             [DomainFact]
-            public void AndThen_EntryNameShouldBeResultCsv()
+            public void AndThen_SingleEntryNameShouldBeResultCsv()
             {
                 var expected = "Result.csv";
                 Fixture.ScenarioState.Entry = Fixture.ScenarioState.CompressedSettlementReport.Entries.Single();
@@ -76,7 +76,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
 
             [Priority(4)]
             [DomainFact]
-            public async Task AndThen_EntryShouldContainCorrectGridAreaCodesAndProcessType()
+            public async Task AndThen_SingleEntryShouldContainCorrectGridAreaCodesAndProcessType()
             {
                 var expected = "543,D04,";
                 var lines = await Fixture.SplitEntryIntoLinesAsync(Fixture.ScenarioState.Entry);

--- a/source/dotnet/domain-tests/SettlementFeatureTests.cs
+++ b/source/dotnet/domain-tests/SettlementFeatureTests.cs
@@ -26,46 +26,64 @@ namespace Energinet.DataHub.Wholesale.DomainTests
     /// </summary>
     public class SettlementFeatureTests
     {
-        /// <summary>
-        /// These tests uses an authorized Wholesale client to perform requests.
-        /// </summary>
-        public class Given_Calculated : DomainTestsBase<AuthorizedClientFixture>
+        [TestCaseOrderer(
+            ordererTypeName: "Energinet.DataHub.Wholesale.DomainTests.Fixtures.Orderers.PriorityOrderer",
+            ordererAssemblyName: "Energinet.DataHub.Wholesale.DomainTests")]
+        public class SettlementReportDownloadScenario : DomainTestsBase<SettlementReportScenarioFixture>
         {
-            private static readonly DateTimeOffset _existingBatchPeriodStart = DateTimeOffset.Parse("2020-01-28T23:00:00Z");
-            private static readonly DateTimeOffset _existingBatchPeriodEnd = DateTimeOffset.Parse("2020-01-29T23:00:00Z");
-            private static readonly string _existingGridAreaCode = "543";
-
-            public Given_Calculated(LazyFixtureFactory<AuthorizedClientFixture> lazyFixtureFactory)
+            public SettlementReportDownloadScenario(LazyFixtureFactory<SettlementReportScenarioFixture> lazyFixtureFactory)
                 : base(lazyFixtureFactory)
             {
             }
 
-            [DomainFact(Skip = "Test fails on cold runs with a timeout error - expected to be fixed when switching to Databricks Serverless warehouse")]
-            public async Task WhenDownloadingSettlementReport_ResponseIsCompressedFileWithData()
+            [Priority(0)]
+            [DomainFact]
+            public void Given_SettlementDownloadInput()
             {
-                // Arrange + Act
-                var fileResponse = await Fixture.WholesaleClient.DownloadAsync(
-                    new[] { _existingGridAreaCode },
-                    Clients.v3.ProcessType.BalanceFixing,
-                    _existingBatchPeriodStart,
-                    _existingBatchPeriodEnd);
+                Fixture.ScenarioState.SettlementDownloadInput.GridAreaCodes.Add("543");
+                Fixture.ScenarioState.SettlementDownloadInput.ProcessType = Clients.v3.ProcessType.BalanceFixing;
+                Fixture.ScenarioState.SettlementDownloadInput.CalculationPeriodStart = DateTimeOffset.Parse("2020-01-28T23:00:00Z");
+                Fixture.ScenarioState.SettlementDownloadInput.CalculationPeriodEnd = DateTimeOffset.Parse("2020-01-29T23:00:00Z");
+            }
+
+            [Priority(1)]
+            [DomainFact]
+            public async Task When_SettlementReportDownloadedIsStarted()
+            {
+                Fixture.ScenarioState.SettlementReportFile = await Fixture.StartDownloadingAsync(Fixture.ScenarioState.SettlementDownloadInput);
+            }
+
+            [Priority(2)]
+            [DomainFact]
+            public void Then_SettlementReportEntriesShouldNotBeEmpty()
+            {
+                Fixture.ScenarioState.CompressedSettlementReport = new ZipArchive(Fixture.ScenarioState.SettlementReportFile.Stream, ZipArchiveMode.Read);
 
                 // Assert
-                using var compressedSettlementReport = new ZipArchive(fileResponse.Stream, ZipArchiveMode.Read);
-                compressedSettlementReport.Entries.Should().NotBeEmpty();
+                Fixture.ScenarioState.CompressedSettlementReport.Entries.Should().NotBeEmpty();
+            }
 
-                var resultEntry = compressedSettlementReport.Entries.Single();
-                resultEntry.Name.Should().Be("Result.csv");
+            [Priority(3)]
+            [DomainFact]
+            public void AndThen_FirstEntryNameShouldBeResultCsv()
+            {
+                var expected = "Result.csv";
+                Fixture.ScenarioState.Entry = Fixture.ScenarioState.CompressedSettlementReport.Entries.Single();
 
-                using var stringReader = new StreamReader(resultEntry.Open());
-                var content = await stringReader.ReadToEndAsync();
+                // Assert
+                Fixture.ScenarioState.Entry.Name.Should().Be(expected);
+            }
 
-                var lines = content.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-
-                foreach (var line in lines[1..])
+            [Priority(4)]
+            [DomainFact]
+            public async Task AndThen_FirstEntryShouldContainCorrectGridAreaCodesAndProcessType()
+            {
+                var expected = "543,D04,";
+                var lines = await Fixture.SplitEntryIntoLines(Fixture.ScenarioState.Entry);
+                foreach (var line in lines[1..]) //// The first line is the header.
                 {
-                    // Check that the line contains the expected grid area code and process type.
-                    Assert.StartsWith("543,D04,", line);
+                    // Assert
+                    line.Should().StartWith(expected);
                 }
             }
         }

--- a/source/dotnet/domain-tests/SettlementFeatureTests.cs
+++ b/source/dotnet/domain-tests/SettlementFeatureTests.cs
@@ -65,7 +65,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
 
             [Priority(3)]
             [DomainFact]
-            public void AndThen_FirstEntryNameShouldBeResultCsv()
+            public void AndThen_EntryNameShouldBeResultCsv()
             {
                 var expected = "Result.csv";
                 Fixture.ScenarioState.Entry = Fixture.ScenarioState.CompressedSettlementReport.Entries.Single();
@@ -76,10 +76,10 @@ namespace Energinet.DataHub.Wholesale.DomainTests
 
             [Priority(4)]
             [DomainFact]
-            public async Task AndThen_FirstEntryShouldContainCorrectGridAreaCodesAndProcessType()
+            public async Task AndThen_EntryShouldContainCorrectGridAreaCodesAndProcessType()
             {
                 var expected = "543,D04,";
-                var lines = await Fixture.SplitEntryIntoLines(Fixture.ScenarioState.Entry);
+                var lines = await Fixture.SplitEntryIntoLinesAsync(Fixture.ScenarioState.Entry);
                 foreach (var line in lines[1..]) //// The first line is the header.
                 {
                     // Assert


### PR DESCRIPTION
Rewritten download settlement report domain test to follow a kind of BDD.
Note that this test was previously skipped due to timeout. 

https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/team-mandalorian/80
