### PR TITLE
feat: Grid area is nullable when querying aggregated time series

### DIFF
--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/QueryAggregatedTimeSeriesStatement.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/QueryAggregatedTimeSeriesStatement.cs
@@ -55,26 +55,31 @@ public class QueryAggregatedTimeSeriesStatement : DatabricksStatement
 
     private static string CreateSqlQueryFilters(AggregatedTimeSeriesQueryParameters parameters)
     {
-        var whereClausesSql = $@"t1.{EnergyResultColumnNames.GridArea} IN ({parameters.GridArea})
-            AND t1.{EnergyResultColumnNames.TimeSeriesType} IN ('{TimeSeriesTypeMapper.ToDeltaTableValue(parameters.TimeSeriesType)}')
+        var whereClausesSql = $@"
+                t1.{EnergyResultColumnNames.TimeSeriesType} IN ('{TimeSeriesTypeMapper.ToDeltaTableValue(parameters.TimeSeriesType)}')
             AND t1.{EnergyResultColumnNames.Time} >= '{parameters.StartOfPeriod.ToString()}'
             AND t1.{EnergyResultColumnNames.Time} < '{parameters.EndOfPeriod.ToString()}'
             AND t1.{EnergyResultColumnNames.AggregationLevel} = '{AggregationLevelMapper.ToDeltaTableValue(parameters.TimeSeriesType, parameters.EnergySupplierId, parameters.BalanceResponsibleId)}'
             ";
+        if (parameters.GridArea != null)
+        {
+            whereClausesSql += $"AND t1.{EnergyResultColumnNames.GridArea} IN ({parameters.GridArea})";
+        }
+
         if (parameters.ProcessType != null)
         {
             whereClausesSql +=
-                $@"AND t1.{EnergyResultColumnNames.BatchProcessType} = '{ProcessTypeMapper.ToDeltaTableValue((ProcessType)parameters.ProcessType)}'";
+                $"AND t1.{EnergyResultColumnNames.BatchProcessType} = '{ProcessTypeMapper.ToDeltaTableValue((ProcessType)parameters.ProcessType)}'";
         }
 
         if (parameters.EnergySupplierId != null)
         {
-            whereClausesSql += $@"AND t1.{EnergyResultColumnNames.EnergySupplierId} = '{parameters.EnergySupplierId}'";
+            whereClausesSql += $"AND t1.{EnergyResultColumnNames.EnergySupplierId} = '{parameters.EnergySupplierId}'";
         }
 
         if (parameters.BalanceResponsibleId != null)
         {
-            whereClausesSql += $@"AND t1.{EnergyResultColumnNames.BalanceResponsibleId} = '{parameters.BalanceResponsibleId}'";
+            whereClausesSql += $"AND t1.{EnergyResultColumnNames.BalanceResponsibleId} = '{parameters.BalanceResponsibleId}'";
         }
 
         return whereClausesSql;

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Infrastructure/RequestCalculationResult/AggregatedTimeSeriesQueriesTests.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Infrastructure/RequestCalculationResult/AggregatedTimeSeriesQueriesTests.cs
@@ -41,7 +41,9 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
     private const string ThirdQuantity = "3.333";
     private const string FourthQuantity = "4.444";
     private const string FourthQuantityThirdCorrection = "4.555";
-    private const string GridAreaCode = "301";
+    private const string GridAreaCodeA = "101";
+    private const string GridAreaCodeB = "201";
+    private const string GridAreaCodeC = "301";
     private readonly DatabricksSqlStatementApiFixture _fixture;
 
     public AggregatedTimeSeriesQueriesTests(DatabricksSqlStatementApiFixture fixture)
@@ -55,7 +57,7 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
     public async Task GetAsync_WhenRequestFromGridOperatorTotalProduction_ReturnsResult()
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
@@ -67,11 +69,12 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             endOfPeriod: endOfPeriodFilter);
 
         // Act
-        var actual = await Sut.GetAsync(parameters);
+        var result = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
+        var actual = result.First();
 
         // Assert
-        actual.Should().NotBeNull();
         using var assertionScope = new AssertionScope();
+        result.Should().HaveCount(1);
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.TimeSeriesType.Should().Be(timeSeriesTypeFilter);
         actual.TimeSeriesPoints
@@ -87,21 +90,22 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
         // Arrange
         await AddCreatedRowsInArbitraryOrderAsync();
         var parameters = CreateQueryParameters(
+            gridArea: GridAreaCodeA,
             startOfPeriod: Instant.FromUtc(2020, 1, 1, 1, 1),
             endOfPeriod: Instant.FromUtc(2021, 1, 2, 1, 1));
 
         // Act
-        var actual = await Sut.GetAsync(parameters);
+        var result = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
 
         // Assert
-        actual.Should().BeNull();
+        result.Should().HaveCount(0);
     }
 
     [Fact]
     public async Task GetAsync_WhenRequestFromEnergySupplierTotalProduction_ReturnsResult()
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var energySupplierIdFilter = "4321987654321";
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -115,11 +119,12 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             energySupplierId: energySupplierIdFilter);
 
         // Act
-        var actual = await Sut.GetAsync(parameters);
+        var result = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
+        var actual = result.First();
 
         // Assert
-        actual.Should().NotBeNull();
         using var assertionScope = new AssertionScope();
+        result.Should().HaveCount(1);
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.TimeSeriesType.Should().Be(timeSeriesTypeFilter);
         actual.TimeSeriesPoints
@@ -141,7 +146,7 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
     public async Task GetAsync_WhenRequestFromEnergySupplierTotalProductionBadId_ReturnsNoResults()
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var energySupplierId = "badId";
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -155,17 +160,17 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             energySupplierId: energySupplierId);
 
         // Act
-        var actual = await Sut.GetAsync(parameters);
+        var result = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
 
         // Assert
-        actual.Should().BeNull();
+        result.Should().HaveCount(0);
     }
 
     [Fact]
     public async Task GetAsync_WhenRequestFromBalanceResponsibleTotalProduction_ReturnsResult()
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var balanceResponsibleIdFilter = "1234567891234";
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -180,11 +185,12 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             processType: ProcessType.BalanceFixing);
 
         // Act
-        var actual = await Sut.GetAsync(parameters);
+        var result = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
+        var actual = result.First();
 
         // Assert
-        actual.Should().NotBeNull();
         using var assertionScope = new AssertionScope();
+        result.Should().HaveCount(1);
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.TimeSeriesType.Should().Be(timeSeriesTypeFilter);
         actual.TimeSeriesPoints
@@ -198,7 +204,7 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
     public async Task GetAsync_WhenRequestFromEnergySupplierPerBalanceResponsibleTotalProduction_ReturnsResult()
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var balanceResponsibleIdFilter = "1234567891234";
         var energySupplierIdFilter = "4321987654321";
         var timeSeriesTypeFilter = TimeSeriesType.Production;
@@ -214,11 +220,12 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             balanceResponsibleId: balanceResponsibleIdFilter);
 
         // Act
-        var actual = await Sut.GetAsync(parameters);
+        var result = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
+        var actual = result.First();
 
         // Assert
-        actual.Should().NotBeNull();
         using var assertionScope = new AssertionScope();
+        result.Should().HaveCount(1);
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.TimeSeriesType.Should().Be(timeSeriesTypeFilter);
         actual.TimeSeriesPoints
@@ -232,7 +239,7 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
     public async Task GetAsync_WhenRequestFromGridOperatorTotalProductionFirstCorrectionSettlement_ReturnsResult()
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
@@ -247,11 +254,12 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             processType: processTypeFilter);
 
         // Act
-        var actual = await Sut.GetAsync(parameters);
+        var result = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
+        var actual = result.First();
 
         // Assert
-        actual.Should().NotBeNull();
         using var assertionScope = new AssertionScope();
+        result.Should().HaveCount(1);
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.TimeSeriesType.Should().Be(timeSeriesTypeFilter);
         actual.ProcessType.Should().Be(ProcessType.FirstCorrectionSettlement);
@@ -267,7 +275,7 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
     public async Task GetAsync_WhenRequestFromGridOperatorTotalProductionSecondCorrectionSettlement_ReturnsResult()
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
@@ -282,11 +290,12 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             processType: processTypeFilter);
 
         // Act
-        var actual = await Sut.GetAsync(parameters);
+        var result = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
+        var actual = result.First();
 
         // Assert
-        actual.Should().NotBeNull();
         using var assertionScope = new AssertionScope();
+        result.Should().HaveCount(1);
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.ProcessType.Should().Be(ProcessType.SecondCorrectionSettlement);
         actual.TimeSeriesType.Should().Be(timeSeriesTypeFilter);
@@ -302,7 +311,7 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
     public async Task GetAsync_WhenRequestFromGridOperatorTotalProductionThirdCorrectionSettlement_ReturnsResult()
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
@@ -317,11 +326,12 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             processType: processTypeFilter);
 
         // Act
-        var actual = await Sut.GetAsync(parameters);
+        var result = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
+        var actual = result.First();
 
         // Assert
-        actual.Should().NotBeNull();
         using var assertionScope = new AssertionScope();
+        result.Should().HaveCount(1);
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.ProcessType.Should().Be(ProcessType.ThirdCorrectionSettlement);
         actual.TimeSeriesType.Should().Be(timeSeriesTypeFilter);
@@ -337,7 +347,7 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
     public async Task GetAsync_WhenRequestFromGridOperatorForOneDay_ReturnsResult()
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 3, 0, 0);
@@ -350,11 +360,12 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             endOfPeriod: endOfPeriodFilter);
 
         // Act
-        var actual = await Sut.GetAsync(parameters);
+        var result = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
+        var actual = result.First();
 
         // Assert
-        actual.Should().NotBeNull();
         using var assertionScope = new AssertionScope();
+        result.Should().HaveCount(1);
         actual!.GridArea.Should().Be(gridAreaFilter);
         actual.TimeSeriesType.Should().Be(timeSeriesTypeFilter);
         actual.TimeSeriesPoints
@@ -369,7 +380,7 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
     public async Task GetAsync_WhenRequestFromGridOperatorStartAndEndDataAreEqual_ReturnsNoResult()
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
@@ -384,16 +395,42 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             processType: ProcessType.BalanceFixing);
 
         // Act
-        var actual = await Sut.GetAsync(parameters);
+        var result = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
 
         // Assert
-        actual.Should().BeNull();
+        result.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public async Task GetAsync_RequestFromEnergySupplierPerBalanceResponsibleTotalProduction_ReturnsTwoResults()
+    {
+        // Arrange
+        var balanceResponsibleIdFilter = "1234567891234";
+        var energySupplierIdFilter = "4321987654321";
+        var timeSeriesTypeFilter = TimeSeriesType.Production;
+        var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
+        var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
+        var parameters = CreateQueryParameters(
+            timeSeriesType: timeSeriesTypeFilter,
+            startOfPeriod: startOfPeriodFilter,
+            endOfPeriod: endOfPeriodFilter,
+            energySupplierId: energySupplierIdFilter,
+            balanceResponsibleId: balanceResponsibleIdFilter,
+            processType: ProcessType.BalanceFixing);
+
+        // Act
+        var results = await Sut.GetAsync(parameters).ToListAsync(CancellationToken.None);
+
+        // Assert
+        results.Should().HaveCount(2);
+        results.Select(result => result.GridArea).Should().Equal(GridAreaCodeC, GridAreaCodeB);
+        results.Should().AllSatisfy(aggregatedTimeSeries => aggregatedTimeSeries.TimeSeriesType.Should().Be(timeSeriesTypeFilter));
     }
 
     [Fact]
     public async Task GetLatestCorrectionAsync_WhenLatestCorrectionSettlementIsThirdCorrection_ReturnsThirdCorrection()
     {
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
@@ -405,17 +442,19 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             gridAreaFilter);
 
         // Act
-        var actual = await Sut.GetLatestCorrectionAsync(parameters);
+        var result = await Sut.GetLatestCorrectionAsync(parameters).ToListAsync(CancellationToken.None);
+        var actual = result.First();
 
         // Assert
-        actual.Should().NotBeNull();
+        using var assertionScope = new AssertionScope();
+        result.Should().HaveCount(1);
         actual!.ProcessType.Should().Be(ProcessType.ThirdCorrectionSettlement);
     }
 
     [Fact]
     public async Task GetLatestCorrectionAsync_WhenLatestCorrectionSettlementIsSecondCorrection_ReturnsSecondCorrection()
     {
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
@@ -427,17 +466,19 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             gridAreaFilter);
 
         // Act
-        var actual = await Sut.GetLatestCorrectionAsync(parameters);
+        var result = await Sut.GetLatestCorrectionAsync(parameters).ToListAsync(CancellationToken.None);
+        var actual = result.First();
 
         // Assert
-        actual.Should().NotBeNull();
+        using var assertionScope = new AssertionScope();
+        result.Should().HaveCount(1);
         actual!.ProcessType.Should().Be(ProcessType.SecondCorrectionSettlement);
     }
 
     [Fact]
     public async Task GetLatestCorrectionAsync_WhenLatestCorrectionSettlementIsFirstCorrection_ReturnsFirstCorrection()
     {
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
@@ -449,17 +490,19 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             gridAreaFilter);
 
         // Act
-        var actual = await Sut.GetLatestCorrectionAsync(parameters);
+        var result = await Sut.GetLatestCorrectionAsync(parameters).ToListAsync(CancellationToken.None);
+        var actual = result.First();
 
         // Assert
-        actual.Should().NotBeNull();
+        using var assertionScope = new AssertionScope();
+        result.Should().HaveCount(1);
         actual!.ProcessType.Should().Be(ProcessType.FirstCorrectionSettlement);
     }
 
     [Fact]
     public async Task GetLatestCorrectionAsync_WhenNoCorrectionsExists_ReturnsNoResult()
     {
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
@@ -471,17 +514,17 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             gridAreaFilter);
 
         // Act
-        var actual = await Sut.GetLatestCorrectionAsync(parameters);
+        var actual = await Sut.GetLatestCorrectionAsync(parameters).ToListAsync(CancellationToken.None);
 
         // Assert
-        actual.Should().BeNull();
+        actual.Should().HaveCount(0);
     }
 
     [Fact]
     public async Task GetLatestCorrectionAsync_WhenProcessTypeIsDefined_ThrowsException()
     {
         // Arrange
-        var gridAreaFilter = GridAreaCode;
+        var gridAreaFilter = GridAreaCodeC;
         var timeSeriesTypeFilter = TimeSeriesType.Production;
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
         var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
@@ -492,9 +535,10 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             gridAreaFilter,
             processType: ProcessType.BalanceFixing);
 
-        var act = () => Sut.GetLatestCorrectionAsync(parameters);
+        // Act
+        var act = async () => await Sut.GetLatestCorrectionAsync(parameters).ToListAsync();
 
-        // Act and Assert
+        // Assert
         await act.Should().ThrowAsync<ArgumentException>(
             "The process type will be overwritten when fetching the latest correction.",
             parameters.ProcessType);
@@ -504,7 +548,7 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
         TimeSeriesType? timeSeriesType = null,
         Instant? startOfPeriod = null,
         Instant? endOfPeriod = null,
-        string gridArea = "101",
+        string? gridArea = null,
         string? energySupplierId = null,
         string? balanceResponsibleId = null,
         ProcessType? processType = null)
@@ -534,29 +578,33 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
 
         const string energySupplier = "4321987654321";
         const string balanceResponsibleId = "1234567891234";
-        var row1 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCode, quantity: FirstQuantity);
-        var row2 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondHour, gridArea: GridAreaCode, quantity: SecondQuantity);
+        var row1 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCodeC, quantity: FirstQuantity);
+        var row2 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondHour, gridArea: GridAreaCodeC, quantity: SecondQuantity);
 
-        var row3 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: secondHour, gridArea: GridAreaCode, quantity: ThirdQuantity, batchExecutionTimeStart: "2022-03-12T03:00:00.000Z");
-        var row4 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: thirdHour, gridArea: GridAreaCode, quantity: FourthQuantity, batchExecutionTimeStart: "2022-03-12T03:00:00.000Z");
+        var row3 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: secondHour, gridArea: GridAreaCodeC, quantity: ThirdQuantity, batchExecutionTimeStart: "2022-03-12T03:00:00.000Z");
+        var row4 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: thirdHour, gridArea: GridAreaCodeC, quantity: FourthQuantity, batchExecutionTimeStart: "2022-03-12T03:00:00.000Z");
 
-        var row5 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCode, quantity: FirstQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndGridArea, energySupplierId: energySupplier);
-        var row6 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: secondHour, gridArea: GridAreaCode, quantity: SecondQuantity, aggregationLevel: DeltaTableAggregationLevel.BalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId);
+        var row5 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCodeC, quantity: FirstQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndGridArea, energySupplierId: energySupplier);
+        var row6 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, time: secondHour, gridArea: GridAreaCodeC, quantity: SecondQuantity, aggregationLevel: DeltaTableAggregationLevel.BalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId);
 
-        var row7 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondHour, gridArea: GridAreaCode, quantity: ThirdQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId, energySupplierId: energySupplier);
+        var row7 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondHour, gridArea: GridAreaCodeC, quantity: ThirdQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId, energySupplierId: energySupplier);
+        var row8 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: thirdHour, gridArea: GridAreaCodeB, quantity: FourthQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId, energySupplierId: energySupplier);
 
-        var row1FirstCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, batchProcessType: DeltaTableProcessType.FirstCorrectionSettlement, time: firstHour, gridArea: GridAreaCode, quantity: FirstQuantityFirstCorrection);
-        var row2FirstCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, batchProcessType: DeltaTableProcessType.FirstCorrectionSettlement, time: secondHour, gridArea: GridAreaCode, quantity: SecondQuantityFirstCorrection);
+        var row9 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCodeA, quantity: FirstQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea);
+        var row10 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: thirdHour, gridArea: GridAreaCodeB, quantity: FourthQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId, energySupplierId: energySupplier);
 
-        var row1SecondCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, batchProcessType: DeltaTableProcessType.SecondCorrectionSettlement, time: firstHour, gridArea: GridAreaCode, quantity: FirstQuantitySecondCorrection);
-        var row2SecondCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, batchProcessType: DeltaTableProcessType.SecondCorrectionSettlement, time: secondHour, gridArea: GridAreaCode, quantity: SecondQuantitySecondCorrection);
+        var row1FirstCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, batchProcessType: DeltaTableProcessType.FirstCorrectionSettlement, time: firstHour, gridArea: GridAreaCodeC, quantity: FirstQuantityFirstCorrection);
+        var row2FirstCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, batchProcessType: DeltaTableProcessType.FirstCorrectionSettlement, time: secondHour, gridArea: GridAreaCodeC, quantity: SecondQuantityFirstCorrection);
 
-        var row1ThirdCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: thirdCalculationResultId, batchProcessType: DeltaTableProcessType.ThirdCorrectionSettlement, time: firstHour, gridArea: GridAreaCode, quantity: FirstQuantityThirdCorrection);
-        var row2ThirdCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: thirdCalculationResultId, batchProcessType: DeltaTableProcessType.ThirdCorrectionSettlement, time: secondHour, gridArea: GridAreaCode, quantity: SecondQuantityThirdCorrection);
-        var row4ThirdCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: thirdCalculationResultId, batchProcessType: DeltaTableProcessType.ThirdCorrectionSettlement, time: thirdHour, gridArea: GridAreaCode, quantity: FourthQuantityThirdCorrection);
+        var row1SecondCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, batchProcessType: DeltaTableProcessType.SecondCorrectionSettlement, time: firstHour, gridArea: GridAreaCodeC, quantity: FirstQuantitySecondCorrection);
+        var row2SecondCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: secondCalculationResultId, batchProcessType: DeltaTableProcessType.SecondCorrectionSettlement, time: secondHour, gridArea: GridAreaCodeC, quantity: SecondQuantitySecondCorrection);
 
-        var row1SecondDay = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondDay, gridArea: GridAreaCode, quantity: FirstQuantity);
-        var row1ThirdDay = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: thirdDay, gridArea: GridAreaCode, quantity: SecondQuantity);
+        var row1ThirdCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: thirdCalculationResultId, batchProcessType: DeltaTableProcessType.ThirdCorrectionSettlement, time: firstHour, gridArea: GridAreaCodeC, quantity: FirstQuantityThirdCorrection);
+        var row2ThirdCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: thirdCalculationResultId, batchProcessType: DeltaTableProcessType.ThirdCorrectionSettlement, time: secondHour, gridArea: GridAreaCodeC, quantity: SecondQuantityThirdCorrection);
+        var row4ThirdCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: thirdCalculationResultId, batchProcessType: DeltaTableProcessType.ThirdCorrectionSettlement, time: thirdHour, gridArea: GridAreaCodeC, quantity: FourthQuantityThirdCorrection);
+
+        var row1SecondDay = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondDay, gridArea: GridAreaCodeC, quantity: FirstQuantity);
+        var row1ThirdDay = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: thirdDay, gridArea: GridAreaCodeC, quantity: SecondQuantity);
 
         var rows = new List<IReadOnlyCollection<string>>
         {
@@ -567,6 +615,9 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             row5,
             row6,
             row7,
+            row8,
+            row9,
+            row10,
             row1SecondDay,
             row1ThirdDay,
         };

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults/IAggregatedTimeSeriesQueries.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults/IAggregatedTimeSeriesQueries.cs
@@ -19,14 +19,14 @@ namespace Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationR
 public interface IAggregatedTimeSeriesQueries
 {
     /// <summary>
-    /// Get the latest aggregated time series
+    /// Gets the latest aggregated time series
     /// </summary>
-    /// <returns>Returns null if the aggregated time series does not contain any points.</returns>
-    Task<AggregatedTimeSeries?> GetAsync(AggregatedTimeSeriesQueryParameters parameters);
+    /// <returns>Returns an empty list if the aggregated time series does not contain any points.</returns>
+    IAsyncEnumerable<AggregatedTimeSeries> GetAsync(AggregatedTimeSeriesQueryParameters parameters);
 
     /// <summary>
-    /// Get the most recent aggregated time series for the last correction settlements.
+    /// Gets the most recent aggregated time series for the last correction settlements.
     /// </summary>
-    /// <returns>Returns null if the aggregated time series does not contain any points.</returns>
-    Task<AggregatedTimeSeries?> GetLatestCorrectionAsync(AggregatedTimeSeriesQueryParameters parameters);
+    /// <returns>Returns an empty list if the aggregated time series does not contain any points.</returns>
+    IAsyncEnumerable<AggregatedTimeSeries> GetLatestCorrectionAsync(AggregatedTimeSeriesQueryParameters parameters);
 }

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults/Model/EnergyResults/AggregatedTimeSeriesQueryParameters.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults/Model/EnergyResults/AggregatedTimeSeriesQueryParameters.cs
@@ -21,7 +21,7 @@ public record AggregatedTimeSeriesQueryParameters(
     TimeSeriesType TimeSeriesType,
     Instant StartOfPeriod,
     Instant EndOfPeriod,
-    string GridArea,
+    string? GridArea,
     string? EnergySupplierId,
     string? BalanceResponsibleId,
     ProcessType? ProcessType = null);

--- a/source/dotnet/wholesale-api/Edi.UnitTests/AggregatedTimeSeriesRequestHandlerTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/AggregatedTimeSeriesRequestHandlerTests.cs
@@ -59,7 +59,7 @@ public class AggregatedTimeSeriesRequestHandlerTests
         var aggregatedTimeSeries = CreateAggregatedTimeSeries();
         aggregatedTimeSeriesQueries
             .Setup(parameters => parameters.GetAsync(It.IsAny<AggregatedTimeSeriesQueryParameters>()))
-            .ReturnsAsync(() => aggregatedTimeSeries);
+            .Returns(() => aggregatedTimeSeries.ToAsyncEnumerable());
 
         validator.Setup(vali => vali.Validate(
                 It.IsAny<AggregatedTimeSeriesRequest>()))
@@ -112,7 +112,7 @@ public class AggregatedTimeSeriesRequestHandlerTests
 
         aggregatedTimeSeriesQueries
             .Setup(parameters => parameters.GetAsync(It.IsAny<AggregatedTimeSeriesQueryParameters>()))
-            .ReturnsAsync(() => null);
+            .Returns(() => new List<AggregatedTimeSeries>().ToAsyncEnumerable());
 
         var sut = new AggregatedTimeSeriesRequestHandler(
             senderMock.Object,
@@ -139,7 +139,7 @@ public class AggregatedTimeSeriesRequestHandlerTests
 
     [Theory]
     [InlineAutoMoqData]
-    public async Task ProcessAsync_WhenNoCalculationResult_SendsRejectedEdiMessage(
+    public async Task ProcessAsync_WhenNoAggregatedTimeSeries_SendsRejectedEdiMessage(
         [Frozen] Mock<IAggregatedTimeSeriesQueries> aggregatedTimeSeriesQueries,
         [Frozen] Mock<IEdiClient> senderMock,
         [Frozen] Mock<AggregatedTimeSeriesRequestFactory> aggregatedTimeSeriesRequestMessageParseMock,
@@ -163,7 +163,7 @@ public class AggregatedTimeSeriesRequestHandlerTests
             .Setup(parameters =>
                 parameters.GetAsync(
                     It.IsAny<AggregatedTimeSeriesQueryParameters>()))
-            .ReturnsAsync(() => null);
+            .Returns(() => new List<AggregatedTimeSeries>().ToAsyncEnumerable());
 
         var sut = new AggregatedTimeSeriesRequestHandler(
             senderMock.Object,
@@ -189,12 +189,18 @@ public class AggregatedTimeSeriesRequestHandlerTests
             Times.Once);
     }
 
-    private AggregatedTimeSeries CreateAggregatedTimeSeries()
+    private List<AggregatedTimeSeries> CreateAggregatedTimeSeries()
     {
-        return new AggregatedTimeSeries(
-            gridArea: "543",
-            timeSeriesPoints: new EnergyTimeSeriesPoint[] { new(DateTime.Now, 0, new List<QuantityQuality> { QuantityQuality.Measured }) },
-            timeSeriesType: TimeSeriesType.Production,
-            processType: ProcessType.Aggregation);
+        return new List<AggregatedTimeSeries>
+        {
+            new AggregatedTimeSeries(
+                gridArea: "543",
+                timeSeriesPoints: new EnergyTimeSeriesPoint[]
+                {
+                    new(DateTime.Now, 0, new List<QuantityQuality> { QuantityQuality.Measured }),
+                },
+                timeSeriesType: TimeSeriesType.Production,
+                processType: ProcessType.Aggregation),
+        };
     }
 }

--- a/source/dotnet/wholesale-api/Edi/AggregatedTimeSeriesRequestHandler.cs
+++ b/source/dotnet/wholesale-api/Edi/AggregatedTimeSeriesRequestHandler.cs
@@ -49,34 +49,29 @@ public class AggregatedTimeSeriesRequestHandler : IAggregatedTimeSeriesRequestHa
 
         var validationErrors = _validator.Validate(aggregatedTimeSeriesRequest);
 
-        ServiceBusMessage message;
-        if (!validationErrors.Any())
+        if (validationErrors.Any())
         {
-            var aggregatedTimeSeriesRequestMessage = _aggregatedTimeSeriesRequestFactory.Parse(aggregatedTimeSeriesRequest);
-            var result = await GetCalculationResultsAsync(
-                aggregatedTimeSeriesRequestMessage).ConfigureAwait(false);
-
-            if (result is not null)
-            {
-                message = AggregatedTimeSeriesRequestAcceptedMessageFactory.Create(
-                    result,
-                    referenceId);
-            }
-            else
-            {
-                message = AggregatedTimeSeriesRequestRejectedMessageFactory.Create(new[] { _noDataAvailable }, referenceId);
-            }
-        }
-        else
-        {
-            message = AggregatedTimeSeriesRequestRejectedMessageFactory.Create(validationErrors.ToList(), referenceId);
+            await SendRejectedMessageAsync(validationErrors.ToList(), referenceId, cancellationToken).ConfigureAwait(false);
+            return;
         }
 
-        await _ediClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        var aggregatedTimeSeriesRequestMessage = _aggregatedTimeSeriesRequestFactory.Parse(aggregatedTimeSeriesRequest);
+        var results = await GetAggregatedTimeSeriesAsync(
+            aggregatedTimeSeriesRequestMessage,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!results.Any())
+        {
+            await SendRejectedMessageAsync(new List<ValidationError>() { _noDataAvailable }, referenceId, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await SendAcceptedMessageAsync(results, referenceId, cancellationToken).ConfigureAwait(false);
     }
 
-    private Task<AggregatedTimeSeries?> GetCalculationResultsAsync(
-        AggregatedTimeSeriesRequest request)
+    private async Task<List<AggregatedTimeSeries>> GetAggregatedTimeSeriesAsync(
+        AggregatedTimeSeriesRequest request,
+        CancellationToken cancellationToken)
     {
         var parameters = new AggregatedTimeSeriesQueryParameters(
             CalculationTimeSeriesTypeMapper.MapTimeSeriesTypeFromEdi(request.TimeSeriesType),
@@ -88,13 +83,25 @@ public class AggregatedTimeSeriesRequestHandler : IAggregatedTimeSeriesRequestHa
 
         if (request.RequestedProcessType == RequestedProcessType.LatestCorrection)
         {
-            return _aggregatedTimeSeriesQueries.GetLatestCorrectionAsync(parameters);
+            return await _aggregatedTimeSeriesQueries.GetLatestCorrectionAsync(parameters).ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        return _aggregatedTimeSeriesQueries.GetAsync(
+        return await _aggregatedTimeSeriesQueries.GetAsync(
             parameters with
             {
                 ProcessType = ProcessTypeMapper.FromRequestedProcessType(request.RequestedProcessType),
-            });
+            }).ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task SendRejectedMessageAsync(List<ValidationError> validationErrors, string referenceId, CancellationToken cancellationToken)
+    {
+        var message = AggregatedTimeSeriesRequestRejectedMessageFactory.Create(validationErrors, referenceId);
+        await _ediClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task SendAcceptedMessageAsync(List<AggregatedTimeSeries> results, string referenceId, CancellationToken cancellationToken)
+    {
+       var message = AggregatedTimeSeriesRequestAcceptedMessageFactory.Create(results, referenceId);
+       await _ediClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
+++ b/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
@@ -19,6 +19,10 @@ import "google/protobuf/timestamp.proto";
 option csharp_namespace = "Energinet.DataHub.Edi.Responses";
 
 message AggregatedTimeSeriesRequestAccepted {
+    repeated Serie series = 1;
+}
+
+message Serie {
     string grid_area = 1;
     QuantityUnit quantity_unit = 2;
     repeated TimeSeriesPoint time_series_points = 3;

--- a/source/dotnet/wholesale-api/Edi/Edi.csproj
+++ b/source/dotnet/wholesale-api/Edi/Edi.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactory.cs
+++ b/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactory.cs
@@ -24,7 +24,7 @@ namespace Energinet.DataHub.Wholesale.EDI.Factories;
 
 public class AggregatedTimeSeriesRequestAcceptedMessageFactory
 {
-    public static ServiceBusMessage Create(AggregatedTimeSeries aggregatedTimeSeries, string referenceId)
+    public static ServiceBusMessage Create(List<AggregatedTimeSeries> aggregatedTimeSeries, string referenceId)
     {
         var body = CreateAcceptedResponse(aggregatedTimeSeries);
 
@@ -38,18 +38,23 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactory
         return message;
     }
 
-    private static AggregatedTimeSeriesRequestAccepted CreateAcceptedResponse(AggregatedTimeSeries aggregatedTimeSeries)
+    private static AggregatedTimeSeriesRequestAccepted CreateAcceptedResponse(List<AggregatedTimeSeries> aggregatedTimeSeries)
     {
-        var points = CreateTimeSeriesPoints(aggregatedTimeSeries);
-
-        return new AggregatedTimeSeriesRequestAccepted()
+        var response = new AggregatedTimeSeriesRequestAccepted();
+        foreach (var aggregatedTimeSerie in aggregatedTimeSeries)
         {
-            GridArea = aggregatedTimeSeries.GridArea,
-            QuantityUnit = QuantityUnit.Kwh,
-            TimeSeriesPoints = { points },
-            TimeSeriesType = CalculationTimeSeriesTypeMapper.MapTimeSeriesTypeFromCalculationsResult(aggregatedTimeSeries.TimeSeriesType),
-            Resolution = Resolution.Pt15M,
-        };
+            var points = CreateTimeSeriesPoints(aggregatedTimeSerie);
+            response.Series.Add(new Serie()
+            {
+                GridArea = aggregatedTimeSerie.GridArea,
+                QuantityUnit = QuantityUnit.Kwh,
+                TimeSeriesPoints = { points },
+                TimeSeriesType = CalculationTimeSeriesTypeMapper.MapTimeSeriesTypeFromCalculationsResult(aggregatedTimeSerie.TimeSeriesType),
+                Resolution = Resolution.Pt15M,
+            });
+        }
+
+        return response;
     }
 
     private static IReadOnlyCollection<TimeSeriesPoint> CreateTimeSeriesPoints(AggregatedTimeSeries aggregatedTimeSeries)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

Grid area is nullable when requesting aggregated time series. 
The reason for this change is that Balance responsibles and energy suppliers should not be restricted one grid area. 
Note that the service bus message may be rather big, hence we need to alter the max_message_size for the queue in EDI.
