### PR TITLE
Filter Job list by job name when requesting jobs

### DIFF
--- a/source/dotnet/domain-tests/Fixtures/DatabricksClientExtensions.cs
+++ b/source/dotnet/domain-tests/Fixtures/DatabricksClientExtensions.cs
@@ -70,7 +70,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
         /// </summary>
         public static async Task<long> GetCalculatorJobIdAsync(this DatabricksClient databricksClient)
         {
-            var jobs = await databricksClient.Jobs.List(limit: 100);
+            var jobs = await databricksClient.Jobs.List(name: "CalculatorJob");
             return jobs.Jobs
                 .Single(j => j.Settings.Name == "CalculatorJob")
                 .JobId;

--- a/source/dotnet/domain-tests/Fixtures/DatabricksClientExtensions.cs
+++ b/source/dotnet/domain-tests/Fixtures/DatabricksClientExtensions.cs
@@ -72,7 +72,7 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Fixtures
         {
             var jobs = await databricksClient.Jobs.List(name: "CalculatorJob");
             return jobs.Jobs
-                .Single(j => j.Settings.Name == "CalculatorJob")
+                .Single()
                 .JobId;
         }
     }


### PR DESCRIPTION
Job list API docs. was incorrect with regards to "limit" (max is not 100 but 25), so I decided to use name filter instead, which is also better anyways: https://docs.databricks.com/api/workspace/jobs/list