### PR TITLE
test: Fixed failing subsystem test

### DIFF
--- a/source/dotnet/subsystem-tests/Features/Calculations/WholesaleFixingCalculationScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/WholesaleFixingCalculationScenario.cs
@@ -296,11 +296,11 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations
 AppTraces
 | where AppRoleName == ""dbr-calculation-engine""
 | where SeverityLevel == 1 // Information
-| where Message startswith_cs ""Calculation arguments:""
+| where Message startswith_cs ""Command line arguments:""
 | where OperationId != ""00000000000000000000000000000000""
 | where Properties.Domain == ""wholesale""
 | where Properties.calculation_id == ""{Fixture.ScenarioState.CalculationId}""
-| where Properties.CategoryName == ""Energinet.DataHub.package.calculator_job""
+| where Properties.CategoryName == ""Energinet.DataHub.package.calculator_job_args""
 | count";
 
             // Assert


### PR DESCRIPTION
The test AndThen_ACalculationTelemetryLogIsCreated failed due to an updated search parametres.
