### PR TITLE
feat: Filter python tests

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# $1: Is used to set a filter for running python tests by using 'keyword expressions'.
+# $1: (Optional) Can be set to specify a filter for running python tests by using 'keyword expressions'.
 # See use of '-k' and 'keyword expressions' here: https://docs.pytest.org/en/7.4.x/how-to/usage.html#specifying-which-tests-to-run
 echo "Filter (keyword expression): $1"
 

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# $1: Can be used to set a filter for running python tests by using 'keyword expressions'.
+# See use of '-k' and 'keyword expressions' here: https://docs.pytest.org/en/7.4.x/how-to/usage.html#specifying-which-tests-to-run
+echo "Filter (keyword expression): $1"
+
 # Configure Azure CLI to use token cache which must be mapped as volume from host machine
 export AZURE_CONFIG_DIR=/root/.azure
-
-cd source/databricks/calculation_engine/tests/
 
 # There env vars are important to ensure that the driver and worker nodes in spark are alligned
 export PYSPARK_PYTHON=/opt/conda/bin/python
@@ -26,7 +28,8 @@ export PYSPARK_DRIVER_PYTHON=/opt/conda/bin/python
 # Exit immediately with failure status if any command fails
 set -e
 
-coverage run --branch -m pytest --junitxml=pytest-results.xml .
+cd source/databricks/calculation_engine/tests/
+coverage run --branch -m pytest -k "$1" --junitxml=pytest-results.xml .
 
 # Create data for threshold evaluation
 coverage json

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# $1: Can be used to set a filter for running python tests by using 'keyword expressions'.
+# $1: Is used to set a filter for running python tests by using 'keyword expressions'.
 # See use of '-k' and 'keyword expressions' here: https://docs.pytest.org/en/7.4.x/how-to/usage.html#specifying-which-tests-to-run
 echo "Filter (keyword expression): $1"
 

--- a/.github/actions/python-unit-test/action.yml
+++ b/.github/actions/python-unit-test/action.yml
@@ -15,6 +15,11 @@
 name: PySpark execution
 description: This action allows you to execute code, written for Spark, Databricks or other similar engines.
 
+inputs:
+  tests_filter_expression:
+    description: Filter expression to use with pytest. Read description in 'entrypoint.sh'.
+    required: true
+
 runs:
   using: composite
   steps:
@@ -22,4 +27,4 @@ runs:
       shell: bash
       run: |
         chmod +x ./.docker/entrypoint.sh
-        docker-compose -f .devcontainer/docker-compose.yml run --rm -u root -w //workspaces/opengeh-wholesale wholesale ./.docker/entrypoint.sh
+        docker-compose -f .devcontainer/docker-compose.yml run --rm -u root -w //workspaces/opengeh-wholesale wholesale ./.docker/entrypoint.sh "${{ inputs.tests_filter_expression }}"

--- a/.github/workflows/ci-databricks.yml
+++ b/.github/workflows/ci-databricks.yml
@@ -130,7 +130,7 @@ jobs:
       # documented here: https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/databricks#styling-and-formatting
       ignore_errors_and_warning_flake8: E501,F401,E402,E203,W503
       test_report_path: ./source/databricks/calculation_engine/tests
-      tests_filter_expression: "not calculator_job"
+      tests_filter_expression: not calculator_job
 
   mypy_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-databricks.yml
+++ b/.github/workflows/ci-databricks.yml
@@ -105,19 +105,32 @@ jobs:
             fi
           done
 
-  databricks_ci_test:
-    uses: Energinet-DataHub/.github/.github/workflows/python-ci.yml@v12
+  python_tests_calculationjob:
+    # TODO: Revert to using v12
+    uses: Energinet-DataHub/.github/.github/workflows/python-ci.yml@dstenroejl/python-ci-test-filter
     with:
       operating_system: dh3-ubuntu-20.04-4core
       path_static_checks: ./source/databricks/calculation_engine
       # documented here: https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/databricks#styling-and-formatting
       ignore_errors_and_warning_flake8: E501,F401,E402,E203,W503
       test_report_path: ./source/databricks/calculation_engine/tests
+      tests_filter_expression: calculator_job
       use_integrationtest_environment: true
       azure_integrationtest_tenant_id: ${{ vars.integration_test_azure_tenant_id }}
       azure_integrationtest_subscription_id: ${{ vars.integration_test_azure_subscription_id }}
       azure_integrationtest_spn_id: ${{ vars.integration_test_azure_spn_id_oidc }}
       azure_keyvault_url: ${{ vars.integration_test_azure_keyvault_url }}
+
+  python_tests_other:
+    # TODO: Revert to using v12
+    uses: Energinet-DataHub/.github/.github/workflows/python-ci.yml@dstenroejl/python-ci-test-filter
+    with:
+      operating_system: dh3-ubuntu-20.04-4core
+      path_static_checks: ./source/databricks/calculation_engine
+      # documented here: https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/databricks#styling-and-formatting
+      ignore_errors_and_warning_flake8: E501,F401,E402,E203,W503
+      test_report_path: ./source/databricks/calculation_engine/tests
+      tests_filter_expression: "not calculator_job"
 
   mypy_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-databricks.yml
+++ b/.github/workflows/ci-databricks.yml
@@ -106,8 +106,7 @@ jobs:
           done
 
   python_tests_calculationjob:
-    # TODO: Revert to using v12
-    uses: Energinet-DataHub/.github/.github/workflows/python-ci.yml@dstenroejl/python-ci-test-filter
+    uses: Energinet-DataHub/.github/.github/workflows/python-ci.yml@v12
     with:
       operating_system: dh3-ubuntu-20.04-4core
       path_static_checks: ./source/databricks/calculation_engine
@@ -122,8 +121,7 @@ jobs:
       azure_keyvault_url: ${{ vars.integration_test_azure_keyvault_url }}
 
   python_tests_other:
-    # TODO: Revert to using v12
-    uses: Energinet-DataHub/.github/.github/workflows/python-ci.yml@dstenroejl/python-ci-test-filter
+    uses: Energinet-DataHub/.github/.github/workflows/python-ci.yml@v12
     with:
       operating_system: dh3-ubuntu-20.04-4core
       path_static_checks: ./source/databricks/calculation_engine


### PR DESCRIPTION
We want to split python tests so we can run some on one GitHub runner and others on another runner, so they run in parallel and our CI pipeline becomes faster.

To do this we need to be able to define a filter that pytest can understand.