### PR TITLE
feat: Add error message if an actor has no data for requested grid area but has data in another grid area

### DIFF
--- a/source/dotnet/wholesale-api/Edi.UnitTests/AggregatedTimeSeriesRequestHandlerTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/AggregatedTimeSeriesRequestHandlerTests.cs
@@ -20,7 +20,7 @@ using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResul
 using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults.Model.EnergyResults;
 using Energinet.DataHub.Wholesale.Common.Interfaces.Models;
 using Energinet.DataHub.Wholesale.EDI.Client;
-using Energinet.DataHub.Wholesale.EDI.Factories;
+using Energinet.DataHub.Wholesale.EDI.Models;
 using Energinet.DataHub.Wholesale.EDI.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.EDI.UnitTests.Extensions;
 using Energinet.DataHub.Wholesale.EDI.Validation;
@@ -37,12 +37,13 @@ public class AggregatedTimeSeriesRequestHandlerTests
 {
     private static readonly ValidationError _noDataAvailable = new("Ingen data tilgængelig / No data available", "E0H");
 
+    private static readonly ValidationError _noDataForRequestedGridArea = new("Forkert netområde / invalid grid area", "D46");
+
     [Theory]
     [InlineAutoMoqData]
     public async Task ProcessAsync_WithTotalProductionPerGridAreaRequest_SendsAcceptedEdiMessage(
         [Frozen] Mock<IAggregatedTimeSeriesQueries> aggregatedTimeSeriesQueries,
         [Frozen] Mock<IEdiClient> senderMock,
-        [Frozen] Mock<AggregatedTimeSeriesRequestFactory> aggregatedTimeSeriesRequestMessageParseMock,
         [Frozen] Mock<IValidator<AggregatedTimeSeriesRequest>> validator)
     {
         // Arrange
@@ -67,7 +68,6 @@ public class AggregatedTimeSeriesRequestHandlerTests
 
         var sut = new AggregatedTimeSeriesRequestHandler(
             senderMock.Object,
-            aggregatedTimeSeriesRequestMessageParseMock.Object,
             validator.Object,
             aggregatedTimeSeriesQueries.Object);
 
@@ -90,10 +90,9 @@ public class AggregatedTimeSeriesRequestHandlerTests
 
     [Theory]
     [InlineAutoMoqData]
-    public async Task ProcessAsync_WithTotalProductionPerGridAreaRequest_SendsRejectedEdiMessage(
+    public async Task ProcessAsync_WhenNoAggregatedTimeSeries_SendsRejectedEdiMessage(
         [Frozen] Mock<IAggregatedTimeSeriesQueries> aggregatedTimeSeriesQueries,
         [Frozen] Mock<IEdiClient> senderMock,
-        [Frozen] Mock<AggregatedTimeSeriesRequestFactory> aggregatedTimeSeriesRequestMessageParseMock,
         [Frozen] Mock<IValidator<AggregatedTimeSeriesRequest>> validator)
     {
         // Arrange
@@ -116,58 +115,6 @@ public class AggregatedTimeSeriesRequestHandlerTests
 
         var sut = new AggregatedTimeSeriesRequestHandler(
             senderMock.Object,
-            aggregatedTimeSeriesRequestMessageParseMock.Object,
-            validator.Object,
-            aggregatedTimeSeriesQueries.Object);
-
-        // Act
-        await sut.ProcessAsync(
-            serviceBusReceivedMessage,
-            expectedReferenceId,
-            CancellationToken.None);
-
-        // Assert
-        senderMock.Verify(
-            bus => bus.SendAsync(
-            It.Is<ServiceBusMessage>(message =>
-                message.Subject.Equals(expectedRejectedSubject)
-                && message.ApplicationProperties.ContainsKey("ReferenceId")
-                && message.ApplicationProperties["ReferenceId"].Equals(expectedReferenceId)),
-            It.IsAny<CancellationToken>()),
-            Times.Once);
-    }
-
-    [Theory]
-    [InlineAutoMoqData]
-    public async Task ProcessAsync_WhenNoAggregatedTimeSeries_SendsRejectedEdiMessage(
-        [Frozen] Mock<IAggregatedTimeSeriesQueries> aggregatedTimeSeriesQueries,
-        [Frozen] Mock<IEdiClient> senderMock,
-        [Frozen] Mock<AggregatedTimeSeriesRequestFactory> aggregatedTimeSeriesRequestMessageParseMock,
-        [Frozen] Mock<IValidator<AggregatedTimeSeriesRequest>> validator)
-    {
-        // Arrange
-        const string expectedRejectedSubject = nameof(AggregatedTimeSeriesRequestRejected);
-        var expectedReferenceId = Guid.NewGuid().ToString();
-        var request = AggregatedTimeSeriesRequestBuilder
-            .AggregatedTimeSeriesRequest()
-            .Build();
-        var serviceBusReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(
-            properties: new Dictionary<string, object> { { "ReferenceId", expectedReferenceId } },
-            body: new BinaryData(request.ToByteArray()));
-
-        validator.Setup(vali => vali.Validate(
-                It.IsAny<AggregatedTimeSeriesRequest>()))
-            .Returns(() => new List<ValidationError>());
-
-        aggregatedTimeSeriesQueries
-            .Setup(parameters =>
-                parameters.GetAsync(
-                    It.IsAny<AggregatedTimeSeriesQueryParameters>()))
-            .Returns(() => new List<AggregatedTimeSeries>().ToAsyncEnumerable());
-
-        var sut = new AggregatedTimeSeriesRequestHandler(
-            senderMock.Object,
-            aggregatedTimeSeriesRequestMessageParseMock.Object,
             validator.Object,
             aggregatedTimeSeriesQueries.Object);
 
@@ -183,6 +130,66 @@ public class AggregatedTimeSeriesRequestHandlerTests
             It.Is<ServiceBusMessage>(message =>
                 message.Subject.Equals(expectedRejectedSubject)
                 && message.WithErrorCode(_noDataAvailable.ErrorCode)
+                && message.ApplicationProperties.ContainsKey("ReferenceId")
+                && message.ApplicationProperties["ReferenceId"].Equals(expectedReferenceId)),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public async Task ProcessAsync_WhenNoAggregatedTimeSeriesForRequestedGridArea_SendsRejectedEdiMessage(
+        [Frozen] Mock<IAggregatedTimeSeriesQueries> aggregatedTimeSeriesQueries,
+        [Frozen] Mock<IEdiClient> senderMock,
+        [Frozen] Mock<IValidator<AggregatedTimeSeriesRequest>> validator)
+    {
+        // Arrange
+        const string expectedRejectedSubject = nameof(AggregatedTimeSeriesRequestRejected);
+        var expectedReferenceId = Guid.NewGuid().ToString();
+        var request = AggregatedTimeSeriesRequestBuilder
+            .AggregatedTimeSeriesRequest()
+            .WithRequestedByActorRole(ActorRoleCode.EnergySupplier)
+            .WithGridArea("303")
+            .Build();
+        var serviceBusReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            properties: new Dictionary<string, object> { { "ReferenceId", expectedReferenceId } },
+            body: new BinaryData(request.ToByteArray()));
+
+        var aggregatedTimeSeries = CreateAggregatedTimeSeries();
+
+        validator.Setup(vali => vali.Validate(
+                It.IsAny<AggregatedTimeSeriesRequest>()))
+            .Returns(() => new List<ValidationError>());
+
+        aggregatedTimeSeriesQueries
+            .Setup(parameters =>
+                parameters.GetAsync(
+                    It.IsAny<AggregatedTimeSeriesQueryParameters>()))
+            .Returns(() => new List<AggregatedTimeSeries>().ToAsyncEnumerable());
+
+        aggregatedTimeSeriesQueries
+            .Setup(parameters =>
+                parameters.GetAsync(
+                    It.Is<AggregatedTimeSeriesQueryParameters>(x => x.GridArea == null)))
+            .Returns(() => aggregatedTimeSeries.ToAsyncEnumerable());
+
+        var sut = new AggregatedTimeSeriesRequestHandler(
+            senderMock.Object,
+            validator.Object,
+            aggregatedTimeSeriesQueries.Object);
+
+        // Act
+        await sut.ProcessAsync(
+            serviceBusReceivedMessage,
+            expectedReferenceId,
+            CancellationToken.None);
+
+        // Assert
+        senderMock.Verify(
+            bus => bus.SendAsync(
+            It.Is<ServiceBusMessage>(message =>
+                message.Subject.Equals(expectedRejectedSubject)
+                && message.WithErrorCode(_noDataForRequestedGridArea.ErrorCode)
                 && message.ApplicationProperties.ContainsKey("ReferenceId")
                 && message.ApplicationProperties["ReferenceId"].Equals(expectedReferenceId)),
             It.IsAny<CancellationToken>()),

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Builders/AggregatedTimeSeriesRequestBuilder.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Builders/AggregatedTimeSeriesRequestBuilder.cs
@@ -22,7 +22,6 @@ namespace Energinet.DataHub.Wholesale.EDI.UnitTests.Builders;
 
 public class AggregatedTimeSeriesRequestBuilder
 {
-    private readonly AggregationPerGridArea _aggregationPerGridArea = new();
     private string _meteringPointType = MeteringPointType.Production;
 
     private string _start;
@@ -34,6 +33,7 @@ public class AggregatedTimeSeriesRequestBuilder
     private string? _balanceResponsibleId;
     private string? _settlementSeriesVersion;
     private string _businessReason;
+    private string? _gridAreaCode;
 
     private AggregatedTimeSeriesRequestBuilder()
     {
@@ -55,7 +55,6 @@ public class AggregatedTimeSeriesRequestBuilder
     {
         var request = new AggregatedTimeSeriesRequest
         {
-            AggregationPerGridarea = _aggregationPerGridArea,
             Period = new DataHub.Edi.Requests.Period()
             {
                 Start = _start,
@@ -72,6 +71,9 @@ public class AggregatedTimeSeriesRequestBuilder
 
         if (_balanceResponsibleId != null)
             request.BalanceResponsibleId = _balanceResponsibleId;
+
+        if (_gridAreaCode != null)
+            request.GridAreaCode = _gridAreaCode;
 
         if (_settlementMethod != null)
             request.SettlementMethod = _settlementMethod;
@@ -140,6 +142,12 @@ public class AggregatedTimeSeriesRequestBuilder
     public AggregatedTimeSeriesRequestBuilder WithBusinessReason(string businessReason)
     {
         _businessReason = businessReason;
+        return this;
+    }
+
+    public AggregatedTimeSeriesRequestBuilder WithGridArea(string gridArea)
+    {
+        _gridAreaCode = gridArea;
         return this;
     }
 }

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactoryTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactoryTests.cs
@@ -24,7 +24,7 @@ using Xunit;
 using QuantityQuality = Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults.Model.QuantityQuality;
 using TimeSeriesType = Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults.Model.EnergyResults.TimeSeriesType;
 
-namespace Energinet.DataHub.Wholesale.EDI.UnitTests;
+namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Factories;
 
 public class AggregatedTimeSeriesRequestAcceptedMessageFactoryTests
 {

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestFactoryTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestFactoryTests.cs
@@ -1,0 +1,136 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Edi.Requests;
+using Energinet.DataHub.Wholesale.EDI.Factories;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Factories;
+
+public class AggregatedTimeSeriesRequestFactoryTests
+{
+    [Fact]
+    public void Parse_WhenGridAreaIsNull_ExpectedParsing()
+    {
+        // Arrange
+        var balanceResponsibleId = "1234567891234";
+        var energySupplier = "1234567891237";
+        var gridAreaCode = null as string;
+        var request = CreateRequest(
+            gridAreaCode: gridAreaCode,
+            energySupplier: energySupplier,
+            balanceResponsible: balanceResponsibleId);
+
+        // Act
+        var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
+
+        // Assert
+        actual.Should().NotBeNull();
+        using var assertionScope = new AssertionScope();
+        var aggregationLevel = actual.AggregationPerRoleAndGridArea;
+        aggregationLevel.BalanceResponsibleId.Should().Be(balanceResponsibleId);
+        aggregationLevel.EnergySupplierId.Should().Be(energySupplier);
+        aggregationLevel.GridAreaCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_WhenEnergySupplierIsNull_ExpectedParsing()
+    {
+        // Arrange
+        var balanceResponsibleId = "1234567891234";
+        var energySupplier = null as string;
+        var gridAreaCode = "303";
+        var request = CreateRequest(
+            gridAreaCode: gridAreaCode,
+            energySupplier: energySupplier,
+            balanceResponsible: balanceResponsibleId);
+
+        // Act
+        var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
+
+        // Assert
+        actual.Should().NotBeNull();
+        using var assertionScope = new AssertionScope();
+        var aggregationLevel = actual.AggregationPerRoleAndGridArea;
+        aggregationLevel.BalanceResponsibleId.Should().Be(balanceResponsibleId);
+        aggregationLevel.EnergySupplierId.Should().BeNull();
+        aggregationLevel.GridAreaCode.Should().Be(gridAreaCode);
+    }
+
+    [Fact]
+    public void Parse_WhenBalanceResponsibleIsNull_ExpectedParsing()
+    {
+        // Arrange
+        var balanceResponsibleId = null as string;
+        var energySupplier = "1234567891234";
+        var gridAreaCode = "303";
+        var request = CreateRequest(
+            gridAreaCode: gridAreaCode,
+            energySupplier: energySupplier,
+            balanceResponsible: balanceResponsibleId);
+
+        // Act
+        var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
+
+        // Assert
+        actual.Should().NotBeNull();
+        using var assertionScope = new AssertionScope();
+        var aggregationLevel = actual.AggregationPerRoleAndGridArea;
+        aggregationLevel.BalanceResponsibleId.Should().BeNull();
+        aggregationLevel.EnergySupplierId.Should().Be(energySupplier);
+        aggregationLevel.GridAreaCode.Should().Be(gridAreaCode);
+    }
+
+    private AggregatedTimeSeriesRequest CreateRequest(
+        string? gridAreaCode = null,
+        string? energySupplier = null,
+        string? balanceResponsible = null)
+    {
+        var request = new AggregatedTimeSeriesRequest()
+        {
+            // Required
+            Period = new Period()
+            {
+                Start = "2022-12-30T23:00:00Z",
+                End = "2022-12-31T23:00:00Z",
+            },
+            MeteringPointType = "E18",
+            RequestedByActorId = "1234567891234",
+            RequestedByActorRole = "DDQ",
+            BusinessReason = "D04",
+
+            // Optional
+            SettlementMethod = "D01",
+        };
+
+        if (gridAreaCode is not null)
+        {
+            request.GridAreaCode = gridAreaCode;
+        }
+
+        if (energySupplier is not null)
+        {
+            request.EnergySupplierId = energySupplier;
+        }
+
+        if (balanceResponsible is not null)
+        {
+            request.BalanceResponsibleId = balanceResponsible;
+        }
+
+        return request;
+    }
+}

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestFactoryTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestFactoryTests.cs
@@ -38,7 +38,6 @@ public class AggregatedTimeSeriesRequestFactoryTests
         var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
 
         // Assert
-        actual.Should().NotBeNull();
         using var assertionScope = new AssertionScope();
         var aggregationLevel = actual.AggregationPerRoleAndGridArea;
         aggregationLevel.BalanceResponsibleId.Should().Be(balanceResponsibleId);
@@ -62,7 +61,6 @@ public class AggregatedTimeSeriesRequestFactoryTests
         var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
 
         // Assert
-        actual.Should().NotBeNull();
         using var assertionScope = new AssertionScope();
         var aggregationLevel = actual.AggregationPerRoleAndGridArea;
         aggregationLevel.BalanceResponsibleId.Should().Be(balanceResponsibleId);
@@ -86,7 +84,6 @@ public class AggregatedTimeSeriesRequestFactoryTests
         var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
 
         // Assert
-        actual.Should().NotBeNull();
         using var assertionScope = new AssertionScope();
         var aggregationLevel = actual.AggregationPerRoleAndGridArea;
         aggregationLevel.BalanceResponsibleId.Should().BeNull();

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestRejectedMessageFactoryTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestRejectedMessageFactoryTests.cs
@@ -19,7 +19,7 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
 
-namespace Energinet.DataHub.Wholesale.EDI.UnitTests;
+namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Factories;
 
 public class AggregatedTimeSeriesRequestRejectedMessageFactoryTests
 {

--- a/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequest.proto
+++ b/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequest.proto
@@ -19,79 +19,18 @@ option csharp_namespace = "Energinet.DataHub.Edi.Requests";
 
 message AggregatedTimeSeriesRequest {
   Period period = 1;
-  oneof aggregation_level {
-    AggregationPerGridArea aggregation_per_gridarea = 2;
-    AggregationPerEnergySupplierPerGridArea aggregation_per_energysupplier_per_gridarea = 3;
-    AggregationPerBalanceResponsiblePartyPerGridArea aggregation_per_balanceresponsibleparty_per_gridarea = 4;
-    AggregationPerEnergySupplierPerBalanceResponsiblePartyPerGridArea aggregation_per_energysupplier_per_balanceresponsibleparty_per_gridarea = 5;
-  }
-  string metering_point_type = 6;
-  optional string settlement_method = 7;
-  optional string energy_supplier_id = 8;
-  string requested_by_actor_id = 9;
-  string requested_by_actor_role = 10;
-  optional string balance_responsible_id = 11;
-  optional string settlement_series_version = 12;
-  optional string grid_area_code = 13;
-  string business_reason = 14;
+  string metering_point_type = 2;
+  optional string settlement_method = 3;
+  optional string energy_supplier_id = 4;
+  string requested_by_actor_id = 5;
+  string requested_by_actor_role = 6;
+  optional string balance_responsible_id = 7;
+  optional string settlement_series_version = 8;
+  optional string grid_area_code = 9;
+  string business_reason = 10;
 }
 
 message Period {
   string start = 1;
   optional string end = 2;
-}
-
-message AggregationPerGridArea {
-  /*
-   * The grid area code specifying the grid area for which the time series is aggregated.
-   * The grid area code is a 3 character string consisting solely of digits.
-   * Examples:
-   *   543
-   *   020
-   *
-   * The grid responsible id is the sender id of the grid responsible.
-   */
-  string grid_area_code = 1;
-  string grid_responsible_id = 2;
-}
-
-message AggregationPerEnergySupplierPerGridArea {
-  /*
-   * The grid area code specifying the grid area for which the time series is aggregated.
-   * The grid area code is a 3 character string consisting solely of digits.
-   * Examples:
-   *   543
-   *   020
-   */
-  string grid_area_code = 1;
-
-  string energy_supplier_id = 2;
-}
-
-message AggregationPerBalanceResponsiblePartyPerGridArea {
-  /*
-   * The grid area code specifying the grid area for which the time series is aggregated.
-   * The grid area code is a 3 character string consisting solely of digits.
-   * Examples:
-   *   543
-   *   020
-   */
-  string grid_area_code = 1;
-
-  string balance_responsible_party_id = 2;
-}
-
-message AggregationPerEnergySupplierPerBalanceResponsiblePartyPerGridArea {
-  /*
-   * The grid area code specifying the grid area for which the time series is aggregated.
-   * The grid area code is a 3 character string consisting solely of digits.
-   * Examples:
-   *   543
-   *   020
-   */
-  string grid_area_code = 1;
-
-  string balance_responsible_party_id = 2;
-
-  string energy_supplier_id = 3;
 }

--- a/source/dotnet/wholesale-api/Edi/EdiRegistration.cs
+++ b/source/dotnet/wholesale-api/Edi/EdiRegistration.cs
@@ -31,7 +31,6 @@ public static class EdiRegistration
     {
         serviceCollection.AddScoped<IAggregatedTimeSeriesRequestHandler, AggregatedTimeSeriesRequestHandler>();
         serviceCollection.AddSingleton<IEdiClient, EdiClient>();
-        serviceCollection.AddScoped<IAggregatedTimeSeriesRequestFactory, AggregatedTimeSeriesRequestFactory>();
         AddAggregatedTimeSeriesRequestValidation(serviceCollection);
     }
 

--- a/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestFactory.cs
+++ b/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestFactory.cs
@@ -19,9 +19,9 @@ using Period = Energinet.DataHub.Wholesale.EDI.Models.Period;
 
 namespace Energinet.DataHub.Wholesale.EDI.Factories;
 
-public class AggregatedTimeSeriesRequestFactory : IAggregatedTimeSeriesRequestFactory
+public class AggregatedTimeSeriesRequestFactory
 {
-    public AggregatedTimeSeriesRequest Parse(Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest request)
+    public static AggregatedTimeSeriesRequest Parse(Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest request)
     {
         return new AggregatedTimeSeriesRequest(
             MapPeriod(request.Period),
@@ -30,30 +30,15 @@ public class AggregatedTimeSeriesRequestFactory : IAggregatedTimeSeriesRequestFa
             RequestedProcessTypeMapper.ToRequestedProcessType(request.BusinessReason, request.HasSettlementSeriesVersion ? request.SettlementSeriesVersion : null));
     }
 
-    private AggregationPerRoleAndGridArea MapAggregationPerRoleAndGridArea(Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest request)
+    private static AggregationPerRoleAndGridArea MapAggregationPerRoleAndGridArea(Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest request)
     {
-        return request.AggregationLevelCase switch
-        {
-            Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest.AggregationLevelOneofCase.AggregationPerGridarea =>
-                new AggregationPerRoleAndGridArea(GridAreaCode: request.AggregationPerGridarea.GridAreaCode),
-            Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest.AggregationLevelOneofCase.AggregationPerEnergysupplierPerGridarea =>
-                new AggregationPerRoleAndGridArea(
-                    GridAreaCode: request.AggregationPerEnergysupplierPerGridarea.GridAreaCode,
-                    EnergySupplierId: request.AggregationPerEnergysupplierPerGridarea.EnergySupplierId),
-            Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest.AggregationLevelOneofCase.AggregationPerBalanceresponsiblepartyPerGridarea =>
-                new AggregationPerRoleAndGridArea(
-                    GridAreaCode: request.AggregationPerBalanceresponsiblepartyPerGridarea.GridAreaCode,
-                    BalanceResponsibleId: request.AggregationPerBalanceresponsiblepartyPerGridarea.BalanceResponsiblePartyId),
-            Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest.AggregationLevelOneofCase.AggregationPerEnergysupplierPerBalanceresponsiblepartyPerGridarea =>
-                new AggregationPerRoleAndGridArea(
-                    GridAreaCode: request.AggregationPerEnergysupplierPerBalanceresponsiblepartyPerGridarea.GridAreaCode,
-                    EnergySupplierId: request.AggregationPerEnergysupplierPerBalanceresponsiblepartyPerGridarea.EnergySupplierId,
-                    BalanceResponsibleId: request.AggregationPerEnergysupplierPerBalanceresponsiblepartyPerGridarea.BalanceResponsiblePartyId),
-            _ => throw new InvalidOperationException("Unknown aggregation level"),
-        };
+        return new AggregationPerRoleAndGridArea(
+            GridAreaCode: request.HasGridAreaCode ? request.GridAreaCode : null,
+            EnergySupplierId: request.HasEnergySupplierId ? request.EnergySupplierId : null,
+            BalanceResponsibleId: request.HasBalanceResponsibleId ? request.BalanceResponsibleId : null);
     }
 
-    private Period MapPeriod(Energinet.DataHub.Edi.Requests.Period period)
+    private static Period MapPeriod(Energinet.DataHub.Edi.Requests.Period period)
     {
         return new Period(
         InstantPattern.General.Parse(period.Start).Value,

--- a/source/dotnet/wholesale-api/Edi/Models/AggregationPerRoleAndGridArea.cs
+++ b/source/dotnet/wholesale-api/Edi/Models/AggregationPerRoleAndGridArea.cs
@@ -14,4 +14,4 @@
 
 namespace Energinet.DataHub.Wholesale.EDI.Models;
 
-public record AggregationPerRoleAndGridArea(string GridAreaCode, string? EnergySupplierId = null, string? BalanceResponsibleId = null);
+public record AggregationPerRoleAndGridArea(string? GridAreaCode, string? EnergySupplierId = null, string? BalanceResponsibleId = null);


### PR DESCRIPTION
If an energy supplier or balance responsible request aggregated time series for a specific grid area and there is no data. We check if the actor has data for another grid area and return a matching error
