### PR TITLE
Set ApplicationVersion and Subsystem in all telemetry events

### DIFF
--- a/source/dotnet/subsystem-tests/Features/Telemetry/BackgroundServiceTelemetryScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Telemetry/BackgroundServiceTelemetryScenario.cs
@@ -65,11 +65,15 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry
             // From 'StartCalculationHandler' (handled in default http request pipeline)
             Fixture.ScenarioState.ExpectedTelemetryEvents.Add(new AppTraceMatch
             {
+                AppVersionContains = "PR:",
+                Subsystem = "wholesale",
                 MessageContains = $"Calculation with id {Fixture.ScenarioState.CalculationId} started",
             });
             // From 'IntegrationEventProvider' (handled in background service)
             Fixture.ScenarioState.ExpectedTelemetryEvents.Add(new AppTraceMatch
             {
+                AppVersionContains = "PR:",
+                Subsystem = "wholesale",
                 MessageContains = $"Published results for succeeded energy calculation {Fixture.ScenarioState.CalculationId} to the service bus",
             });
         }
@@ -83,7 +87,7 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry
                 | where AppRoleName contains ""app-webapi-wholsal-""
                 | where Message contains ""{Fixture.ScenarioState.CalculationId}""
                 | extend parsedProp = parse_json(Properties)
-                | project TimeGenerated, OperationId, ParentId, Type, EventName=parsedProp.EventName, Message
+                | project TimeGenerated, OperationId, ParentId, Type, AppVersion, Subsystem=parsedProp.Subsystem, EventName=parsedProp.EventName, Message
                 | order by TimeGenerated asc";
 
             var wasEventsLogged = await Fixture.WaitForTelemetryEventsAsync(

--- a/source/dotnet/subsystem-tests/Features/Telemetry/Fixtures/TelemetryScenarioFixture.cs
+++ b/source/dotnet/subsystem-tests/Features/Telemetry/Fixtures/TelemetryScenarioFixture.cs
@@ -62,7 +62,7 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry.Fixtures
         }
 
         public async Task<bool> WaitForTelemetryEventsAsync(
-            IReadOnlyCollection<ITelemetryEventMatch> expectedEvents,
+            IReadOnlyCollection<TelemetryEventMatch> expectedEvents,
             string query,
             QueryTimeRange queryTimeRange,
             TimeSpan waitTimeLimit,
@@ -95,7 +95,7 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry.Fixtures
             return Task.CompletedTask;
         }
 
-        private static bool ContainsExpectedEvents(IReadOnlyCollection<ITelemetryEventMatch> expectedEvents, IReadOnlyList<TelemetryQueryResult> actualResults)
+        private static bool ContainsExpectedEvents(IReadOnlyCollection<TelemetryEventMatch> expectedEvents, IReadOnlyList<TelemetryQueryResult> actualResults)
         {
             if (actualResults.Count < expectedEvents.Count)
                 return false;

--- a/source/dotnet/subsystem-tests/Features/Telemetry/RequestTelemetryScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Telemetry/RequestTelemetryScenario.cs
@@ -49,15 +49,21 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry
         {
             Fixture.ScenarioState.ExpectedTelemetryEvents.Add(new AppRequestMatch
             {
+                AppVersionContains = "PR:",
+                Subsystem = "wholesale",
                 Name = "GET Calculation/Get [batchId]",
             });
             Fixture.ScenarioState.ExpectedTelemetryEvents.Add(new AppDependencyMatch
             {
+                AppVersionContains = "PR:",
+                Subsystem = "wholesale",
                 NameContains = "mssqldb-data-wholsal-",
                 DependencyType = "SQL",
             });
             Fixture.ScenarioState.ExpectedTelemetryEvents.Add(new AppExceptionMatch
             {
+                AppVersionContains = "PR:",
+                Subsystem = "wholesale",
                 EventName = "ApplicationError",
                 OuterType = "System.InvalidOperationException",
                 OuterMessage = "Sequence contains no elements.",
@@ -88,7 +94,7 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry
                 OperationIds
                 | join(union AppRequests, AppDependencies, AppTraces, AppExceptions) on OperationId
                 | extend parsedProp = parse_json(Properties)
-                | project TimeGenerated, OperationId, ParentId, Id, Type, Name, DependencyType, EventName=parsedProp.EventName, Message, Url, OuterType, OuterMessage, Properties
+                | project TimeGenerated, OperationId, ParentId, Id, Type, AppVersion, Subsystem=parsedProp.Subsystem, Name, DependencyType, EventName=parsedProp.EventName, Message, Url, OuterType, OuterMessage, Properties
                 | order by TimeGenerated asc";
 
             var wasEventsLogged = await Fixture.WaitForTelemetryEventsAsync(

--- a/source/dotnet/subsystem-tests/Features/Telemetry/States/BackgroundServiceTelemetryScenarioState.cs
+++ b/source/dotnet/subsystem-tests/Features/Telemetry/States/BackgroundServiceTelemetryScenarioState.cs
@@ -23,7 +23,7 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry.States
 
         public Guid CalculationId { get; set; }
 
-        public IList<ITelemetryEventMatch> ExpectedTelemetryEvents { get; }
-            = new List<ITelemetryEventMatch>();
+        public IList<TelemetryEventMatch> ExpectedTelemetryEvents { get; }
+            = new List<TelemetryEventMatch>();
     }
 }

--- a/source/dotnet/subsystem-tests/Features/Telemetry/States/RequestTelemetryScenarioState.cs
+++ b/source/dotnet/subsystem-tests/Features/Telemetry/States/RequestTelemetryScenarioState.cs
@@ -18,7 +18,7 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry.States
     {
         public Guid BatchId { get; set; }
 
-        public IList<ITelemetryEventMatch> ExpectedTelemetryEvents { get; }
-            = new List<ITelemetryEventMatch>();
+        public IList<TelemetryEventMatch> ExpectedTelemetryEvents { get; }
+            = new List<TelemetryEventMatch>();
     }
 }

--- a/source/dotnet/subsystem-tests/Features/Telemetry/States/TelemetryEventMatch.cs
+++ b/source/dotnet/subsystem-tests/Features/Telemetry/States/TelemetryEventMatch.cs
@@ -16,14 +16,24 @@
 namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry.States
 {
     /// <summary>
-    /// Marker interface for event match types.
+    /// Base class for event match types.
     /// </summary>
-    public interface ITelemetryEventMatch
+    public abstract class TelemetryEventMatch
     {
-        public bool IsMatch(TelemetryQueryResult actual);
+        public string AppVersionContains { get; set; }
+            = string.Empty;
+
+        public string Subsystem { get; set; }
+            = string.Empty;
+
+        public virtual bool IsMatch(TelemetryQueryResult actual)
+        {
+            return actual.AppVersion.Contains(AppVersionContains)
+                && actual.Subsystem.Equals(Subsystem);
+        }
     }
 
-    public class AppRequestMatch : ITelemetryEventMatch
+    public class AppRequestMatch : TelemetryEventMatch
     {
         /// <summary>
         /// Use if Name must match exactly.
@@ -31,13 +41,14 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry.States
         public string Name { get; set; }
             = string.Empty;
 
-        public bool IsMatch(TelemetryQueryResult actual)
+        public override bool IsMatch(TelemetryQueryResult actual)
         {
-            return actual.Name.Equals(Name);
+            return base.IsMatch(actual)
+                && actual.Name.Equals(Name);
         }
     }
 
-    public class AppDependencyMatch : ITelemetryEventMatch
+    public class AppDependencyMatch : TelemetryEventMatch
     {
         /// <summary>
         /// Use if Name must match exactly.
@@ -54,8 +65,11 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry.States
         public string DependencyType { get; set; }
             = string.Empty;
 
-        public bool IsMatch(TelemetryQueryResult actual)
+        public override bool IsMatch(TelemetryQueryResult actual)
         {
+            if (!base.IsMatch(actual))
+                return false;
+
             if (!string.IsNullOrEmpty(NameContains))
             {
                 // Compare using NameContains
@@ -71,7 +85,7 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry.States
         }
     }
 
-    public class AppTraceMatch : ITelemetryEventMatch
+    public class AppTraceMatch : TelemetryEventMatch
     {
         public string EventName { get; set; }
             = string.Empty;
@@ -79,14 +93,15 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry.States
         public string MessageContains { get; set; }
             = string.Empty;
 
-        public bool IsMatch(TelemetryQueryResult actual)
+        public override bool IsMatch(TelemetryQueryResult actual)
         {
-            return (actual.EventName ?? string.Empty) == EventName
+            return base.IsMatch(actual)
+                && (actual.EventName ?? string.Empty) == EventName
                 && actual.Message.Contains(MessageContains);
         }
     }
 
-    public class AppExceptionMatch : ITelemetryEventMatch
+    public class AppExceptionMatch : TelemetryEventMatch
     {
         public string EventName { get; set; }
             = string.Empty;
@@ -97,9 +112,10 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry.States
         public string OuterMessage { get; set; }
             = string.Empty;
 
-        public bool IsMatch(TelemetryQueryResult actual)
+        public override bool IsMatch(TelemetryQueryResult actual)
         {
-            return (actual.EventName ?? string.Empty) == EventName
+            return base.IsMatch(actual)
+                && (actual.EventName ?? string.Empty) == EventName
                 && actual.OuterType == OuterType
                 && actual.OuterMessage == OuterMessage;
         }

--- a/source/dotnet/subsystem-tests/Features/Telemetry/States/TelemetryQueryResult.cs
+++ b/source/dotnet/subsystem-tests/Features/Telemetry/States/TelemetryQueryResult.cs
@@ -50,6 +50,19 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry.States
             = string.Empty;
 
         /// <summary>
+        /// All types.
+        /// </summary>
+        public string AppVersion { get; set; }
+            = string.Empty;
+
+        /// <summary>
+        /// All types.
+        /// Custom property set as global property.
+        /// </summary>
+        public string Subsystem { get; set; }
+            = string.Empty;
+
+        /// <summary>
         /// AppRequests, AppDependencies
         /// </summary>
         public string Name { get; set; }

--- a/source/dotnet/wholesale-api/WebApi/Startup.cs
+++ b/source/dotnet/wholesale-api/WebApi/Startup.cs
@@ -32,8 +32,6 @@ using Energinet.DataHub.Wholesale.WebApi.Configuration.Options;
 using Energinet.DataHub.Wholesale.WebApi.HealthChecks;
 using Energinet.DataHub.Wholesale.WebApi.HealthChecks.DataLake;
 using Energinet.DataHub.Wholesale.WebApi.Telemetry;
-using FluentAssertions.Common;
-using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Azure;
 using Microsoft.OpenApi.Models;

--- a/source/dotnet/wholesale-api/WebApi/Startup.cs
+++ b/source/dotnet/wholesale-api/WebApi/Startup.cs
@@ -156,7 +156,6 @@ public class Startup
             }
         });
 
-        app.UseLoggingScope();
         app.UseHttpsRedirection();
         app.UseAuthentication();
         app.UseAuthorization();

--- a/source/dotnet/wholesale-api/WebApi/Startup.cs
+++ b/source/dotnet/wholesale-api/WebApi/Startup.cs
@@ -130,7 +130,6 @@ public class Startup
         });
 
         serviceCollection.AddUserAuthentication<FrontendUser, FrontendUserProvider>();
-        serviceCollection.AddHttpLoggingScope(SubsystemName);
     }
 
     public void Configure(IApplicationBuilder app)

--- a/source/dotnet/wholesale-api/WebApi/Startup.cs
+++ b/source/dotnet/wholesale-api/WebApi/Startup.cs
@@ -31,6 +31,10 @@ using Energinet.DataHub.Wholesale.WebApi.Configuration;
 using Energinet.DataHub.Wholesale.WebApi.Configuration.Options;
 using Energinet.DataHub.Wholesale.WebApi.HealthChecks;
 using Energinet.DataHub.Wholesale.WebApi.HealthChecks.DataLake;
+using Energinet.DataHub.Wholesale.WebApi.Telemetry;
+using FluentAssertions.Common;
+using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Azure;
 using Microsoft.OpenApi.Models;
 
@@ -115,6 +119,8 @@ public class Startup
 
         AddJwtTokenSecurity(serviceCollection);
         AddHealthCheck(serviceCollection);
+
+        serviceCollection.AddSingleton<ITelemetryInitializer>(new SubsystemInitializer(SubsystemName));
         serviceCollection.AddApplicationInsightsTelemetry(options =>
         {
             options.EnableAdaptiveSampling = false;

--- a/source/dotnet/wholesale-api/WebApi/Startup.cs
+++ b/source/dotnet/wholesale-api/WebApi/Startup.cs
@@ -17,6 +17,7 @@ using System.Text.Json.Serialization;
 using Asp.Versioning;
 using Asp.Versioning.ApiExplorer;
 using Energinet.DataHub.Core.App.Common.Diagnostics.HealthChecks;
+using Energinet.DataHub.Core.App.Common.Reflection;
 using Energinet.DataHub.Core.App.WebApp.Authentication;
 using Energinet.DataHub.Core.App.WebApp.Authorization;
 using Energinet.DataHub.Core.App.WebApp.Diagnostics.HealthChecks;
@@ -114,7 +115,15 @@ public class Startup
 
         AddJwtTokenSecurity(serviceCollection);
         AddHealthCheck(serviceCollection);
-        serviceCollection.AddApplicationInsightsTelemetry(options => options.EnableAdaptiveSampling = false);
+        serviceCollection.AddApplicationInsightsTelemetry(options =>
+        {
+            options.EnableAdaptiveSampling = false;
+            options.ApplicationVersion = Assembly
+                .GetEntryAssembly()!
+                .GetAssemblyInformationalVersionAttribute()!
+                .GetSourceVersionInformation()
+                .ToString();
+        });
 
         serviceCollection.AddUserAuthentication<FrontendUser, FrontendUserProvider>();
         serviceCollection.AddHttpLoggingScope(SubsystemName);

--- a/source/dotnet/wholesale-api/WebApi/Telemetry/SubsystemInitializer.cs
+++ b/source/dotnet/wholesale-api/WebApi/Telemetry/SubsystemInitializer.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Energinet.DataHub.Wholesale.WebApi.Telemetry
+{
+    public class SubsystemInitializer : ITelemetryInitializer
+    {
+        private readonly string _subsystemName;
+
+        public SubsystemInitializer(string subsystemName)
+        {
+            if (string.IsNullOrWhiteSpace(subsystemName))
+                throw new ArgumentException("Cannot be null or whitespace.", nameof(subsystemName));
+
+            _subsystemName = subsystemName;
+        }
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            telemetry.Context.GlobalProperties["Subsystem"] = _subsystemName;
+        }
+    }
+}


### PR DESCRIPTION
- [x] Set ApplicationVersion to be used in all telemetry events
- [x] Use telemetry initializer to set subsystem name in all telemetry events
- [x] Remove use of http logging scope middleware
- [x] Extend tests to prove global properties are available in all telemetry events (http request pipeline AND background services)

Part of:
https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/team-mandalorian/38