### PR TITLE
refac: Use metering_point_time_series in tariff calculation

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/calculation.py
@@ -40,9 +40,9 @@ def execute(args: CalculatorArgs, prepared_data_reader: PreparedDataReader) -> N
     )
 
     metering_point_time_series = prepared_data_reader.get_metering_point_time_series(
-        metering_point_periods_df,
         args.batch_period_start_datetime,
         args.batch_period_end_datetime,
+        metering_point_periods_df,
     ).cache()
 
     basis_data_writer = BasisDataWriter(args.wholesale_container_path, args.batch_id)
@@ -75,11 +75,10 @@ def execute(args: CalculatorArgs, prepared_data_reader: PreparedDataReader) -> N
         metering_points_periods_df = _get_production_and_consumption_metering_points(
             metering_point_periods_df
         )
-        raw_time_series_points = prepared_data_reader.get_raw_time_series_points()
 
         tariffs_hourly_df = prepared_data_reader.get_tariff_charges(
             metering_points_periods_df,
-            raw_time_series_points,
+            metering_point_time_series,
             charges_df,
             ChargeResolution.HOUR,
         )

--- a/source/databricks/calculation_engine/package/calculation/calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/calculation.py
@@ -40,9 +40,9 @@ def execute(args: CalculatorArgs, prepared_data_reader: PreparedDataReader) -> N
     )
 
     metering_point_time_series = prepared_data_reader.get_metering_point_time_series(
+        metering_point_periods_df,
         args.batch_period_start_datetime,
         args.batch_period_end_datetime,
-        metering_point_periods_df,
     ).cache()
 
     basis_data_writer = BasisDataWriter(args.wholesale_container_path, args.batch_id)

--- a/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types.py
@@ -23,7 +23,7 @@ from package.constants import Colname
 
 def get_tariff_charges(
     metering_points: DataFrame,
-    time_series: DataFrame,
+    metering_point_time_series: DataFrame,
     charges_df: DataFrame,
     resolution: ChargeResolution,
 ) -> DataFrame:
@@ -39,7 +39,7 @@ def get_tariff_charges(
     # group by time series on metering point id and resolution and sum quantity
     grouped_time_series = (
         _group_by_time_series_on_metering_point_id_and_resolution_and_sum_quantity(
-            time_series
+            metering_point_time_series
         )
     )
 
@@ -138,10 +138,10 @@ def _join_with_metering_points(df: DataFrame, metering_points: DataFrame) -> Dat
 
 
 def _group_by_time_series_on_metering_point_id_and_resolution_and_sum_quantity(
-    time_series: DataFrame,
+    metering_point_time_series: DataFrame,
 ) -> DataFrame:
     grouped_time_series = t.aggregate_quantity_and_quality(
-        time_series,
+        metering_point_time_series,
         [
             Colname.metering_point_id,
             Colname.observation_time,


### PR DESCRIPTION
Currently, wholesale calculation reads raw time series although the time series data is already available via metering_point_time_series. This gives high performance penalty. In this PR metering_point_time_series is sent to the wholesale calculation instead, thereby avoiding the extra loading from delta lake.