### PR TITLE
fix: Fixing failing subsystem test

### DIFF
--- a/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationScenarioFixture.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationScenarioFixture.cs
@@ -211,7 +211,7 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations.Fixtu
                     continue;
                 }
 
-                var columns = line!.Split(',');
+                var columns = line!.Split(',', ';');
                 var result = createResult(columns);
                 resultList.Add(result);
             }


### PR DESCRIPTION
Added ';' as delimitor when parsing CVS files.