### PR TITLE
refac: Add logging in energy_calculation_result_writer

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/calculator_args.py
+++ b/source/databricks/calculation_engine/package/calculation/calculator_args.py
@@ -24,7 +24,7 @@ class CalculatorArgs:
     data_storage_account_credentials: ClientSecretCredential
     wholesale_container_path: str
     calculation_input_path: str
-    time_series_periods_table_name: str | None
+    time_series_points_table_name: str | None
     metering_point_periods_table_name: str | None
     batch_id: str
     batch_grid_areas: list[str]

--- a/source/databricks/calculation_engine/package/calculation/energy/energy_calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/energy_calculation.py
@@ -35,7 +35,6 @@ from package.codelists import (
     ProcessType,
     MeteringPointType,
 )
-from package.common.logger import Logger
 
 
 def execute(
@@ -82,8 +81,6 @@ def _calculate(
         result_writer,
         quarterly_metering_point_time_series,
     )
-    logger = Logger(__name__)
-    logger.info(f"Finalized exchange calculation, calc. id:{batch_id}")
 
     temporary_production_per_ga_and_brp_and_es = (
         _calculate_temporary_production_per_per_ga_and_brp_and_es(

--- a/source/databricks/calculation_engine/package/calculation_output/energy_calculation_result_writer.py
+++ b/source/databricks/calculation_engine/package/calculation_output/energy_calculation_result_writer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from datetime import datetime
+from package.common.logger import Logger
 
 import pyspark.sql.functions as f
 from pyspark.sql import DataFrame
@@ -55,6 +56,12 @@ class EnergyCalculationResultWriter:
         results_df = self._map_to_storage_dataframe(results_df)
 
         self._write_to_storage(results_df)
+
+        logger = Logger(__name__)
+        logger.info(
+            f"Leaving ´energy_calculation_result_writer::write´. Time series type: {time_series_type.value}. "
+            f"Aggregation level: {aggregation_level.value}"
+        )
 
     @staticmethod
     def _add_aggregation_level_and_time_series_type(

--- a/source/databricks/calculation_engine/package/calculator_job.py
+++ b/source/databricks/calculation_engine/package/calculator_job.py
@@ -94,7 +94,7 @@ def create_prepared_data_reader(args: CalculatorArgs) -> calculation.PreparedDat
     delta_table_reader = calculation_input.TableReader(
         spark,
         args.calculation_input_path,
-        args.time_series_periods_table_name,
+        args.time_series_points_table_name,
         args.metering_point_periods_table_name,
     )
     prepared_data_reader = calculation.PreparedDataReader(delta_table_reader)

--- a/source/databricks/calculation_engine/package/calculator_job_args.py
+++ b/source/databricks/calculation_engine/package/calculator_job_args.py
@@ -39,7 +39,7 @@ def get_calculator_args() -> CalculatorArgs:
         data_storage_account_credentials=credential,
         wholesale_container_path=paths.get_container_root_path(storage_account_name),
         calculation_input_path=paths.get_calculation_input_path(storage_account_name),
-        time_series_periods_table_name=job_args.time_series_periods_table_name,
+        time_series_points_table_name=job_args.time_series_points_table_name,
         metering_point_periods_table_name=job_args.metering_point_periods_table_name,
         batch_id=job_args.batch_id,
         batch_grid_areas=job_args.batch_grid_areas,
@@ -66,7 +66,7 @@ def _get_valid_args_or_throw(command_line_args: list[str]) -> argparse.Namespace
     p.add("--batch-period-end-datetime", type=valid_date, required=True)
     p.add("--batch-process-type", type=ProcessType, required=True)
     p.add("--batch-execution-time-start", type=valid_date, required=True)
-    p.add("--time_series_periods_table_name", type=str, required=False)
+    p.add("--time_series_points_table_name", type=str, required=False)
     p.add("--metering_point_periods_table_name", type=str, required=False)
 
     args, unknown_args = p.parse_known_args(args=command_line_args)

--- a/source/databricks/calculation_engine/tests/calculator_job/conftest.py
+++ b/source/databricks/calculation_engine/tests/calculator_job/conftest.py
@@ -51,7 +51,7 @@ def calculator_args_balance_fixing(
         data_storage_account_credentials=ClientSecretCredential("foo", "foo", "foo"),
         wholesale_container_path=data_lake_path,
         calculation_input_path=calculation_input_path,
-        time_series_periods_table_name=None,
+        time_series_points_table_name=None,
         metering_point_periods_table_name=None,
         batch_id=C.executed_balance_fixing_batch_id,
         batch_process_type=ProcessType.BALANCE_FIXING,

--- a/source/databricks/calculation_engine/tests/infrastructure/test_get_calculator_args.py
+++ b/source/databricks/calculation_engine/tests/infrastructure/test_get_calculator_args.py
@@ -111,15 +111,15 @@ class TestWhenInvokedWithValidParameters:
         )
         assert actual.time_zone == "Europe/Copenhagen"
 
-    def test_parses_optional_time_series_periods_table_name(
+    def test_parses_optional_time_series_points_table_name(
         self,
         job_environment_variables: dict,
         sys_argv_from_contract,
     ) -> None:
         # Arrange
-        expected = "the_time_series_periods_table_name"
+        expected = "the_time_series_points_table_name"
         sys_argv_from_contract = sys_argv_from_contract + [
-            f"--time_series_periods_table_name={expected}"
+            f"--time_series_points_table_name={expected}"
         ]
 
         with patch("sys.argv", sys_argv_from_contract):
@@ -128,9 +128,9 @@ class TestWhenInvokedWithValidParameters:
                 actual = get_calculator_args()
 
         # Assert
-        assert actual.time_series_periods_table_name == expected
+        assert actual.time_series_points_table_name == expected
 
-    def test_returns_none_when_time_series_periods_table_name_absent(
+    def test_returns_none_when_time_series_points_table_name_absent(
         self,
         job_environment_variables: dict,
         sys_argv_from_contract,
@@ -142,7 +142,7 @@ class TestWhenInvokedWithValidParameters:
                 actual = get_calculator_args()
 
         # Assert
-        assert actual.time_series_periods_table_name is None
+        assert actual.time_series_points_table_name is None
 
 
 class TestWhenUnknownProcessType:


### PR DESCRIPTION
Adding log statement when leavin write(...). This makes it easier to see the performance of each energy calculation

Also, a minor type-o in is fixed (time_series_periods -> time_series_points)