### PR TITLE
refac: Rename "domain" and health checks

### DIFF
--- a/source/databricks/calculation_engine/tests/calculation_input/test_input_table_schemas.py
+++ b/source/databricks/calculation_engine/tests/calculation_input/test_input_table_schemas.py
@@ -37,8 +37,8 @@ def test__input_time_series_point_schema__matches_published_contract(
     )
 
     # When asserting both that the calculator creates output, and it does it with input data that matches
-    # the time series points contract from the time-series domain (in the same test), then we can infer that the
-    # calculator works with the format of the data published from the time-series domain.
+    # the time series points contract from the time-series subsystem (in the same test), then we can infer that the
+    # calculator works with the format of the data published from the time-series subsystem.
     # NOTE:It is not evident from this test that it uses the same input as the calculator job
     # Apparently nullability is ignored for CSV sources, so we have to compare schemas in this slightly odd way
     # See more at https://stackoverflow.com/questions/50609548/compare-schema-ignoring-nullable

--- a/source/databricks/exploratory-notebooks/issue-32/balance-fixing-poc.py
+++ b/source/databricks/exploratory-notebooks/issue-32/balance-fixing-poc.py
@@ -21,7 +21,7 @@
 
 # General (future?) considerations
 # - In geh-timeseries: Why not enrich time series with metering point data (or simply publish the metering point data that was used for validation of the metering points)?
-#   Then we would not have to deal with metering point events in wholesale and perhaps more important both domains will have the same perspective about the points
+#   Then we would not have to deal with metering point events in wholesale and perhaps more important both subsystems will have the same perspective about the points
 # - There seems to be a problem with the modelling of grid areas vs grid area links in the actor register.
 #   How can a grid area have a (single) grid area link id when it's a one-to-many relation?
 

--- a/source/databricks/static-test-data/README.md
+++ b/source/databricks/static-test-data/README.md
@@ -1,4 +1,4 @@
 # Static test data files fro charges
 
-These files are used temporarily during development of charges in the wholesale domain. When the Migration domain starts to migrate charge data, these files can be removed.
+These files are used temporarily during development of charges in the wholesale subsystem. When the Migration subsystem starts to migrate charge data, these files can be removed.
 The csv files (charges_links.csv, charges_master.csv and chages_prices.csv) are the raw files. These needs to be uploaded to Databricks. Import them using the Databricks UI and then copy the data to the delta tables using the notebook (write_static charge_test_data_to_delta_table.py)

--- a/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/CalculationState/CalculationExecutionStateInfrastructureServiceTests.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/CalculationState/CalculationExecutionStateInfrastructureServiceTests.cs
@@ -15,7 +15,6 @@
 using AutoFixture.Xunit2;
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
 using Energinet.DataHub.Wholesale.Calculations.Application;
-using Energinet.DataHub.Wholesale.Calculations.Application.Model;
 using Energinet.DataHub.Wholesale.Calculations.Application.Model.Calculations;
 using Energinet.DataHub.Wholesale.Calculations.Infrastructure.CalculationState;
 using Energinet.DataHub.Wholesale.Calculations.UnitTests.Infrastructure.CalculationAggregate;
@@ -26,9 +25,9 @@ using NodaTime;
 using Test.Core;
 using Xunit;
 
-namespace Energinet.DataHub.Wholesale.Calculations.UnitTests.Infrastructure.CalculationExecutionStateDomainService;
+namespace Energinet.DataHub.Wholesale.Calculations.UnitTests.Infrastructure.CalculationState;
 
-public class CalculationExecutionStateDomainServiceTests
+public class CalculationExecutionStateInfrastructureServiceTests
 {
     [Theory]
     [InlineAutoMoqData]
@@ -42,7 +41,7 @@ public class CalculationExecutionStateDomainServiceTests
         var pendingCalculations = new List<Calculation>() { calculation };
         calculationRepositoryMock.Setup(repo => repo.GetByStatesAsync(It.IsAny<IEnumerable<CalculationExecutionState>>()))
             .ReturnsAsync(pendingCalculations);
-        calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation.CalculationJobId!)).ReturnsAsync(CalculationState.Running);
+        calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation.CalculationJobId!)).ReturnsAsync(Wholesale.Calculations.Application.Model.CalculationState.Running);
 
         // Act
         await sut.UpdateExecutionStateAsync();
@@ -66,7 +65,7 @@ public class CalculationExecutionStateDomainServiceTests
         var executingCalculations = new List<Calculation>() { calculation };
         calculationRepositoryMock.Setup(repo => repo.GetByStatesAsync(It.IsAny<IEnumerable<CalculationExecutionState>>()))
             .ReturnsAsync(executingCalculations);
-        calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation.CalculationJobId!)).ReturnsAsync(CalculationState.Completed);
+        calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation.CalculationJobId!)).ReturnsAsync(Wholesale.Calculations.Application.Model.CalculationState.Completed);
 
         // Act
         await sut.UpdateExecutionStateAsync();
@@ -91,7 +90,7 @@ public class CalculationExecutionStateDomainServiceTests
         var executingCalculations = new List<Calculation>() { calculation };
         calculationRepositoryMock.Setup(repo => repo.GetByStatesAsync(It.IsAny<IEnumerable<CalculationExecutionState>>()))
             .ReturnsAsync(executingCalculations);
-        calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation.CalculationJobId!)).ReturnsAsync(CalculationState.Canceled);
+        calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation.CalculationJobId!)).ReturnsAsync(Wholesale.Calculations.Application.Model.CalculationState.Canceled);
 
         // Act
         await sut.UpdateExecutionStateAsync();
@@ -118,9 +117,9 @@ public class CalculationExecutionStateDomainServiceTests
         calculationRepositoryMock.Setup(repo => repo.GetByStatesAsync(It.IsAny<IEnumerable<CalculationExecutionState>>()))
             .ReturnsAsync(calculations);
         calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation1.CalculationJobId!))
-            .ReturnsAsync(CalculationState.Pending); // Unchanged
+            .ReturnsAsync(Wholesale.Calculations.Application.Model.CalculationState.Pending); // Unchanged
         calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation2.CalculationJobId!))
-            .ReturnsAsync(CalculationState.Completed);
+            .ReturnsAsync(Wholesale.Calculations.Application.Model.CalculationState.Completed);
 
         // Act
         await sut.UpdateExecutionStateAsync();
@@ -147,7 +146,7 @@ public class CalculationExecutionStateDomainServiceTests
         calculationRepositoryMock.Setup(repo => repo.GetByStatesAsync(It.IsAny<IEnumerable<CalculationExecutionState>>()))
             .ReturnsAsync(calculations);
         calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation2.CalculationJobId!))
-            .ReturnsAsync(CalculationState.Completed);
+            .ReturnsAsync(Wholesale.Calculations.Application.Model.CalculationState.Completed);
 
         // Act
         await sut.UpdateExecutionStateAsync();
@@ -175,10 +174,10 @@ public class CalculationExecutionStateDomainServiceTests
         calculationRepositoryMock.Setup(repo => repo.GetByStatesAsync(It.IsAny<IEnumerable<CalculationExecutionState>>()))
             .ReturnsAsync(calculations);
         calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation1.CalculationJobId!))
-            .ReturnsAsync(CalculationState.Completed);
+            .ReturnsAsync(Wholesale.Calculations.Application.Model.CalculationState.Completed);
         calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation2.CalculationJobId!)).ThrowsAsync(default!);
         calculatorJobRunnerMock.Setup(runner => runner.GetStatusAsync(calculation3.CalculationJobId!))
-            .ReturnsAsync(CalculationState.Completed);
+            .ReturnsAsync(Wholesale.Calculations.Application.Model.CalculationState.Completed);
 
         // Act
         await sut.UpdateExecutionStateAsync();

--- a/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/CalculationState/CalculationStateMapperTests.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/CalculationState/CalculationStateMapperTests.cs
@@ -13,23 +13,22 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
-using Energinet.DataHub.Wholesale.Calculations.Application.Model;
 using Energinet.DataHub.Wholesale.Calculations.Application.Model.Calculations;
 using Energinet.DataHub.Wholesale.Calculations.Infrastructure.CalculationState;
 using FluentAssertions;
 using Xunit;
 
-namespace Energinet.DataHub.Wholesale.Calculations.UnitTests.Infrastructure.CalculationExecutionStateDomainService;
+namespace Energinet.DataHub.Wholesale.Calculations.UnitTests.Infrastructure.CalculationState;
 
 public class CalculationStateMapperTests
 {
     [Theory]
-    [InlineAutoMoqData(CalculationState.Pending, CalculationExecutionState.Pending)]
-    [InlineAutoMoqData(CalculationState.Running, CalculationExecutionState.Executing)]
-    [InlineAutoMoqData(CalculationState.Completed, CalculationExecutionState.Completed)]
-    [InlineAutoMoqData(CalculationState.Canceled, CalculationExecutionState.Canceled)]
-    [InlineAutoMoqData(CalculationState.Failed, CalculationExecutionState.Failed)]
-    public void MapState_CalledWithACalculationStateItCanMap_ExpectedCalculationExecutionState(CalculationState calculationState, CalculationExecutionState expectedCalculationExecutionState)
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Pending, CalculationExecutionState.Pending)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Running, CalculationExecutionState.Executing)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Completed, CalculationExecutionState.Completed)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Canceled, CalculationExecutionState.Canceled)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Failed, CalculationExecutionState.Failed)]
+    public void MapState_CalledWithACalculationStateItCanMap_ExpectedCalculationExecutionState(Wholesale.Calculations.Application.Model.CalculationState calculationState, CalculationExecutionState expectedCalculationExecutionState)
     {
         // Act
         var actualCalculationExecutionState = CalculationStateMapper.MapState(calculationState);
@@ -42,7 +41,7 @@ public class CalculationStateMapperTests
     public void MapState_CalledWithAUnexpectedCalculationStateItCanNotMap_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        const CalculationState unexpectedCalculationState = (CalculationState)99;
+        const Wholesale.Calculations.Application.Model.CalculationState unexpectedCalculationState = (Wholesale.Calculations.Application.Model.CalculationState)99;
 
         // Act
         var act = () => CalculationStateMapper.MapState(unexpectedCalculationState);

--- a/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/Calculations/DatabricksCalculatorJobRunnerTests.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/Calculations/DatabricksCalculatorJobRunnerTests.cs
@@ -15,7 +15,6 @@
 using AutoFixture.Xunit2;
 using Energinet.DataHub.Core.Databricks.Jobs.Abstractions;
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
-using Energinet.DataHub.Wholesale.Calculations.Application.Model;
 using Energinet.DataHub.Wholesale.Calculations.Application.Model.Calculations;
 using Energinet.DataHub.Wholesale.Calculations.Infrastructure.Calculations;
 using Microsoft.Azure.Databricks.Client.Models;
@@ -29,22 +28,22 @@ public class DatabricksCalculatorJobRunnerTests
     [Theory]
 
     // When LifeCycleState is not Terminated, LifeCycleState will determine JobState
-    [InlineAutoMoqData(CalculationState.Pending, RunLifeCycleState.PENDING)]
-    [InlineAutoMoqData(CalculationState.Running, RunLifeCycleState.RUNNING)]
-    [InlineAutoMoqData(CalculationState.Running, RunLifeCycleState.TERMINATING)]
-    [InlineAutoMoqData(CalculationState.Canceled, RunLifeCycleState.SKIPPED)]
-    [InlineAutoMoqData(CalculationState.Failed, RunLifeCycleState.INTERNAL_ERROR)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Pending, RunLifeCycleState.PENDING)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Running, RunLifeCycleState.RUNNING)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Running, RunLifeCycleState.TERMINATING)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Canceled, RunLifeCycleState.SKIPPED)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Failed, RunLifeCycleState.INTERNAL_ERROR)]
 
     // When LifCycleState is Terminated, ResultState will determine JobState
-    [InlineAutoMoqData(CalculationState.Completed, RunLifeCycleState.TERMINATED, RunResultState.SUCCESS)]
-    [InlineAutoMoqData(CalculationState.Failed, RunLifeCycleState.TERMINATED, RunResultState.FAILED)]
-    [InlineAutoMoqData(CalculationState.Canceled, RunLifeCycleState.TERMINATED, RunResultState.CANCELED)]
-    [InlineAutoMoqData(CalculationState.Canceled, RunLifeCycleState.TERMINATED, RunResultState.TIMEDOUT)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Completed, RunLifeCycleState.TERMINATED, RunResultState.SUCCESS)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Failed, RunLifeCycleState.TERMINATED, RunResultState.FAILED)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Canceled, RunLifeCycleState.TERMINATED, RunResultState.CANCELED)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Canceled, RunLifeCycleState.TERMINATED, RunResultState.TIMEDOUT)]
 
     // LifeCycleState determine JobState since LifeCycleState is not Terminated
-    [InlineAutoMoqData(CalculationState.Running, RunLifeCycleState.TERMINATING, RunResultState.SUCCESS)]
+    [InlineAutoMoqData(Wholesale.Calculations.Application.Model.CalculationState.Running, RunLifeCycleState.TERMINATING, RunResultState.SUCCESS)]
     public async Task GivenRunState_WhenGetJobStateAsyncIsCalled_ThenReturnCorrectJobState(
-        CalculationState expectedCalculationState,
+        Wholesale.Calculations.Application.Model.CalculationState expectedCalculationState,
         RunLifeCycleState runLifeCycleState,
         RunResultState runResultState,
         [Frozen] Mock<IJobsApiClient> jobsApiMock,

--- a/source/dotnet/wholesale-api/WebApi/HealthChecks/HealthCheckNames.cs
+++ b/source/dotnet/wholesale-api/WebApi/HealthChecks/HealthCheckNames.cs
@@ -18,7 +18,7 @@ public static class HealthCheckNames
 {
     public const string WholesaleInboxEventsQueue = "WholesaleInboxHealthCheck";
     public const string EdiInboxEventsQueue = "EdiInboxEventsQueueHealthCheck";
-    public const string IntegrationEventsTopic = "IntegrationEventsTopicHealthCheck";
+    public const string IntegrationEventsTopicSubscription = "IntegrationEventsTopicSubscriptionHealthCheck";
     public const string DatabricksSqlStatementsApi = "DatabricksSqlStatementsApiHealthCheck";
     public const string DatabricksJobsApi = "DatabricksJobsApiHealthCheck";
     public const string SqlDatabaseContext = "SqlDatabaseContextHealthCheck";

--- a/source/dotnet/wholesale-api/WebApi/Startup.cs
+++ b/source/dotnet/wholesale-api/WebApi/Startup.cs
@@ -208,7 +208,7 @@ public class Startup
                 serviceBusOptions.SERVICE_BUS_TRANCEIVER_CONNECTION_STRING,
                 serviceBusOptions.INTEGRATIONEVENTS_TOPIC_NAME,
                 serviceBusOptions.INTEGRATIONEVENTS_SUBSCRIPTION_NAME,
-                name: HealthCheckNames.IntegrationEventsTopic)
+                name: HealthCheckNames.IntegrationEventsTopicSubscription)
             .AddDataLakeHealthCheck(
                 _ => Configuration.Get<DataLakeOptions>()!,
                 name: HealthCheckNames.DataLake)

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/documentation.md
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/documentation.md
@@ -1,3 +1,3 @@
 # Wholesale Contracts Documentation
 
-A package containing contracts for the wholesale domain.
+A package containing contracts for the wholesale subsystem.

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Wholesale Contracts Release notes
 
+## Version 8.0.2
+
+Renamed use of word "domain" to "subsystem.
+
 ## Version 8.0.1
 
 Removed obsolete section from documentation.

--- a/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
@@ -21,7 +21,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Wholesale.Contracts</PackageId>
-    <PackageVersion>8.0.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>8.0.2$(VersionSuffix)</PackageVersion>
     <Title>Wholesale Contracts</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
@@ -42,7 +42,7 @@ limitations under the License.
       [Release Notes](https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/dotnet/Packages/Contracts.Documentation/release-notes/release-notes.md)
       [Documentation](https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/dotnet/Packages/Contracts.Documentation/documentation.md)
     </PackageDescription>
-    <Description>A package containing contracts for integrations with the wholesale domain in Energinet.DataHub.</Description>
+    <Description>A package containing contracts for integrations with the wholesale subsystem in Energinet.DataHub.</Description>
     <PackageTags>energinet;datahub;wholesale</PackageTags>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
- [x] Rename health check name to match scope
- [x] Rename word "domain" to "subsystem" 

Tested deployment to sandbox_002: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/7842849532

Part of: https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/team-mandalorian/131