### PR TITLE
feat: Add validation rule for business reason as a balance responsible

### DIFF
--- a/source/dotnet/wholesale-api/Edi.UnitTests/Builders/AggregatedTimeSeriesRequestBuilder.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Builders/AggregatedTimeSeriesRequestBuilder.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Edi.Requests;
 using Energinet.DataHub.Wholesale.EDI.Models;
 using Energinet.DataHub.Wholesale.EDI.UnitTests.Validators;
 using NodaTime;
@@ -43,7 +42,7 @@ public class AggregatedTimeSeriesRequestBuilder
         _requestedByActorRoleId = ActorRoleCode.EnergySupplier;
         _requestedByActorId = EnergySupplierValidatorTest.ValidGlnNumber;
         _energySupplierId = _requestedByActorId;
-        _businessReason = BusinessReason.WholesaleFixing;
+        _businessReason = BusinessReason.BalanceFixing;
     }
 
     public static AggregatedTimeSeriesRequestBuilder AggregatedTimeSeriesRequest()

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/AggregatedTimeSeriesRequestValidatorTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/AggregatedTimeSeriesRequestValidatorTests.cs
@@ -168,4 +168,23 @@ public class AggregatedTimeSeriesRequestValidatorTests
         validationErrors.Should().ContainSingle()
             .Which.ErrorCode.Should().Be("D11");
     }
+
+    [Fact]
+    public async Task Validate_WhenWholesaleFixingForBalanceResponsible_ReturnsUnsuccessfulValidation()
+    {
+        // Arrange
+        var request = AggregatedTimeSeriesRequestBuilder
+            .AggregatedTimeSeriesRequest()
+            .WithRequestedByActorRole(ActorRoleCode.BalanceResponsibleParty)
+            .WithBusinessReason("D05")
+            .WithBalanceResponsibleId(BalanceResponsibleValidatorTest.ValidGlnNumber)
+            .Build();
+
+        // Act
+        var validationErrors = await _sut.ValidateAsync(request);
+
+        // Assert
+        validationErrors.Should().ContainSingle()
+            .Which.ErrorCode.Should().Be("D11");
+    }
 }

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
@@ -30,8 +30,8 @@ public class BalanceResponsibleValidatorTest
     private const string ValidGlnNumber = "qwertyuiopasd"; // Must be 13 characters to be a valid GLN
     private const string ValidEicNumber = "qwertyuiopasdfgh"; // Must be 16 characters to be a valid GLN
     private static readonly ValidationError _invalidBalanceResponsible = new("Feltet BalanceResponsibleParty skal være udfyldt med et valid GLN/EIC når en balanceansvarlig anmoder om data / BalanceResponsibleParty must be submitted with a valid GLN/EIC when a balance responsible requests data", "E18");
-    private static readonly ValidationError _mismatchedBalanceResponsibleInHeaderAndMessage = new("BalanceResponsibleParty i beskeden stemmer ikke overenes med balanceansvarlig anmoder i header / BalanceResponsibleParty in message does not correspond with balance responsible in header", "E18");
-    private static readonly ValidationError _invalidBusinessReason = new("En BalanceResponsibleParty kan kun benytte forretningsårsag D03 eller D04 i forbindelse med en anmodning / A BalanceResponsibleParty can only use business reason D03 or D04 in connection with a request", "D11");
+    private static readonly ValidationError _mismatchedBalanceResponsibleInHeaderAndMessage = new("Den balanceansvarlige i beskeden stemmer ikke overenes med den balanceansvarlige i headeren / BalanceResponsibleParty in the message does not correspond with balance responsible in header", "E18");
+    private static readonly ValidationError _invalidBusinessReason = new("En balanceansvarlig kan kun benytte forretningsårsag D03 eller D04 i forbindelse med en anmodning / A BalanceResponsibleParty can only use business reason D03 or D04 in connection with a request", "D11");
 
     private readonly BalanceResponsibleValidationRule _sut = new();
 

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
@@ -26,9 +26,9 @@ namespace Energinet.DataHub.Wholesale.EDI.UnitTests.Validators;
 [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Async suffix is not needed for test methods")]
 public class BalanceResponsibleValidatorTest
 {
-    private const string BalanceResponsibleRole = "DDK";
-    private const string ValidGlnNumber = "qwertyuiopasd"; // Must be 13 characters to be a valid GLN
+    public const string ValidGlnNumber = "qwertyuiopasd"; // Must be 13 characters to be a valid GLN
     private const string ValidEicNumber = "qwertyuiopasdfgh"; // Must be 16 characters to be a valid GLN
+    private const string BalanceResponsibleRole = "DDK";
     private static readonly ValidationError _invalidBalanceResponsible = new("Feltet BalanceResponsibleParty skal være udfyldt med et valid GLN/EIC når en balanceansvarlig anmoder om data / BalanceResponsibleParty must be submitted with a valid GLN/EIC when a balance responsible requests data", "E18");
     private static readonly ValidationError _mismatchedBalanceResponsibleInHeaderAndMessage = new("Den balanceansvarlige i beskeden stemmer ikke overenes med den balanceansvarlige i headeren / BalanceResponsibleParty in the message does not correspond with balance responsible in header", "E18");
     private static readonly ValidationError _invalidBusinessReason = new("En balanceansvarlig kan kun benytte forretningsårsag D03 eller D04 i forbindelse med en anmodning / A BalanceResponsibleParty can only use business reason D03 or D04 in connection with a request", "D11");

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
@@ -225,7 +225,7 @@ public class BalanceResponsibleValidatorTest
             .WithRequestedByActorId(ValidGlnNumber)
             .WithRequestedByActorRole(BalanceResponsibleRole)
             .WithBalanceResponsibleId("invalid-format")
-            .WithBusinessReason(BusinessReason.WholesaleFixing)
+            .WithBusinessReason(BusinessReason.Correction)
             .Build();
 
         // Act

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/BalanceResponsibleValidatorTest.cs
@@ -155,6 +155,44 @@ public class BalanceResponsibleValidatorTest
     }
 
     [Fact]
+    public async Task Validate_WhenBusinessReasonIsBalanceFixing_ReturnsNoValidationErrors()
+    {
+        // Arrange
+        var message = AggregatedTimeSeriesRequestBuilder
+            .AggregatedTimeSeriesRequest()
+            .WithRequestedByActorId(ValidGlnNumber)
+            .WithRequestedByActorRole(BalanceResponsibleRole)
+            .WithBalanceResponsibleId(ValidGlnNumber)
+            .WithBusinessReason(BusinessReason.BalanceFixing)
+            .Build();
+
+        // Act
+        var errors = await _sut.ValidateAsync(message);
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_WhenBusinessReasonIsPreliminaryAggregation_ReturnsNoValidationErrors()
+    {
+        // Arrange
+        var message = AggregatedTimeSeriesRequestBuilder
+            .AggregatedTimeSeriesRequest()
+            .WithRequestedByActorId(ValidGlnNumber)
+            .WithRequestedByActorRole(BalanceResponsibleRole)
+            .WithBalanceResponsibleId(ValidGlnNumber)
+            .WithBusinessReason(BusinessReason.PreliminaryAggregation)
+            .Build();
+
+        // Act
+        var errors = await _sut.ValidateAsync(message);
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task Validate_WhenRequestingInvalidBusinessReason_ReturnsExpectedValidationError()
     {
         // Arrange

--- a/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSeries/Rules/BalanceResponsibleValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSeries/Rules/BalanceResponsibleValidationRule.cs
@@ -19,10 +19,10 @@ namespace Energinet.DataHub.Wholesale.EDI.Validation.AggregatedTimeSeries.Rules;
 
 public class BalanceResponsibleValidationRule : IValidationRule<AggregatedTimeSeriesRequest>
 {
-    private static readonly string _balanceResponsiblePartyName = "BalanceResponsibleParty";
-    private static readonly ValidationError _invalidBalanceResponsible = new($"Feltet {_balanceResponsiblePartyName} skal være udfyldt med et valid GLN/EIC når en balanceansvarlig anmoder om data / {_balanceResponsiblePartyName} must be submitted with a valid GLN/EIC when a balance responsible requests data", "E18");
-    private static readonly ValidationError _notEqualToRequestedBy = new($"{_balanceResponsiblePartyName} i beskeden stemmer ikke overenes med balanceansvarlig anmoder i header / {_balanceResponsiblePartyName} in message does not correspond with balance responsible in header", "E18");
-    private static readonly ValidationError _invalidBusinessReason = new($"En {_balanceResponsiblePartyName} kan kun benytte forretningsårsag D03 eller D04 i forbindelse med en anmodning / A {_balanceResponsiblePartyName} can only use business reason D03 or D04 in connection with a request", "D11");
+    private static readonly string _propertyName = "BalanceResponsibleParty";
+    private static readonly ValidationError _invalidBalanceResponsible = new($"Feltet {_propertyName} skal være udfyldt med et valid GLN/EIC når en balanceansvarlig anmoder om data / {_propertyName} must be submitted with a valid GLN/EIC when a balance responsible requests data", "E18");
+    private static readonly ValidationError _notEqualToRequestedBy = new($"Den balanceansvarlige i beskeden stemmer ikke overenes med den balanceansvarlige i headeren / {_propertyName} in the message does not correspond with balance responsible in header", "E18");
+    private static readonly ValidationError _invalidBusinessReason = new($"En balanceansvarlig kan kun benytte forretningsårsag {BusinessReason.PreliminaryAggregation} eller {BusinessReason.BalanceFixing} i forbindelse med en anmodning / A {_propertyName} can only use business reason {BusinessReason.PreliminaryAggregation} or {BusinessReason.BalanceFixing} in connection with a request", "D11");
 
     public Task<IList<ValidationError>> ValidateAsync(AggregatedTimeSeriesRequest subject)
     {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

This pull request adds validation rules for the business reason, when the requester of Aggregated Times series is a balance responsible 
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/57

- [ ] update the error message, such that the balance responsible has the same "name" in the error message 