### PR TITLE
fix: calculation result should be group by grid area

### DIFF
--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/AggregatedTimeSeriesQueryStatement.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/AggregatedTimeSeriesQueryStatement.cs
@@ -49,7 +49,7 @@ public class AggregatedTimeSeriesQueryStatement : DatabricksStatement
             WHERE t2.time IS NULL
                 AND {CreateSqlQueryFilters(_parameters)}";
 
-        sql += $@"ORDER BY t1.time";
+        sql += $@"ORDER BY t1.{EnergyResultColumnNames.GridArea}, t1.{EnergyResultColumnNames.Time}";
         return sql;
     }
 

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Infrastructure/RequestCalculationResult/AggregatedTimeSeriesQueriesTests.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Infrastructure/RequestCalculationResult/AggregatedTimeSeriesQueriesTests.cs
@@ -236,6 +236,33 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
     }
 
     [Fact]
+    public async Task GetAsync_WhenRequestFromEnergySupplierTotalProductionWithoutGridAreaFilter_ReturnsOneResultPerGridArea()
+    {
+        // Arrange
+        var energySupplierIdFilter = "4321987654321";
+        var timeSeriesTypeFilter = TimeSeriesType.Production;
+        var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
+        var endOfPeriodFilter = Instant.FromUtc(2022, 1, 2, 0, 0);
+        await AddCreatedRowsInArbitraryOrderAsync();
+        var parameters = CreateQueryParameters(
+            timeSeriesType: timeSeriesTypeFilter,
+            startOfPeriod: startOfPeriodFilter,
+            endOfPeriod: endOfPeriodFilter,
+            energySupplierId: energySupplierIdFilter);
+
+        // Act
+        var actual = await Sut.GetAsync(parameters).ToListAsync();
+
+        // Assert
+        var resultsPerGridArea = actual.GroupBy(x => x.GridArea);
+        using var assertionScope = new AssertionScope();
+        foreach (var resultsInGridArea in resultsPerGridArea)
+        {
+            resultsInGridArea.Should().ContainSingle($"There should be only one result for grid area: {resultsInGridArea.Key}.");
+        }
+    }
+
+    [Fact]
     public async Task GetAsync_WhenRequestFromGridOperatorTotalProductionFirstCorrectionSettlement_ReturnsResult()
     {
         // Arrange
@@ -424,7 +451,7 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
         // Assert
         using var assertionScope = new AssertionScope();
         actual.Should().HaveCount(2);
-        actual.Select(result => result.GridArea).Should().Equal(GridAreaCodeC, GridAreaCodeB);
+        actual.Select(result => result.GridArea).Should().Equal(GridAreaCodeB, GridAreaCodeC);
         actual.Should().AllSatisfy(aggregatedTimeSeries => aggregatedTimeSeries.TimeSeriesType.Should().Be(timeSeriesTypeFilter));
     }
 
@@ -591,6 +618,9 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
         var row9 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCodeA, quantity: FirstQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea);
         var row10 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: thirdHour, gridArea: GridAreaCodeB, quantity: FourthQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndBalanceResponsibleAndGridArea, balanceResponsibleId: balanceResponsibleId, energySupplierId: energySupplier);
 
+        var row11 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: firstHour, gridArea: GridAreaCodeB, quantity: FirstQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndGridArea, energySupplierId: energySupplier);
+        var row12 = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, time: secondHour, gridArea: GridAreaCodeB, quantity: FirstQuantity, aggregationLevel: DeltaTableAggregationLevel.EnergySupplierAndGridArea, energySupplierId: energySupplier);
+
         var row1FirstCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, batchProcessType: DeltaTableProcessType.FirstCorrectionSettlement, time: firstHour, gridArea: GridAreaCodeC, quantity: FirstQuantityFirstCorrection);
         var row2FirstCorrection = EnergyResultDeltaTableHelper.CreateRowValues(batchId: BatchId, calculationResultId: firstCalculationResultId, batchProcessType: DeltaTableProcessType.FirstCorrectionSettlement, time: secondHour, gridArea: GridAreaCodeC, quantity: SecondQuantityFirstCorrection);
 
@@ -616,6 +646,8 @@ public class AggregatedTimeSeriesQueriesTests : TestBase<AggregatedTimeSeriesQue
             row8,
             row9,
             row10,
+            row11,
+            row12,
             row1SecondDay,
             row1ThirdDay,
         };


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

Ensure we group the result by grid area to avoid creating multiple results for the same grid area

## TODO

Please complete and remove this TODO section before entering PR ready for review state.

- [x] Title: Follow [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Write tests
- [ ] Update documentation
- [ ] Update [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) if there are relevant changes to integration events
- [ ] Inform team Outlaws if there are relevant C4 changes
