### PR TITLE
refac: Remove retry of python tests

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -23,66 +23,14 @@ cd source/databricks/calculation_engine/tests/
 export PYSPARK_PYTHON=/opt/conda/bin/python
 export PYSPARK_DRIVER_PYTHON=/opt/conda/bin/python
 
-# Writing output to log with 'tee' cause exit code to be '0' even if tests fails
-coverage run --branch -m pytest --junitxml=pytest-results.xml . | tee pytest-results.log
-
-################################################
-# Scenario: Test errors (exceptions) occured
-################################################
-
-# EXAMPLE 1 test summary which our regex can match (multiple errors):
-# ================== 65 passed, 195 errors in 94.15s (0:01:34) ===================
-
-# EXAMPLE 2 test summary which our regex can match (single error):
-# ============ 610 passed, 989 warnings, 1 error in 455.00s (0:07:34) ============
-
-# If test summary contains errors we return exit code 2 to signal we want to retry
-matchTestErrors=$(grep -Po '^=+.* [[:digit:]]+ error.* in .*=+$' pytest-results.log)
-if [ ! -z "$matchTestErrors" ]; then
-  echo "Test errors occured, which is typically caused by network issues (download failure). We should retry."
-  exit 2
-fi
-
-################################################
-# Scenario: Only 'entry point tests' failed
-################################################
-
-# EXAMPLE test summary which our regex can match:
-# =========================== short test summary info ============================
-# FAILED entry_points/test_entry_points.py::test__entry_point__start_calculator__returns_0
-# FAILED entry_points/test_entry_points.py::test__entry_point__uncommitted_migrations_count__returns_0
-# FAILED entry_points/test_entry_points.py::test__entry_point__unlock_storage__returns_0
-# FAILED entry_points/test_entry_points.py::test__entry_point__lock_storage__returns_0
-# FAILED entry_points/test_entry_points.py::test__entry_point__migrate_data_lake__returns_0
-# ============= 5 failed, 264 passed, 3 skipped in 191.60s (0:03:11) =============
-
-# If test summary only contains 5 failing 'entry point tests' return exit code 2 to signal we want to retry
-# See https://unix.stackexchange.com/questions/637959/regex-matching-multi-line-search for understanding use of
-#   z parameter to grep
-#   (?m) in regex
-#   pipe to remove NULL
-matchFailedEntryPointTests=$(grep -Pzo '(?m)=+ short test summary info =+\n(FAILED .*test_entry_points.py::.*\n){5}=+ 5 failed' pytest-results.log | tr -d '\0')
-if [ ! -z "$matchFailedEntryPointTests" ]; then
-  echo "Only 'entry point tests' failed. We should retry."
-  exit 2
-fi
-
-################################################
-# Scenario: Not only 'entry point tests' failed
-################################################
-
-# If test summary contains other combination of failed tests we return exit code 1 to signal we DO NOT want to retry
-matchFailedTests=$(grep -Po '^=+.* [[:digit:]]+ failed.* in .*=+$' pytest-results.log)
-if [ ! -z "$matchFailedTests" ]; then
-  echo "Not only 'entry point tests' failed. We should not retry."
-  exit 1
-fi
-
 # Exit immediately with failure status if any command fails
 set -e
+
+coverage run --branch -m pytest --junitxml=pytest-results.xml .
 
 # Create data for threshold evaluation
 coverage json
 # Create human reader friendly HTML report
 coverage html
+
 coverage-threshold --line-coverage-min 25

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -18,17 +18,8 @@ description: This action allows you to execute code, written for Spark, Databric
 runs:
   using: composite
   steps:
-    - name: Execute entrypoint.sh (with retry)
-      uses: nick-fields/retry@v2
-      with:
-        timeout_minutes: 15
-
-        # Disabled retry after merge of PR-1048, as this retry might not be needed anymore.
-        # Will keep it now, if pipeline is still unstable periodically, reverting will be much easier
-        # Note: Dont forget to remove logic regarding exit codes in the entrypoint.sh script if removing retry logic at some point
-        max_attempts: 1
-        retry_on_exit_code: 2 # In our script we return exit code 2 if we detect a scenario for which to retry
-        shell: bash
-        command: |
-          chmod +x ./.docker/entrypoint.sh
-          docker-compose -f .devcontainer/docker-compose.yml run --rm -u root -w //workspaces/opengeh-wholesale wholesale ./.docker/entrypoint.sh
+    - name: Execute python tests
+      shell: bash
+      run: |
+        chmod +x ./.docker/entrypoint.sh
+        docker-compose -f .devcontainer/docker-compose.yml run --rm -u root -w //workspaces/opengeh-wholesale wholesale ./.docker/entrypoint.sh


### PR DESCRIPTION
We might not need retry anymore, and it complicates the CI pipeline. So we will make an experiment at remove it for now, and then create a task so we remember to follow up in a month or so. If we did not experience issues within that month, we expect it can be removed forever.