### PR TITLE
fix: Use balance fixing test data for settlment report instead of wholesale fixing

### DIFF
--- a/source/dotnet/subsystem-tests/Features/SettlementReport/SettlementReportScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/SettlementReport/SettlementReportScenario.cs
@@ -36,10 +36,13 @@ public class SettlementReportScenario : SubsystemTestsBase<SettlementReportScena
     [SubsystemFact]
     public void Given_SettlementDownloadInput()
     {
-        Fixture.ScenarioState.SettlementDownloadInput.GridAreaCodes.Add("804");
+        // The values below are taken from BalanceFixingCalculationScenario. The tests below expects that the balance
+        // fixing calculation has been executed. This means that the tests will fail the very first time they are run,
+        // when there is no data in the delta table.
+        Fixture.ScenarioState.SettlementDownloadInput.GridAreaCodes.Add("543");
         Fixture.ScenarioState.SettlementDownloadInput.ProcessType = ProcessType.BalanceFixing;
-        Fixture.ScenarioState.SettlementDownloadInput.CalculationPeriodStart = DateTimeOffset.Parse("2023-01-31T23:00:00");
-        Fixture.ScenarioState.SettlementDownloadInput.CalculationPeriodEnd = DateTimeOffset.Parse("2023-02-01T23:00:00");
+        Fixture.ScenarioState.SettlementDownloadInput.CalculationPeriodStart = DateTimeOffset.Parse("2022-01-11T23:00:00");
+        Fixture.ScenarioState.SettlementDownloadInput.CalculationPeriodEnd = DateTimeOffset.Parse("2022-01-12T23:00:00");
     }
 
     [ScenarioStep(1)]
@@ -86,7 +89,7 @@ public class SettlementReportScenario : SubsystemTestsBase<SettlementReportScena
     [SubsystemFact]
     public void AndThen_SingleEntryShouldContainCorrectGridAreaCodesAndProcessType()
     {
-        var expected = "804,D04,";
+        var expected = "543,D04,";
 
         // Assert
         using var assertionScope = new AssertionScope();
@@ -101,7 +104,7 @@ public class SettlementReportScenario : SubsystemTestsBase<SettlementReportScena
         // Assert
         Fixture.GetUtcDate(Fixture.ScenarioState.EntryDataLines.First())
             .Should()
-            .Be("2023-01-31T23:00:00Z");
+            .Be("2022-01-11T23:00:00Z");
     }
 
     [ScenarioStep(7)]
@@ -111,6 +114,6 @@ public class SettlementReportScenario : SubsystemTestsBase<SettlementReportScena
         // Assert
         Fixture.GetUtcDate(Fixture.ScenarioState.EntryDataLines.Last())
             .Should()
-            .Be("2023-02-01T22:45:00Z");
+            .Be("2022-01-12T22:45:00Z");
     }
 }


### PR DESCRIPTION
The settlement report subsystem tests was relying on data from wholesale fixing which was never generated. Instead we should rely on balance fixing test data. Also, because settlement reports for wholesale fixing is not yet supported 