### PR TITLE
refac: remove redundant runparameter

### DIFF
--- a/source/dotnet/domain-tests/Features/Databricks/Fixtures/CalculationJobScenarioFixture.cs
+++ b/source/dotnet/domain-tests/Features/Databricks/Fixtures/CalculationJobScenarioFixture.cs
@@ -50,9 +50,6 @@ namespace Energinet.DataHub.Wholesale.DomainTests.Features.Databricks.Fixtures
             var runParameters = new DatabricksCalculationParametersFactory()
                 .CreateParameters(calculationJobInput);
 
-            // TODO - Remove when fixed in migrations: temporary run on metering_point_periods_deduplicated_version_three
-            runParameters.PythonParams.Add("--metering_point_periods_table_name=metering_point_periods_deduplicated_version_three");
-
             var runId = await DatabricksClient
                 .Jobs
                 .RunNow(calculatorJobId, runParameters);


### PR DESCRIPTION
The run parameter is not needed in the new environment where we are running the test