### PR TITLE
fix: Do not remove calculation_input folder in migrations_executed fixture

### DIFF
--- a/source/databricks/calculation_engine/tests/conftest.py
+++ b/source/databricks/calculation_engine/tests/conftest.py
@@ -161,13 +161,14 @@ def calculation_input_path(data_lake_path: str) -> str:
 
 
 @pytest.fixture(scope="session")
-def migrations_executed(spark: SparkSession, data_lake_path: str) -> None:
-    execute_migrations(spark, data_lake_path)
+def calculation_output_path(data_lake_path: str) -> str:
+    return f"{data_lake_path}/calculation-output"
 
 
-def execute_migrations(spark: SparkSession, data_lake_path: str) -> None:
+@pytest.fixture(scope="session")
+def migrations_executed(spark: SparkSession, data_lake_path: str, calculation_output_path: str) -> None:
     # Clean up to prevent problems from previous test runs
-    shutil.rmtree(data_lake_path, ignore_errors=True)
+    shutil.rmtree(calculation_output_path, ignore_errors=True)
     spark.sql(f"DROP DATABASE IF EXISTS {OUTPUT_DATABASE_NAME} CASCADE")
 
     migration_args = MigrationScriptArgs(

--- a/source/databricks/calculation_engine/tests/conftest.py
+++ b/source/databricks/calculation_engine/tests/conftest.py
@@ -166,7 +166,9 @@ def calculation_output_path(data_lake_path: str) -> str:
 
 
 @pytest.fixture(scope="session")
-def migrations_executed(spark: SparkSession, data_lake_path: str, calculation_output_path: str) -> None:
+def migrations_executed(
+    spark: SparkSession, data_lake_path: str, calculation_output_path: str
+) -> None:
     # Clean up to prevent problems from previous test runs
     shutil.rmtree(calculation_output_path, ignore_errors=True)
     spark.sql(f"DROP DATABASE IF EXISTS {OUTPUT_DATABASE_NAME} CASCADE")

--- a/source/databricks/calculation_engine/tests/conftest.py
+++ b/source/databricks/calculation_engine/tests/conftest.py
@@ -31,7 +31,7 @@ from typing import Generator, Callable, Optional
 from package.datamigration.migration import _apply_migration
 from package.datamigration.uncommitted_migrations import _get_all_migrations
 from package.datamigration.migration_script_args import MigrationScriptArgs
-from package.infrastructure.paths import OUTPUT_DATABASE_NAME
+from package.infrastructure.paths import OUTPUT_DATABASE_NAME, OUTPUT_FOLDER
 
 from tests.integration_test_configuration import IntegrationTestConfiguration
 
@@ -162,7 +162,7 @@ def calculation_input_path(data_lake_path: str) -> str:
 
 @pytest.fixture(scope="session")
 def calculation_output_path(data_lake_path: str) -> str:
-    return f"{data_lake_path}/calculation-output"
+    return f"{data_lake_path}/{OUTPUT_FOLDER}"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
in Python tests the fixture, migrations_executed, deleted both calculation_input and calculation_output. The migrations should not touch calculation_input. This caused that some test could fail if they were relying on input, which was deleted by the migrations_executed  fixture.