### PR TITLE
ScenarioStep and orderer

### DIFF
--- a/source/dotnet/domain-tests/CalculationFeatureTests.cs
+++ b/source/dotnet/domain-tests/CalculationFeatureTests.cs
@@ -30,7 +30,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
     public class CalculationFeatureTests
     {
         [TestCaseOrderer(
-            ordererTypeName: "Energinet.DataHub.Wholesale.DomainTests.Fixtures.Orderers.PriorityOrderer",
+            ordererTypeName: "Energinet.DataHub.Wholesale.DomainTests.Fixtures.Orderers.ScenarioStepOrderer",
             ordererAssemblyName: "Energinet.DataHub.Wholesale.DomainTests")]
         public class BalanceFixingCalculationScenario : DomainTestsBase<CalculationScenarioFixture>
         {
@@ -39,7 +39,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
             {
             }
 
-            [Priority(0)]
+            [ScenarioStep(0)]
             [DomainFact]
             public void Given_CalculationInput()
             {
@@ -52,7 +52,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 };
             }
 
-            [Priority(1)]
+            [ScenarioStep(1)]
             [DomainFact]
             public void AndGiven_SubscribedIntegrationEvents()
             {
@@ -60,7 +60,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.SubscribedIntegrationEventNames.Add(EnergyResultProducedV2.EventName);
             }
 
-            [Priority(2)]
+            [ScenarioStep(2)]
             [DomainFact]
             public async Task When_CalculationIsStarted()
             {
@@ -70,7 +70,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.CalculationId.Should().NotBeEmpty();
             }
 
-            [Priority(3)]
+            [ScenarioStep(3)]
             [DomainFact]
             public async Task Then_CalculationIsCompletedWithinWaitTime()
             {
@@ -89,7 +89,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 actualWaitResult.Batch!.ExecutionState.Should().Be(Clients.v3.BatchState.Completed);
             }
 
-            [Priority(4)]
+            [ScenarioStep(4)]
             [DomainFact]
             public void AndThen_CalculationDurationIsLessThanOrEqualToTimeLimit()
             {
@@ -102,7 +102,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 actualCalculationDuration.Should().BeLessThanOrEqualTo(calculationTimeLimit);
             }
 
-            [Priority(5)]
+            [ScenarioStep(5)]
             [DomainFact]
             public async Task AndThen_IntegrationEventsAreReceivedWithinWaitTime()
             {
@@ -126,7 +126,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.ReceivedMonthlyAmountPerChargeResultProducedV1.Should().BeEmpty();
             }
 
-            [Priority(6)]
+            [ScenarioStep(6)]
             [DomainFact]
             public void AndThen_ReceivedEnergyResultProducedEventsCountIsEqualToExpected()
             {
@@ -138,7 +138,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.ReceivedEnergyResultProducedV2.Count.Should().Be(expected);
             }
 
-            [Priority(7)]
+            [ScenarioStep(7)]
             [DomainFact]
             public void AndThen_ReceivedEnergyResultProducedEventsContainAllTimeSeriesTypes()
             {
@@ -162,7 +162,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 }
             }
 
-            [Priority(8)]
+            [ScenarioStep(8)]
             [DomainFact]
             public void AndThen_ReceivedEnergyResultProducedEventsContainExpectedTuplesOfTimeSeriesTypeAndAggregationLevel()
             {
@@ -221,7 +221,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
         }
 
         [TestCaseOrderer(
-            ordererTypeName: "Energinet.DataHub.Wholesale.DomainTests.Fixtures.Orderers.PriorityOrderer",
+            ordererTypeName: "Energinet.DataHub.Wholesale.DomainTests.Fixtures.Orderers.ScenarioStepOrderer",
             ordererAssemblyName: "Energinet.DataHub.Wholesale.DomainTests")]
         public class WholesaleFixingCalculationScenario : DomainTestsBase<CalculationScenarioFixture>
         {
@@ -230,7 +230,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
             {
             }
 
-            [Priority(0)]
+            [ScenarioStep(0)]
             [DomainFact]
             public void Given_CalculationInput()
             {
@@ -243,7 +243,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 };
             }
 
-            [Priority(1)]
+            [ScenarioStep(1)]
             [DomainFact]
             public void AndGiven_SubscribedIntegrationEvents()
             {
@@ -253,7 +253,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.SubscribedIntegrationEventNames.Add(MonthlyAmountPerChargeResultProducedV1.EventName);
             }
 
-            [Priority(2)]
+            [ScenarioStep(2)]
             [DomainFact]
             public async Task When_CalculationIsStarted()
             {
@@ -263,7 +263,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.CalculationId.Should().NotBeEmpty();
             }
 
-            [Priority(3)]
+            [ScenarioStep(3)]
             [DomainFact]
             public async Task Then_CalculationIsCompletedWithinWaitTime()
             {
@@ -282,7 +282,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 actualWaitResult.Batch!.ExecutionState.Should().Be(Clients.v3.BatchState.Completed);
             }
 
-            [Priority(4)]
+            [ScenarioStep(4)]
             [DomainFact]
             public void AndThen_CalculationDurationIsLessThanOrEqualToTimeLimit()
             {
@@ -295,7 +295,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 actualCalculationDuration.Should().BeLessThanOrEqualTo(calculationTimeLimit);
             }
 
-            [Priority(5)]
+            [ScenarioStep(5)]
             [DomainFact]
             public async Task AndThen_IntegrationEventsAreReceivedWithinWaitTime()
             {
@@ -317,7 +317,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.ReceivedMonthlyAmountPerChargeResultProducedV1.Should().NotBeEmpty();
             }
 
-            [Priority(6)]
+            [ScenarioStep(6)]
             [DomainFact]
             public void AndThen_ReceivedEnergyResultProducedEventsCountIsEqualToExpected()
             {
@@ -329,7 +329,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.ReceivedEnergyResultProducedV2.Count.Should().Be(expected);
             }
 
-            [Priority(7)]
+            [ScenarioStep(7)]
             [DomainFact]
             public void AndThen_ReceivedEnergyResultProducedEventsContainExpectedTimeSeriesTypes()
             {
@@ -356,7 +356,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 }
             }
 
-            [Priority(8)]
+            [ScenarioStep(8)]
             [DomainFact]
             public void AndThen_ReceivedEnergyResultProducedEventsContainExpectedTuplesOfTimeSeriesTypeAndAggregationLevel()
             {
@@ -405,7 +405,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 }
             }
 
-            [Priority(9)]
+            [ScenarioStep(9)]
             [DomainFact]
             public void AndThen_ReceivedAmountPerChargeResultProducedEventsCountIsEqualToExpected()
             {
@@ -415,7 +415,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.ReceivedAmountPerChargeResultProducedV1.Count.Should().Be(expected);
             }
 
-            [Priority(10)]
+            [ScenarioStep(10)]
             [DomainFact]
             public void AndThen_ReceivedMonthlyAmountPerChargeResultProducedEventsCountIsEqualToExpected()
             {

--- a/source/dotnet/domain-tests/Fixtures/Attributes/ScenarioStepAttribute.cs
+++ b/source/dotnet/domain-tests/Fixtures/Attributes/ScenarioStepAttribute.cs
@@ -15,19 +15,19 @@
 namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures.Attributes
 {
     /// <summary>
-    /// Use this in combination with <see cref="Orderers.PriorityOrderer"/> to execute xUnit test cases in
-    /// order according to priority. Lowest numbers are executed first.
+    /// Use this in combination with <see cref="Orderers.ScenarioStepOrderer"/> to execute xUnit test cases in
+    /// order according to step number. Lowest numbers are executed first.
     ///
     /// Inspired by: https://learn.microsoft.com/en-us/dotnet/core/testing/order-unit-tests?pivots=xunit#order-by-custom-attribute
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public class PriorityAttribute : Attribute
+    public class ScenarioStepAttribute : Attribute
     {
-        public PriorityAttribute(int priority)
+        public ScenarioStepAttribute(int number)
         {
-            Priority = priority;
+            Number = number;
         }
 
-        public int Priority { get; }
+        public int Number { get; }
     }
 }

--- a/source/dotnet/domain-tests/Fixtures/Orderers/ScenarioStepOrderer.cs
+++ b/source/dotnet/domain-tests/Fixtures/Orderers/ScenarioStepOrderer.cs
@@ -19,24 +19,24 @@ using Xunit.Sdk;
 namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures.Orderers
 {
     /// <summary>
-    /// A custom xUnit test case orderer that executes tests in order according to the attribute <see cref="PriorityAttribute"/>.
+    /// A custom xUnit test case orderer that executes tests in order according to the attribute <see cref="ScenarioStepAttribute"/>.
     /// Use the <see cref="Xunit.TestCaseOrdererAttribute"/> on a test class to enable the orderer.
     ///
     /// Inspired by: https://learn.microsoft.com/en-us/dotnet/core/testing/order-unit-tests?pivots=xunit#order-by-custom-attribute
     /// </summary>
-    public class PriorityOrderer : ITestCaseOrderer
+    public class ScenarioStepOrderer : ITestCaseOrderer
     {
         public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
             where TTestCase : ITestCase
         {
-            var assemblyName = typeof(PriorityAttribute).AssemblyQualifiedName!;
+            var assemblyName = typeof(ScenarioStepAttribute).AssemblyQualifiedName!;
             var sortedMethods = new SortedDictionary<int, List<TTestCase>>();
             foreach (var testCase in testCases)
             {
                 var priority = testCase.TestMethod.Method
                     .GetCustomAttributes(assemblyName)
                     .FirstOrDefault()
-                    ?.GetNamedArgument<int>(nameof(PriorityAttribute.Priority)) ?? 0;
+                    ?.GetNamedArgument<int>(nameof(ScenarioStepAttribute.Number)) ?? 0;
 
                 GetOrCreate(sortedMethods, priority).Add(testCase);
             }

--- a/source/dotnet/domain-tests/SettlementFeatureTests.cs
+++ b/source/dotnet/domain-tests/SettlementFeatureTests.cs
@@ -27,7 +27,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
     public class SettlementFeatureTests
     {
         [TestCaseOrderer(
-            ordererTypeName: "Energinet.DataHub.Wholesale.DomainTests.Fixtures.Orderers.PriorityOrderer",
+            ordererTypeName: "Energinet.DataHub.Wholesale.DomainTests.Fixtures.Orderers.ScenarioStepOrderer",
             ordererAssemblyName: "Energinet.DataHub.Wholesale.DomainTests")]
         public class SettlementReportDownloadScenario : DomainTestsBase<SettlementReportScenarioFixture>
         {
@@ -36,7 +36,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
             {
             }
 
-            [Priority(0)]
+            [ScenarioStep(0)]
             [DomainFact]
             public void Given_SettlementDownloadInput()
             {
@@ -46,14 +46,14 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.SettlementDownloadInput.CalculationPeriodEnd = DateTimeOffset.Parse("2020-01-29T23:00:00Z");
             }
 
-            [Priority(1)]
+            [ScenarioStep(1)]
             [DomainFact]
             public async Task When_SettlementReportDownloadedIsStarted()
             {
                 Fixture.ScenarioState.SettlementReportFile = await Fixture.StartDownloadingAsync(Fixture.ScenarioState.SettlementDownloadInput);
             }
 
-            [Priority(2)]
+            [ScenarioStep(2)]
             [DomainFact]
             public void Then_SettlementReportEntriesShouldNotBeEmpty()
             {
@@ -63,7 +63,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.CompressedSettlementReport.Entries.Should().NotBeEmpty();
             }
 
-            [Priority(3)]
+            [ScenarioStep(3)]
             [DomainFact]
             public void AndThen_SingleEntryNameShouldBeResultCsv()
             {
@@ -74,7 +74,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests
                 Fixture.ScenarioState.Entry.Name.Should().Be(expected);
             }
 
-            [Priority(4)]
+            [ScenarioStep(4)]
             [DomainFact]
             public async Task AndThen_SingleEntryShouldContainCorrectGridAreaCodesAndProcessType()
             {


### PR DESCRIPTION
Rename PriorityAttribute and PriorityOrderer to ScenarioStepAttribute and ScenarioStepOrderer.

These new names better reflect how we use them and link their names to the classes they are used on (XxxScenario).