### PR TITLE
feat: Add calculation input tables to database

### DIFF
--- a/source/databricks/calculation_engine/package/datamigration/migration.py
+++ b/source/databricks/calculation_engine/package/datamigration/migration.py
@@ -14,7 +14,6 @@
 
 import importlib
 from azure.identity import ClientSecretCredential
-from typing import Any
 
 from package.infrastructure import paths, initialize_spark
 import package.infrastructure.environment_variables as env_vars
@@ -67,7 +66,7 @@ def _substitute_placeholders(
         .replace("{INPUT_DATABASE_NAME}", INPUT_DATABASE_NAME)  # "wholesale"
         .replace("{OUTPUT_FOLDER}", OUTPUT_FOLDER)  # "calculation-output"
         .replace(
-            "{INPUT_FOLDER}", env_vars.get_calculation_input_folder_name()
+            "{INPUT_FOLDER}", migration_args.calculation_input_folder
         )  # Usually "calculation_input"
         .replace("{TEST}", TEST)
     )
@@ -84,7 +83,9 @@ def _apply_migration(migration_name: str, migration_args: MigrationScriptArgs) -
 
 
 def _migrate_data_lake(
-    storage_account_name: str, storage_account_credential: ClientSecretCredential
+    storage_account_name: str,
+    storage_account_credential: ClientSecretCredential,
+    calculation_input_folder: str,
 ) -> None:
     file_manager = DataLakeFileManager(
         storage_account_name, storage_account_credential, WHOLESALE_CONTAINER_NAME
@@ -105,6 +106,7 @@ def _migrate_data_lake(
         data_storage_container_name=WHOLESALE_CONTAINER_NAME,
         data_storage_credential=storage_account_credential,
         spark=spark,
+        calculation_input_folder=calculation_input_folder,
     )
 
     for name in uncommitted_migrations:
@@ -116,4 +118,5 @@ def _migrate_data_lake(
 def migrate_data_lake() -> None:
     storage_account_name = env_vars.get_storage_account_name()
     credential = env_vars.get_storage_account_credential()
-    _migrate_data_lake(storage_account_name, credential)
+    calculation_input_folder = env_vars.get_calculation_input_folder_name()
+    _migrate_data_lake(storage_account_name, credential, calculation_input_folder)

--- a/source/databricks/calculation_engine/package/datamigration/migration.py
+++ b/source/databricks/calculation_engine/package/datamigration/migration.py
@@ -23,7 +23,6 @@ from package.infrastructure.paths import (
     WHOLESALE_CONTAINER_NAME,
     OUTPUT_FOLDER,
     INPUT_DATABASE_NAME,
-    INPUT_FOLDER,
 )
 from package.infrastructure.storage_account_access.data_lake_file_manager import (
     DataLakeFileManager,
@@ -67,9 +66,11 @@ def _substitute_placeholders(
         .replace("{OUTPUT_DATABASE_NAME}", OUTPUT_DATABASE_NAME)  # "wholesale_output"
         .replace("{INPUT_DATABASE_NAME}", INPUT_DATABASE_NAME)  # "wholesale"
         .replace("{OUTPUT_FOLDER}", OUTPUT_FOLDER)  # "calculation-output"
-        .replace("{INPUT_FOLDER}", INPUT_FOLDER)  # "calculation_input"
+        .replace(
+            "{INPUT_FOLDER}", env_vars.get_calculation_input_folder_name()
+        )  # Usually "calculation_input"
         .replace("{TEST}", TEST)
-    )  # ""
+    )
 
 
 def _apply_migration(migration_name: str, migration_args: MigrationScriptArgs) -> None:

--- a/source/databricks/calculation_engine/package/datamigration/migration_script_args.py
+++ b/source/databricks/calculation_engine/package/datamigration/migration_script_args.py
@@ -31,9 +31,11 @@ class MigrationScriptArgs:
         data_storage_container_name: str,
         data_storage_credential: ClientSecretCredential,
         spark: SparkSession,
+        calculation_input_folder: str,
     ) -> None:
         self.storage_account_url = data_storage_account_url
         self.storage_account_name = data_storage_account_name
         self.storage_container_path = f"abfss://{data_storage_container_name}@{self.storage_account_name}.dfs.core.windows.net"
         self.storage_credential = data_storage_credential
         self.spark = spark
+        self.calculation_input_folder = calculation_input_folder

--- a/source/databricks/calculation_engine/package/datamigration/migration_scripts/202401101200_Add_calculation_input_tables_to_database.sql
+++ b/source/databricks/calculation_engine/package/datamigration/migration_scripts/202401101200_Add_calculation_input_tables_to_database.sql
@@ -1,0 +1,19 @@
+CREATE TABLE if not exists {INPUT_DATABASE_NAME}.metering_point_periods
+    USING DELTA LOCATION '{CONTAINER_PATH}/{INPUT_FOLDER}/metering_point_periods'
+GO
+
+CREATE TABLE if not exists {INPUT_DATABASE_NAME}.time_series_points
+    USING DELTA LOCATION '{CONTAINER_PATH}/{INPUT_FOLDER}/time_series_points'
+GO
+
+CREATE TABLE if not exists {INPUT_DATABASE_NAME}.charge_link_periods
+    USING DELTA LOCATION '{CONTAINER_PATH}/{INPUT_FOLDER}/charge_link_periods'
+GO
+
+CREATE TABLE if not exists {INPUT_DATABASE_NAME}.charge_masterdata_periods
+    USING DELTA LOCATION '{CONTAINER_PATH}/{INPUT_FOLDER}/charge_masterdata_periods'
+GO
+
+CREATE TABLE if not exists {INPUT_DATABASE_NAME}.charge_price_points
+    USING DELTA LOCATION '{CONTAINER_PATH}/{INPUT_FOLDER}/charge_price_points'
+GO

--- a/source/databricks/calculation_engine/package/datamigration/migration_scripts/202401121500_Add_calculation_input_tables_to_database.sql
+++ b/source/databricks/calculation_engine/package/datamigration/migration_scripts/202401121500_Add_calculation_input_tables_to_database.sql
@@ -1,19 +1,19 @@
-CREATE TABLE if not exists {INPUT_DATABASE_NAME}.metering_point_periods
+CREATE EXTERNAL TABLE if not exists {INPUT_DATABASE_NAME}.metering_point_periods
     USING DELTA LOCATION '{CONTAINER_PATH}/{INPUT_FOLDER}/metering_point_periods'
 GO
 
-CREATE TABLE if not exists {INPUT_DATABASE_NAME}.time_series_points
+CREATE EXTERNAL TABLE if not exists {INPUT_DATABASE_NAME}.time_series_points
     USING DELTA LOCATION '{CONTAINER_PATH}/{INPUT_FOLDER}/time_series_points'
 GO
 
-CREATE TABLE if not exists {INPUT_DATABASE_NAME}.charge_link_periods
+CREATE EXTERNAL TABLE if not exists {INPUT_DATABASE_NAME}.charge_link_periods
     USING DELTA LOCATION '{CONTAINER_PATH}/{INPUT_FOLDER}/charge_link_periods'
 GO
 
-CREATE TABLE if not exists {INPUT_DATABASE_NAME}.charge_masterdata_periods
+CREATE EXTERNAL TABLE if not exists {INPUT_DATABASE_NAME}.charge_masterdata_periods
     USING DELTA LOCATION '{CONTAINER_PATH}/{INPUT_FOLDER}/charge_masterdata_periods'
 GO
 
-CREATE TABLE if not exists {INPUT_DATABASE_NAME}.charge_price_points
+CREATE EXTERNAL TABLE if not exists {INPUT_DATABASE_NAME}.charge_price_points
     USING DELTA LOCATION '{CONTAINER_PATH}/{INPUT_FOLDER}/charge_price_points'
 GO

--- a/source/databricks/calculation_engine/package/infrastructure/paths.py
+++ b/source/databricks/calculation_engine/package/infrastructure/paths.py
@@ -35,7 +35,6 @@ TEST = ""
 
 # Paths
 WHOLESALE_CONTAINER_NAME = "wholesale"
-INPUT_FOLDER = "calculation_input"
 OUTPUT_FOLDER = "calculation-output"
 BASIS_DATA_FOLDER = "basis_data"
 

--- a/source/databricks/calculation_engine/tests/calculation_input/table_reader/test_read_charge_links_periods.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/table_reader/test_read_charge_links_periods.py
@@ -72,9 +72,10 @@ class TestWhenValidInput:
         self,
         spark: SparkSession,
         tmp_path: pathlib.Path,
+        calculation_input_folder: str,
     ) -> None:
         # Arrange
-        calculation_input_path = f"{str(tmp_path)}/calculation_input"
+        calculation_input_path = f"{str(tmp_path)}/{calculation_input_folder}"
         table_location = f"{calculation_input_path}/charge_link_periods"
         row = _create_charge_link_period_row()
         df = spark.createDataFrame(data=[row], schema=charge_link_periods_schema)

--- a/source/databricks/calculation_engine/tests/calculation_input/table_reader/test_read_charge_master_data_periods.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/table_reader/test_read_charge_master_data_periods.py
@@ -71,9 +71,10 @@ class TestWhenValidInput:
         self,
         spark: SparkSession,
         tmp_path: pathlib.Path,
+        calculation_input_folder: str,
     ) -> None:
         # Arrange
-        calculation_input_path = f"{str(tmp_path)}/calculation_input"
+        calculation_input_path = f"{str(tmp_path)}/{calculation_input_folder}"
         table_location = f"{calculation_input_path}/charge_masterdata_periods"
         row = _create_charge_master_period_row()
         df = spark.createDataFrame(data=[row], schema=charge_master_data_periods_schema)

--- a/source/databricks/calculation_engine/tests/calculation_input/table_reader/test_read_charge_price_points.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/table_reader/test_read_charge_price_points.py
@@ -71,9 +71,10 @@ class TestWhenValidInput:
         self,
         spark: SparkSession,
         tmp_path: pathlib.Path,
+        calculation_input_folder: str,
     ) -> None:
         # Arrange
-        calculation_input_path = f"{str(tmp_path)}/calculation_input"
+        calculation_input_path = f"{str(tmp_path)}/{calculation_input_folder}"
         table_location = f"{calculation_input_path}/charge_price_points"
         row = _create_change_price_point_row()
         df = spark.createDataFrame(data=[row], schema=charge_price_points_schema)

--- a/source/databricks/calculation_engine/tests/calculation_input/table_reader/test_read_metering_point_periods.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/table_reader/test_read_metering_point_periods.py
@@ -85,9 +85,10 @@ class TestWhenValidInput:
         self,
         spark: SparkSession,
         tmp_path: pathlib.Path,
+        calculation_input_folder: str,
     ) -> None:
         # Arrange
-        calculation_input_path = f"{str(tmp_path)}/calculation_input"
+        calculation_input_path = f"{str(tmp_path)}/{calculation_input_folder}"
         table_location = f"{calculation_input_path}/metering_point_periods"
         row = _create_metering_point_period_row()
         df = spark.createDataFrame(data=[row], schema=metering_point_period_schema)

--- a/source/databricks/calculation_engine/tests/calculation_input/table_reader/test_read_time_series_points.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/table_reader/test_read_time_series_points.py
@@ -62,9 +62,10 @@ class TestWhenValidInput:
         self,
         spark: SparkSession,
         tmp_path: pathlib.Path,
+        calculation_input_folder: str,
     ) -> None:
         # Arrange
-        calculation_input_path = f"{str(tmp_path)}/calculation_input"
+        calculation_input_path = f"{str(tmp_path)}/{calculation_input_folder}"
         table_location = f"{calculation_input_path}/time_series_points"
         row = _create_time_series_point_row()
         df = spark.createDataFrame(data=[row], schema=time_series_point_schema)

--- a/source/databricks/calculation_engine/tests/conftest.py
+++ b/source/databricks/calculation_engine/tests/conftest.py
@@ -187,6 +187,7 @@ def calculation_output_path(data_lake_path: str) -> str:
 def migrations_executed(
     spark: SparkSession,
     data_lake_path: str,
+    calculation_input_folder: str,
     calculation_input_path: str,
     calculation_output_path: str,
 ) -> None:
@@ -201,7 +202,7 @@ def migrations_executed(
         data_storage_account_name="foo",
         data_storage_container_name="foo",
         data_storage_credential=ClientSecretCredential("foo", "foo", "foo"),
-        calculation_input_folder=calculation_input_path,
+        calculation_input_folder=calculation_input_folder,
         spark=spark,
     )
     # Overwrite in test

--- a/source/databricks/calculation_engine/tests/conftest.py
+++ b/source/databricks/calculation_engine/tests/conftest.py
@@ -188,14 +188,11 @@ def migrations_executed(
     spark: SparkSession,
     data_lake_path: str,
     calculation_input_folder: str,
-    # calculation_input_path: str,
     calculation_output_path: str,
     energy_input_data_written_to_delta: None,
 ) -> None:
     # Clean up to prevent problems from previous test runs
     shutil.rmtree(calculation_output_path, ignore_errors=True)
-    # shutil.rmtree(calculation_input_path, ignore_errors=True)
-    # spark.sql(f"DROP DATABASE IF EXISTS {INPUT_DATABASE_NAME} CASCADE")
     spark.sql(f"DROP DATABASE IF EXISTS {OUTPUT_DATABASE_NAME} CASCADE")
 
     migration_args = MigrationScriptArgs(

--- a/source/databricks/calculation_engine/tests/conftest.py
+++ b/source/databricks/calculation_engine/tests/conftest.py
@@ -188,13 +188,14 @@ def migrations_executed(
     spark: SparkSession,
     data_lake_path: str,
     calculation_input_folder: str,
-    calculation_input_path: str,
+    # calculation_input_path: str,
     calculation_output_path: str,
+    energy_input_data_written_to_delta: None,
 ) -> None:
     # Clean up to prevent problems from previous test runs
     shutil.rmtree(calculation_output_path, ignore_errors=True)
-    shutil.rmtree(calculation_input_path, ignore_errors=True)
-    spark.sql(f"DROP DATABASE IF EXISTS {INPUT_DATABASE_NAME} CASCADE")
+    # shutil.rmtree(calculation_input_path, ignore_errors=True)
+    # spark.sql(f"DROP DATABASE IF EXISTS {INPUT_DATABASE_NAME} CASCADE")
     spark.sql(f"DROP DATABASE IF EXISTS {OUTPUT_DATABASE_NAME} CASCADE")
 
     migration_args = MigrationScriptArgs(
@@ -313,22 +314,47 @@ def integration_test_configuration(tests_path: str) -> IntegrationTestConfigurat
 def energy_input_data_written_to_delta(
     spark: SparkSession, test_files_folder_path: str, calculation_input_path: str
 ) -> None:
-    # Metering point periods
+    shutil.rmtree(calculation_input_path, ignore_errors=True)
+    spark.sql(f"DROP DATABASE IF EXISTS {INPUT_DATABASE_NAME} CASCADE")
+
     _write_input_test_data_to_table(
         spark,
         file_name=f"{test_files_folder_path}/MeteringPointsPeriods.csv",
         table_name=paths.METERING_POINT_PERIODS_TABLE_NAME,
         schema=metering_point_period_schema,
-        table_location=f"{calculation_input_path}/metering_point_periods",
+        table_location=f"{calculation_input_path}/{paths.METERING_POINT_PERIODS_TABLE_NAME}",
     )
 
-    # Time series points
     _write_input_test_data_to_table(
         spark,
         file_name=f"{test_files_folder_path}/TimeSeriesPoints.csv",
         table_name=paths.TIME_SERIES_POINTS_TABLE_NAME,
         schema=time_series_point_schema,
-        table_location=f"{calculation_input_path}/time_series_points",
+        table_location=f"{calculation_input_path}/{paths.TIME_SERIES_POINTS_TABLE_NAME}",
+    )
+
+    _write_input_test_data_to_table(
+        spark,
+        file_name=f"{test_files_folder_path}/ChargeMasterDataPeriods.csv",
+        table_name=paths.CHARGE_MASTER_DATA_PERIODS_TABLE_NAME,
+        schema=charge_master_data_periods_schema,
+        table_location=f"{calculation_input_path}/{paths.CHARGE_MASTER_DATA_PERIODS_TABLE_NAME}",
+    )
+
+    _write_input_test_data_to_table(
+        spark,
+        file_name=f"{test_files_folder_path}/ChargeLinkPeriods.csv",
+        table_name=paths.CHARGE_LINK_PERIODS_TABLE_NAME,
+        schema=charge_link_periods_schema,
+        table_location=f"{calculation_input_path}/{paths.CHARGE_LINK_PERIODS_TABLE_NAME}",
+    )
+
+    _write_input_test_data_to_table(
+        spark,
+        file_name=f"{test_files_folder_path}/ChargePricePoints.csv",
+        table_name=paths.CHARGE_PRICE_POINTS_TABLE_NAME,
+        schema=charge_price_points_schema,
+        table_location=f"{calculation_input_path}/{paths.CHARGE_PRICE_POINTS_TABLE_NAME}",
     )
 
 

--- a/source/databricks/calculation_engine/tests/datamigration/test_migration.py
+++ b/source/databricks/calculation_engine/tests/datamigration/test_migration.py
@@ -41,7 +41,7 @@ def test__migrate_datalake__when_script_not_found__raise_exception(
 
     # Act and Assert
     with pytest.raises(Exception):
-        _migrate_data_lake("dummy_storage_name", mock_credential)
+        _migrate_data_lake("dummy_storage_name", mock_credential, "some_folder")
 
 
 @patch.object(migration, initialize_spark.__name__)
@@ -66,7 +66,7 @@ def test__migrate_datalake__upload_called_with_correct_name(
         calls.append(call(ANY, name))
 
     # Act
-    _migrate_data_lake("dummy_storage_name", mock_credential)
+    _migrate_data_lake("dummy_storage_name", mock_credential, "some_folder")
 
     # Assert
     mock_upload_committed_migration.assert_has_calls(calls)


### PR DESCRIPTION
This improves the developer experience by making the calculation input tables provided by the migrations domain available in the wholesale Databricks workspace.

![image](https://github.com/Energinet-DataHub/opengeh-wholesale/assets/11583438/42a88e2c-d9d7-44f8-96e6-f4e9f2074339)

It also supports the special cases of the `dev_002` and `sandbox_002` environments where the default calculation input folder for delta tables is overridden.

![image](https://github.com/Energinet-DataHub/opengeh-wholesale/assets/11583438/5f6eed7f-450c-4586-8abe-a68be8268530)
