### PR TITLE
refac: Add calculation id to log message

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/calculation.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-from datetime import datetime
-
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
 
@@ -47,11 +44,6 @@ def execute(args: CalculatorArgs, prepared_data_reader: PreparedDataReader) -> N
         args.batch_period_end_datetime,
         metering_point_periods_df,
     ).cache()
-
-    logger = logging.getLogger(__name__)
-    logger.info(
-        f"Done getting metering_point_time_series, calc. id:{args.batch_id}, time: {datetime.now()}"
-    )
 
     energy_calculation.execute(
         args.batch_id,

--- a/source/databricks/calculation_engine/package/calculation/calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/calculation.py
@@ -49,13 +49,8 @@ def execute(args: CalculatorArgs, prepared_data_reader: PreparedDataReader) -> N
     ).cache()
 
     logger = logging.getLogger(__name__)
-    logger.info(f"Done getting metering_point_time_series: {datetime.now()}")
-
-    basis_data_writer = BasisDataWriter(args.wholesale_container_path, args.batch_id)
-    basis_data_writer.write(
-        metering_point_periods_df,
-        metering_point_time_series,
-        args.time_zone,
+    logger.info(
+        f"Done getting metering_point_time_series, calc. id:{args.batch_id}, time: {datetime.now()}"
     )
 
     energy_calculation.execute(
@@ -94,6 +89,13 @@ def execute(args: CalculatorArgs, prepared_data_reader: PreparedDataReader) -> N
             tariffs_hourly_df,
             args.batch_period_start_datetime,
         )
+
+    basis_data_writer = BasisDataWriter(args.wholesale_container_path, args.batch_id)
+    basis_data_writer.write(
+        metering_point_periods_df,
+        metering_point_time_series,
+        args.time_zone,
+    )
 
 
 def _get_production_and_consumption_metering_points(

--- a/source/databricks/calculation_engine/package/calculation/energy/energy_calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/energy_calculation.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from datetime import datetime
+import logging
 from pyspark.sql import DataFrame
 
 import package.calculation.energy.aggregators.metering_point_time_series_aggregators as mp_aggr
@@ -56,6 +57,7 @@ def execute(
     quarterly_metering_point_time_series.cache_internal()
 
     _calculate(
+        batch_id,
         batch_process_type,
         batch_grid_areas,
         calculation_result_writer,
@@ -65,6 +67,7 @@ def execute(
 
 
 def _calculate(
+    batch_id: str,
     process_type: ProcessType,
     batch_grid_areas: list[str],
     result_writer: EnergyCalculationResultWriter,
@@ -78,6 +81,8 @@ def _calculate(
         result_writer,
         quarterly_metering_point_time_series,
     )
+    logger = logging.getLogger(__name__)
+    logger.info(f"Finalized exchange calculation, calc. id:{batch_id}")
 
     temporary_production_per_ga_and_brp_and_es = (
         _calculate_temporary_production_per_per_ga_and_brp_and_es(

--- a/source/databricks/calculation_engine/package/calculation_output/basis_data_writer.py
+++ b/source/databricks/calculation_engine/package/calculation_output/basis_data_writer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-from datetime import datetime
 
 from pyspark.sql import DataFrame
 from pyspark.sql.functions import col

--- a/source/databricks/calculation_engine/package/calculation_output/basis_data_writer.py
+++ b/source/databricks/calculation_engine/package/calculation_output/basis_data_writer.py
@@ -29,6 +29,7 @@ class BasisDataWriter:
         self.__master_basis_data_path = f"{container_path}/{paths.get_basis_data_root_path(BasisDataType.MASTER_BASIS_DATA, batch_id)}"
         self.__time_series_quarter_path = f"{container_path}/{paths.get_basis_data_root_path(BasisDataType.TIME_SERIES_QUARTER, batch_id)}"
         self.__time_series_hour_path = f"{container_path}/{paths.get_basis_data_root_path(BasisDataType.TIME_SERIES_HOUR, batch_id)}"
+        self.calculation_id = batch_id
         self.logger = logging.getLogger(__name__)
 
     def write(
@@ -56,9 +57,7 @@ class BasisDataWriter:
         timeseries_quarter_df: DataFrame,
         timeseries_hour_df: DataFrame,
     ) -> None:
-        self.logger.info(
-            f"Start writing basis data per grid area to csv: {datetime.now()}"
-        )
+        self._log_message("Start writing basis data per grid area to csv")
 
         self._write_ga_basis_data(
             master_basis_data_df,
@@ -66,9 +65,7 @@ class BasisDataWriter:
             timeseries_hour_df,
         )
 
-        self.logger.info(
-            f"Start writing basis data per energy supplier to csv: {datetime.now()}"
-        )
+        self._log_message("Start writing basis data per energy supplier to csv")
 
         self._write_es_basis_data(
             master_basis_data_df,
@@ -76,7 +73,7 @@ class BasisDataWriter:
             timeseries_hour_df,
         )
 
-        self.logger.info(f"Done writing basis data to csv: {datetime.now()}")
+        self._log_message("one writing basis data to csv")
 
     def _write_ga_basis_data(
         self,
@@ -144,9 +141,7 @@ class BasisDataWriter:
         grouping_folder_name: str,
         partition_keys: list[str],
     ) -> None:
-        self.logger.info(
-            f"Start writing timeseries_quarter_df to csv: {datetime.now()}"
-        )
+        self._log_message("Start writing timeseries_quarter_df to csv")
 
         self._write_df_to_csv(
             f"{self.__time_series_quarter_path}/{grouping_folder_name}",
@@ -154,7 +149,7 @@ class BasisDataWriter:
             partition_keys,
         )
 
-        self.logger.info(f"Start writing timeseries_hour_df to csv: {datetime.now()}")
+        self._log_message("Start writing timeseries_hour_df to csv")
 
         self._write_df_to_csv(
             f"{self.__time_series_hour_path}/{grouping_folder_name}",
@@ -162,7 +157,7 @@ class BasisDataWriter:
             partition_keys,
         )
 
-        self.logger.info(f"Start writing master_basis_data_df to csv: {datetime.now()}")
+        self._log_message("Start writing master_basis_data_df to csv")
 
         self._write_df_to_csv(
             f"{self.__master_basis_data_path}/{grouping_folder_name}",
@@ -176,3 +171,8 @@ class BasisDataWriter:
         df.repartition(PartitionKeyName.GRID_AREA).write.mode("overwrite").partitionBy(
             partition_keys
         ).option("header", True).csv(path)
+
+    def _log_message(self, message: str) -> None:
+        self.logger.info(
+            f"{message}, calc. id:{self.calculation_id}, time: {datetime.now()}"
+        )

--- a/source/databricks/calculation_engine/package/calculation_output/basis_data_writer.py
+++ b/source/databricks/calculation_engine/package/calculation_output/basis_data_writer.py
@@ -38,6 +38,8 @@ class BasisDataWriter:
         metering_point_time_series: DataFrame,
         time_zone: str,
     ) -> None:
+        self._log_message("Entering basis_data_writer.write()")
+
         (
             timeseries_quarter_df,
             timeseries_hour_df,
@@ -50,6 +52,8 @@ class BasisDataWriter:
         )
 
         self._write(master_basis_data_df, timeseries_quarter_df, timeseries_hour_df)
+
+        self._log_message("Leaving basis_data_writer.write()")
 
     def _write(
         self,
@@ -173,6 +177,4 @@ class BasisDataWriter:
         ).option("header", True).csv(path)
 
     def _log_message(self, message: str) -> None:
-        self.logger.info(
-            f"{message}, calc. id:{self.calculation_id}, time: {datetime.now()}"
-        )
+        self.logger.info(f"{message}, calc. id:{self.calculation_id}")


### PR DESCRIPTION
A part from adding calculation id to log message, this PR also moves basis data writing to the end of the flow. This makes it easier investigate performance of csv writing, because all data is already materialized when writing basis data 