### PR TITLE
feat: Update ATS-requests to utilise a quantity quality set

### DIFF
--- a/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactoryTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactoryTests.cs
@@ -99,7 +99,7 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactoryTests
         var responseBody = AggregatedTimeSeriesRequestAccepted.Parser.ParseFrom(actual.Body);
         responseBody.Series.Should().ContainSingle();
         responseBody.Series.Single().TimeSeriesPoints.Should().HaveCount(3);
-        responseBody.Series.Single().TimeSeriesPoints.Select(p => p.QuantityQuality).Should().AllSatisfy(
+        responseBody.Series.Single().TimeSeriesPoints.Select(p => p.QuantityQualities).Should().AllSatisfy(
             qqs =>
             {
                 qqs.Should().HaveCount(expectedQuantityQualities.Count);

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactoryTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactoryTests.cs
@@ -84,7 +84,7 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactoryTests
 
     [Theory]
     [MemberData(nameof(QuantityQualitySets))]
-    public void Create_DifferentSetsOfQualities_FullSetIsPartOfMessage(QuantityQuality[] quantityQualities)
+    public void Create_DifferentSetsOfQualities_CreatesCorrectAcceptedEdiMessage(QuantityQuality[] quantityQualities)
     {
         // Arrange
         const string expectedReferenceId = "123456789";

--- a/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
+++ b/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
@@ -41,8 +41,8 @@ message TimeSeriesPoint {
    */
   optional DecimalValue quantity = 2;
 
-  // The aggregated quality currently represents a value suitable for creation of RSM-014 CIM XML messages.
-  QuantityQuality quantity_quality = 3;
+  // The quality currently set representing a value suitable for creation of RSM-014 CIM XML messages.
+  repeated QuantityQuality quantity_quality = 3;
 }
 
 /*
@@ -51,11 +51,10 @@ message TimeSeriesPoint {
  */
 enum QuantityQuality{
   QUANTITY_QUALITY_UNSPECIFIED = 0;
-  QUANTITY_QUALITY_MISSING = 1;
-  QUANTITY_QUALITY_ESTIMATED = 2;
-  QUANTITY_QUALITY_MEASURED = 3;
-  QUANTITY_QUALITY_INCOMPLETE = 4;
-  QUANTITY_QUALITY_CALCULATED = 5;
+  QUANTITY_QUALITY_ESTIMATED = 1;
+  QUANTITY_QUALITY_MEASURED = 2;
+  QUANTITY_QUALITY_MISSING = 3;
+  QUANTITY_QUALITY_CALCULATED = 4;
 }
 
 /*

--- a/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
+++ b/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
@@ -41,8 +41,12 @@ message TimeSeriesPoint {
    */
   optional DecimalValue quantity = 2;
 
-  // The aggregated quality currently represents a value suitable for creation of RSM-014 CIM XML messages.
-  QuantityQuality quantity_quality = 3;
+  // Reserve the old QuantityQuality enum field. It has been replaced by the repeated quantity_qualities enum field.
+  reserved 3;
+  reserved "quantity_quality";
+
+  // The quantity quality set representing a value suitable for creation of RSM-014 CIM XML messages.
+  repeated QuantityQuality quantity_qualities = 4;
 }
 
 /*
@@ -50,11 +54,14 @@ message TimeSeriesPoint {
  * Read more at https://protobuf.dev/programming-guides/style/#enums.
  */
 enum QuantityQuality{
+  // Reserves the old, now unused, QuantityQuality enum value "Incomplete".
+  reserved 4;
+  reserved "QUANTITY_QUALITY_INCOMPLETE";
+
   QUANTITY_QUALITY_UNSPECIFIED = 0;
   QUANTITY_QUALITY_MISSING = 1;
   QUANTITY_QUALITY_ESTIMATED = 2;
   QUANTITY_QUALITY_MEASURED = 3;
-  QUANTITY_QUALITY_INCOMPLETE = 4;
   QUANTITY_QUALITY_CALCULATED = 5;
 }
 

--- a/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
+++ b/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
@@ -41,8 +41,8 @@ message TimeSeriesPoint {
    */
   optional DecimalValue quantity = 2;
 
-  // The quantity quality set representing a value suitable for creation of RSM-014 CIM XML messages.
-  repeated QuantityQuality quantity_quality = 3;
+  // The aggregated quality currently represents a value suitable for creation of RSM-014 CIM XML messages.
+  QuantityQuality quantity_quality = 3;
 }
 
 /*
@@ -51,10 +51,11 @@ message TimeSeriesPoint {
  */
 enum QuantityQuality{
   QUANTITY_QUALITY_UNSPECIFIED = 0;
-  QUANTITY_QUALITY_ESTIMATED = 1;
-  QUANTITY_QUALITY_MEASURED = 2;
-  QUANTITY_QUALITY_MISSING = 3;
-  QUANTITY_QUALITY_CALCULATED = 4;
+  QUANTITY_QUALITY_MISSING = 1;
+  QUANTITY_QUALITY_ESTIMATED = 2;
+  QUANTITY_QUALITY_MEASURED = 3;
+  QUANTITY_QUALITY_INCOMPLETE = 4;
+  QUANTITY_QUALITY_CALCULATED = 5;
 }
 
 /*

--- a/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
+++ b/source/dotnet/wholesale-api/Edi/Contracts/AggregatedTimeSeriesRequestAccepted.proto
@@ -41,7 +41,7 @@ message TimeSeriesPoint {
    */
   optional DecimalValue quantity = 2;
 
-  // The quality currently set representing a value suitable for creation of RSM-014 CIM XML messages.
+  // The quantity quality set representing a value suitable for creation of RSM-014 CIM XML messages.
   repeated QuantityQuality quantity_quality = 3;
 }
 

--- a/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactory.cs
+++ b/source/dotnet/wholesale-api/Edi/Factories/AggregatedTimeSeriesRequestAcceptedMessageFactory.cs
@@ -38,7 +38,7 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactory
         return message;
     }
 
-    private static AggregatedTimeSeriesRequestAccepted CreateAcceptedResponse(IEnumerable<AggregatedTimeSeries> aggregatedTimeSeries)
+    private static AggregatedTimeSeriesRequestAccepted CreateAcceptedResponse(IReadOnlyCollection<AggregatedTimeSeries> aggregatedTimeSeries)
     {
         var response = new AggregatedTimeSeriesRequestAccepted();
         foreach (var series in aggregatedTimeSeries)
@@ -57,7 +57,7 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactory
         return response;
     }
 
-    private static IEnumerable<TimeSeriesPoint> CreateTimeSeriesPoints(AggregatedTimeSeries aggregatedTimeSeries)
+    private static IReadOnlyCollection<TimeSeriesPoint> CreateTimeSeriesPoints(AggregatedTimeSeries aggregatedTimeSeries)
     {
         const decimal nanoFactor = 1_000_000_000;
         var points = new List<TimeSeriesPoint>();
@@ -70,7 +70,7 @@ public class AggregatedTimeSeriesRequestAcceptedMessageFactory
                 Quantity = new DecimalValue { Units = units, Nanos = nanos },
                 Time = new Timestamp { Seconds = timeSeriesPoint.Time.ToUnixTimeSeconds(), },
             };
-            point.QuantityQuality.AddRange(timeSeriesPoint.Qualities.Select(QuantityQualityMapper.MapQuantityQuality));
+            point.QuantityQualities.AddRange(timeSeriesPoint.Qualities.Select(QuantityQualityMapper.MapQuantityQuality));
 
             points.Add(point);
         }

--- a/source/dotnet/wholesale-api/Edi/Mappers/QuantityQualityMapper.cs
+++ b/source/dotnet/wholesale-api/Edi/Mappers/QuantityQualityMapper.cs
@@ -19,45 +19,19 @@ namespace Energinet.DataHub.Wholesale.EDI.Mappers;
 
 public static class QuantityQualityMapper
 {
-    public static EdiModel.QuantityQuality MapQuantityQuality(WholesaleModel.QuantityQuality quality)
+    public static EdiModel.QuantityQuality MapQuantityQuality(WholesaleModel.QuantityQuality quantityQuality)
     {
-        return quality switch
+        return quantityQuality switch
         {
             WholesaleModel.QuantityQuality.Estimated => EdiModel.QuantityQuality.Estimated,
             WholesaleModel.QuantityQuality.Measured => EdiModel.QuantityQuality.Measured,
-            WholesaleModel.QuantityQuality.Calculated => EdiModel.QuantityQuality.Calculated,
             WholesaleModel.QuantityQuality.Missing => EdiModel.QuantityQuality.Missing,
+            WholesaleModel.QuantityQuality.Calculated => EdiModel.QuantityQuality.Calculated,
 
             _ => throw new ArgumentOutOfRangeException(
-                nameof(quality),
-                actualValue: quality,
-                "Value cannot be mapped to quantity quality."),
+                nameof(quantityQuality),
+                actualValue: quantityQuality,
+                "Value cannot be mapped to a quantity quality."),
         };
-    }
-
-    /// <summary>
-    /// NOTE. This a temporary solution.
-    /// When V1 is no longer in use this method can be deleted.
-    /// </summary>
-    public static EdiModel.QuantityQuality SelectBestSuitedQuality(IEnumerable<CalculationResults.Interfaces.CalculationResults.Model.QuantityQuality> qualities)
-    {
-        if (qualities == null)
-            throw new ArgumentNullException(nameof(qualities));
-
-        var quantityQualities = qualities.ToList();
-
-        if (!quantityQualities.Any())
-            return EdiModel.QuantityQuality.Incomplete;
-
-        if (quantityQualities.Contains(CalculationResults.Interfaces.CalculationResults.Model.QuantityQuality.Missing))
-            return EdiModel.QuantityQuality.Missing;
-
-        if (quantityQualities.Contains(CalculationResults.Interfaces.CalculationResults.Model.QuantityQuality.Estimated))
-            return EdiModel.QuantityQuality.Estimated;
-
-        if (quantityQualities.Contains(CalculationResults.Interfaces.CalculationResults.Model.QuantityQuality.Measured))
-            return EdiModel.QuantityQuality.Measured;
-
-        return EdiModel.QuantityQuality.Calculated;
     }
 }


### PR DESCRIPTION
Update the AggregatedTimeSeriesRequestAccepted event to utilise a set of quantity qualities just like EnergyResultProducedV2.