### PR TITLE
refac: Read calculation input using path 

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/calculator_args.py
+++ b/source/databricks/calculation_engine/package/calculation/calculator_args.py
@@ -23,6 +23,7 @@ class CalculatorArgs:
     data_storage_account_name: str
     data_storage_account_credentials: ClientSecretCredential
     wholesale_container_path: str
+    calculation_input_path: str
     batch_id: str
     batch_grid_areas: list[str]
     batch_period_start_datetime: datetime

--- a/source/databricks/calculation_engine/package/calculation_input/table_reader.py
+++ b/source/databricks/calculation_engine/package/calculation_input/table_reader.py
@@ -37,10 +37,10 @@ class TableReader:
     def __init__(
         self,
         spark: SparkSession,
-        storage_account_name: str,
+        calculation_input_path: str,
     ) -> None:
         self.__spark = spark
-        self.__storage_account_name = storage_account_name
+        self.__calculation_input_path = calculation_input_path
 
     def read_metering_point_periods(self) -> DataFrame:
         df = self._read_table("metering_point_periods")
@@ -85,7 +85,7 @@ class TableReader:
         return df
 
     def _read_table(self, folder_name: str) -> DataFrame:
-        path = f"{paths.get_container_root_path(self.__storage_account_name)}/calculation_input/{folder_name}"
+        path = f"{self.__calculation_input_path}/{folder_name}"
         return self.__spark.read.format("delta").load(path)
 
     def _add_charge_key_column(self, charge_df: DataFrame) -> DataFrame:

--- a/source/databricks/calculation_engine/package/calculator_job.py
+++ b/source/databricks/calculation_engine/package/calculator_job.py
@@ -38,7 +38,9 @@ def start() -> None:
 
     # Create calculation execution dependencies
     spark = initialize_spark()
-    delta_table_reader = calculation_input.TableReader(spark)
+    delta_table_reader = calculation_input.TableReader(
+        spark, args.calculation_input_path
+    )
     prepared_data_reader = calculation.PreparedDataReader(delta_table_reader)
 
     # Execute calculation

--- a/source/databricks/calculation_engine/package/calculator_job_args.py
+++ b/source/databricks/calculation_engine/package/calculator_job_args.py
@@ -33,6 +33,7 @@ def get_calculator_args() -> CalculatorArgs:
         data_storage_account_name=storage_account_name,
         data_storage_account_credentials=credential,
         wholesale_container_path=paths.get_container_root_path(storage_account_name),
+        calculation_input_path=paths.get_calculation_input_path(storage_account_name),
         batch_id=job_args.batch_id,
         batch_grid_areas=job_args.batch_grid_areas,
         batch_period_start_datetime=job_args.batch_period_start_datetime,

--- a/source/databricks/calculation_engine/package/infrastructure/paths.py
+++ b/source/databricks/calculation_engine/package/infrastructure/paths.py
@@ -46,6 +46,10 @@ def get_container_root_path(storage_account_name: str) -> str:
     return f"abfss://{WHOLESALE_CONTAINER_NAME}@{storage_account_name}.dfs.core.windows.net/"
 
 
+def get_calculation_input_path(storage_account_name: str) -> str:
+    return f"{get_container_root_path(storage_account_name)}/calculation_input/"
+
+
 def get_basis_data_root_path(basis_data_type: BasisDataType, batch_id: str) -> str:
     batch_path = get_batch_relative_path(batch_id)
     return f"{batch_path}/{BASIS_DATA_FOLDER}/{_get_basis_data_folder_name(basis_data_type)}"

--- a/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
@@ -18,7 +18,7 @@ from unittest import mock
 import pytest
 from pyspark.sql import SparkSession, DataFrame
 from pyspark.sql.types import StructType
-from pyspark.sql.functions import col, when, lit
+import pyspark.sql.functions as f
 
 from package.codelists import (
     InputMeteringPointType,
@@ -110,22 +110,22 @@ def _map_metering_point_type_and_settlement_method(df: DataFrame) -> DataFrame:
     """
     return df.withColumn(
         Colname.metering_point_type,
-        when(
-            col(Colname.metering_point_type)
+        f.when(
+            f.col(Colname.metering_point_type)
             == InputMeteringPointType.CONSUMPTION.value,
             MeteringPointType.CONSUMPTION.value,
-        ).otherwise(col(Colname.metering_point_type)),
+        ).otherwise(f.col(Colname.metering_point_type)),
     ).withColumn(
         Colname.settlement_method,
-        when(
-            col(Colname.settlement_method) == InputSettlementMethod.FLEX.value,
+        f.when(
+            f.col(Colname.settlement_method) == InputSettlementMethod.FLEX.value,
             SettlementMethod.FLEX.value,
         ).otherwise(col(Colname.settlement_method)),
     )
 
 
 def _add_charge_key(df: DataFrame) -> DataFrame:
-    return df.withColumn(Colname.charge_key, lit("foo-foo-foo"))
+    return df.withColumn(Colname.charge_key, f.lit("foo-foo-foo"))
 
 
 @pytest.mark.parametrize(
@@ -236,7 +236,7 @@ def test__read_data__when_schema_mismatch__raises_assertion_error(
     row = create_row()
     reader = TableReader(spark, "dummy_calculation_input_path")
     df = spark.createDataFrame(data=[row], schema=expected_schema)
-    df = df.withColumn("test", lit("test"))
+    df = df.withColumn("test", f.lit("test"))
     sut = getattr(reader, str(method_name.__name__))
 
     # Act & Assert

--- a/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
@@ -120,7 +120,7 @@ def _map_metering_point_type_and_settlement_method(df: DataFrame) -> DataFrame:
         when(
             col(Colname.settlement_method) == InputSettlementMethod.FLEX.value,
             SettlementMethod.FLEX.value,
-        ).otherwise(col(Colname.metering_point_type)),
+        ).otherwise(col(Colname.settlement_method)),
     )
 
 

--- a/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
@@ -299,7 +299,7 @@ def test__read_metering_point_periods__returns_expected_df(
         spark,
         df,
         "test_database",
-        "my_metering_point_periods",
+        "metering_point_periods",
         table_location,
         metering_point_period_schema,
     )
@@ -313,7 +313,33 @@ def test__read_metering_point_periods__returns_expected_df(
     assert_dataframes_equal(actual, expected)
 
 
-# method that asserts that two dataframe are identical
+def test__read_time_series_points__returns_expected_df(
+    spark: SparkSession,
+    tmp_path: pathlib.Path,
+) -> None:
+    # Arrange
+    calculation_input_path = f"{str(tmp_path)}/calculation_input"
+    table_location = f"{calculation_input_path}/time_series_points"
+    row = _create_time_series_point_row()
+    df = spark.createDataFrame(data=[row], schema=time_series_point_schema)
+    write_dataframe_to_table(
+        spark,
+        df,
+        "test_database",
+        "time_series_points",
+        table_location,
+        time_series_point_schema,
+    )
+    expected = df
+    reader = TableReader(spark, calculation_input_path)
+
+    # Act
+    actual = reader.read_time_series_points()
+
+    # Assert
+    assert_dataframes_equal(actual, expected)
+
+
 def assert_dataframes_equal(actual: DataFrame, expected: DataFrame) -> None:
     assert actual.subtract(expected).count() == 0
     assert expected.subtract(actual).count() == 0

--- a/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
@@ -238,6 +238,7 @@ def test__read_data__when_schema_mismatch__raises_assertion_error(
     df = spark.createDataFrame(data=[row], schema=expected_schema)
     df = df.withColumn("test", lit("test"))
     sut = getattr(reader, str(method_name.__name__))
+
     # Act & Assert
     with mock.patch.object(reader, TableReader._read_table.__name__, return_value=df):
         with pytest.raises(AssertionError):

--- a/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
@@ -142,7 +142,7 @@ def test___read_metering_point_periods__returns_df_with_correct_metering_point_t
     # Arrange
     row = _create_metering_point_period_row(metering_point_type=metering_point_type)
     df = spark.createDataFrame(data=[row], schema=metering_point_period_schema)
-    sut = TableReader(spark)
+    sut = TableReader(spark, "dummy_calculation_input_path")
 
     # Act
     with mock.patch.object(sut, TableReader._read_table.__name__, return_value=df):
@@ -166,7 +166,7 @@ def test___read_metering_point_periods__returns_df_with_correct_settlement_metho
 ) -> None:
     row = _create_metering_point_period_row(settlement_method=settlement_method)
     df = spark.createDataFrame(data=[row], schema=metering_point_period_schema)
-    sut = TableReader(spark)
+    sut = TableReader(spark, "dummy_calculation_input_path")
 
     # Act
     with mock.patch.object(sut, TableReader._read_table.__name__, return_value=df):
@@ -211,7 +211,7 @@ def test__read_data__returns_df(
 ) -> None:
     # Arrange
     row = create_row()
-    reader = TableReader(spark)
+    reader = TableReader(spark, "dummy_calculation_input_path")
     df = spark.createDataFrame(data=[row], schema=expected_schema)
     sut = getattr(reader, method_name.__name__)
 
@@ -258,7 +258,7 @@ def test__read_data__when_schema_mismatch__raises_assertion_error(
 ) -> None:
     # Arrange
     row = create_row()
-    reader = TableReader(spark)
+    reader = TableReader(spark, "dummy_calculation_input_path")
     df = spark.createDataFrame(data=[row], schema=expected_schema)
     df = df.withColumn("test", lit("test"))
     sut = getattr(reader, str(method_name.__name__))

--- a/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
@@ -241,8 +241,10 @@ def test__read_data__when_schema_mismatch__raises_assertion_error(
 
     # Act & Assert
     with mock.patch.object(reader, TableReader._read_table.__name__, return_value=df):
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError) as exc_info:
             sut()
+
+        assert "Schema mismatch" in str(exc_info.value)
 
 
 def test__read_metering_point_periods__returns_expected_df(

--- a/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
@@ -120,7 +120,7 @@ def _map_metering_point_type_and_settlement_method(df: DataFrame) -> DataFrame:
         f.when(
             f.col(Colname.settlement_method) == InputSettlementMethod.FLEX.value,
             SettlementMethod.FLEX.value,
-        ).otherwise(col(Colname.settlement_method)),
+        ).otherwise(f.col(Colname.settlement_method)),
     )
 
 

--- a/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
@@ -106,7 +106,7 @@ def _create_charge_master_period_row() -> dict:
 def _map_metering_point_type_and_settlement_method(df: DataFrame) -> DataFrame:
     """
     Maps metering point type and settlement method to the correct values
-    Only supports consumption and flex
+    Currently only supports consumption and flex
     """
     return df.withColumn(
         Colname.metering_point_type,

--- a/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/test_table_reader.py
@@ -36,6 +36,7 @@ from package.calculation_input.schemas import (
 )
 from package.constants import Colname
 from tests.helpers.delta_table_utils import write_dataframe_to_table
+from tests.helpers.data_frame_utils import assert_dataframes_equal
 
 
 def _create_metering_point_period_row(
@@ -338,9 +339,3 @@ def test__read_time_series_points__returns_expected_df(
 
     # Assert
     assert_dataframes_equal(actual, expected)
-
-
-def assert_dataframes_equal(actual: DataFrame, expected: DataFrame) -> None:
-    assert actual.subtract(expected).count() == 0
-    assert expected.subtract(actual).count() == 0
-    assert actual.subtract(expected).count() == 0

--- a/source/databricks/calculation_engine/tests/calculator_job/conftest.py
+++ b/source/databricks/calculation_engine/tests/calculator_job/conftest.py
@@ -110,7 +110,7 @@ def price_input_data_written_to_delta(
         file_name=f"{test_files_folder_path}/ChargeMasterDataPeriods.csv",
         table_name=paths.CHARGE_MASTER_DATA_PERIODS_TABLE_NAME,
         schema=charge_master_data_periods_schema,
-        table_location=f"{calculation_input_path}/charge_master_data_periods",
+        table_location=f"{calculation_input_path}/charge_masterdata_periods",
     )
 
     # Charge link periods

--- a/source/databricks/calculation_engine/tests/helpers/data_frame_utils.py
+++ b/source/databricks/calculation_engine/tests/helpers/data_frame_utils.py
@@ -27,3 +27,9 @@ def set_column(
     if isinstance(column_value, list):
         return df.withColumn(column_name, f.array(*map(f.lit, column_value)))
     return df.withColumn(column_name, f.lit(column_value))
+
+
+def assert_dataframes_equal(actual: DataFrame, expected: DataFrame) -> None:
+    assert actual.subtract(expected).count() == 0
+    assert expected.subtract(actual).count() == 0
+    assert actual.subtract(expected).count() == 0

--- a/source/databricks/calculation_engine/tests/helpers/delta_table_utils.py
+++ b/source/databricks/calculation_engine/tests/helpers/delta_table_utils.py
@@ -26,7 +26,7 @@ def write_dataframe_to_table(
 ) -> None:
     spark.sql(f"CREATE DATABASE IF NOT EXISTS {database_name}")
 
-    sql_schema = struct_type_to_sql_schema(schema)
+    sql_schema = _struct_type_to_sql_schema(schema)
     spark.sql(
         f"CREATE TABLE IF NOT EXISTS {database_name}.{table_name} ({sql_schema}) USING DELTA LOCATION '{table_location}'"
     )
@@ -36,7 +36,7 @@ def write_dataframe_to_table(
     )
 
 
-def struct_type_to_sql_schema(schema: StructType) -> str:
+def _struct_type_to_sql_schema(schema: StructType) -> str:
     schema_string = ""
     for field in schema.fields:
         field_name = field.name

--- a/source/databricks/calculation_engine/tests/helpers/delta_table_utils.py
+++ b/source/databricks/calculation_engine/tests/helpers/delta_table_utils.py
@@ -1,0 +1,52 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyspark.sql import SparkSession, DataFrame
+from pyspark.sql.types import StructType
+
+
+def write_dataframe_to_table(
+    spark: SparkSession,
+    df: DataFrame,
+    database_name: str,
+    table_name: str,
+    table_location: str,
+    schema: StructType,
+) -> None:
+    spark.sql(f"CREATE DATABASE IF NOT EXISTS {database_name}")
+
+    sql_schema = struct_type_to_sql_schema(schema)
+    spark.sql(
+        f"CREATE TABLE IF NOT EXISTS {database_name}.{table_name} ({sql_schema}) USING DELTA LOCATION '{table_location}'"
+    )
+
+    df.write.format("delta").mode("overwrite").saveAsTable(
+        f"{database_name}.{table_name}"
+    )
+
+
+def struct_type_to_sql_schema(schema: StructType) -> str:
+    schema_string = ""
+    for field in schema.fields:
+        field_name = field.name
+        field_type = field.dataType.simpleString()
+
+        if not field.nullable:
+            field_type += " NOT NULL"
+
+        schema_string += f"{field_name} {field_type}, "
+
+    # Remove the trailing comma and space
+    schema_string = schema_string.rstrip(", ")
+    return schema_string


### PR DESCRIPTION
Since our input tables will soon belong to another workspace, we need to modify the way we refer to them when reading. Using path instead of names make it Independent of the workspace. 

Also, some tests are added to TableReader, so that we test against a Delta table rather than a mock.