### PR TITLE
fix: Include all metering point types in basis data

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/calculation.py
@@ -70,12 +70,12 @@ def execute(args: CalculatorArgs, prepared_data_reader: PreparedDataReader) -> N
         )
 
         charges_df = prepared_data_reader.get_charges()
-        metering_points_periods_df = _get_production_and_consumption_metering_points(
-            metering_point_periods_df
+        metering_points_periods_for_wholesale_calculation_df = (
+            _get_production_and_consumption_metering_points(metering_point_periods_df)
         )
 
         tariffs_hourly_df = prepared_data_reader.get_tariff_charges(
-            metering_points_periods_df,
+            metering_points_periods_for_wholesale_calculation_df,
             metering_point_time_series,
             charges_df,
             ChargeResolution.HOUR,
@@ -87,6 +87,7 @@ def execute(args: CalculatorArgs, prepared_data_reader: PreparedDataReader) -> N
             args.calculation_period_start_datetime,
         )
 
+    # We write basis data at the end of the calculation to make it easier to analyze performance of the calculation part
     basis_data_writer = BasisDataWriter(
         args.wholesale_container_path, args.calculation_id
     )


### PR DESCRIPTION
Before:
When performing a wholesale calculation the metering points that were written into basis data csv only container production and consumption. 

Now:
We also include all types that goes into the calculations.