### PR TITLE
refac: Segregate charge types

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/calculation.py
@@ -298,6 +298,7 @@ def _execute(
             metering_point_time_series,
             charges_df,
             ChargeResolution.HOUR,
+            args.time_zone,
         )
 
         tariffs_daily_df = prepared_data_reader.get_tariff_charges(

--- a/source/databricks/calculation_engine/package/calculation/calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/calculation.py
@@ -298,7 +298,6 @@ def _execute(
             metering_point_time_series,
             charges_df,
             ChargeResolution.HOUR,
-            args.time_zone,
         )
 
         tariffs_daily_df = prepared_data_reader.get_tariff_charges(

--- a/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/__init__.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .fees import get_fee_charges
+from .subscriptions import get_subscription_charges
+from .tariffs import get_tariff_charges

--- a/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/fees.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/fees.py
@@ -1,0 +1,69 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyspark.sql.dataframe import DataFrame
+import pyspark.sql.functions as f
+from package.codelists import ChargeType
+from package.constants import Colname
+
+
+def get_fee_charges(
+    charges_df: DataFrame,
+    metering_points: DataFrame,
+) -> DataFrame:
+    charges_df = charges_df.filter(f.col(Colname.charge_type) == ChargeType.FEE.value)
+
+    df = _join_with_metering_points(charges_df, metering_points)
+
+    df = df.select(
+        Colname.charge_key,
+        Colname.charge_code,
+        Colname.charge_type,
+        Colname.charge_owner,
+        Colname.charge_time,
+        Colname.charge_price,
+        Colname.metering_point_type,
+        Colname.settlement_method,
+        Colname.grid_area,
+        Colname.energy_supplier_id,
+    )
+
+    return df
+
+
+def _join_with_metering_points(df: DataFrame, metering_points: DataFrame) -> DataFrame:
+    df = df.join(
+        metering_points,
+        [
+            df[Colname.metering_point_id] == metering_points[Colname.metering_point_id],
+            df[Colname.charge_time] >= metering_points[Colname.from_date],
+            df[Colname.charge_time] < metering_points[Colname.to_date],
+        ],
+        "inner",
+    ).select(
+        df[Colname.charge_key],
+        df[Colname.charge_code],
+        df[Colname.charge_type],
+        df[Colname.charge_owner],
+        df[Colname.charge_tax],
+        df[Colname.resolution],
+        df[Colname.charge_time],
+        df[Colname.charge_price],
+        metering_points[Colname.metering_point_type],
+        metering_points[Colname.settlement_method],
+        metering_points[Colname.grid_area],
+        metering_points[Colname.energy_supplier_id],
+    )
+
+    return df

--- a/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/subscriptions.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/subscriptions.py
@@ -1,0 +1,89 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyspark.sql.dataframe import DataFrame
+import pyspark.sql.functions as f
+
+from package.codelists import ChargeType
+from package.constants import Colname
+
+
+def get_subscription_charges(
+    charges_df: DataFrame,
+    metering_points: DataFrame,
+) -> DataFrame:
+    subscriptions = charges_df.filter(
+        f.col(Colname.charge_type) == ChargeType.SUBSCRIPTION.value
+    )
+
+    subscriptions = _explode_subscription(subscriptions)
+
+    subscriptions = _join_with_metering_points(subscriptions, metering_points)
+
+    return subscriptions
+
+
+def _join_with_metering_points(df: DataFrame, metering_points: DataFrame) -> DataFrame:
+    df = df.join(
+        metering_points,
+        [
+            df[Colname.metering_point_id] == metering_points[Colname.metering_point_id],
+            df[Colname.charge_time] >= metering_points[Colname.from_date],
+            df[Colname.charge_time] < metering_points[Colname.to_date],
+        ],
+        "inner",
+    ).select(
+        df[Colname.charge_key],
+        df[Colname.charge_code],
+        df[Colname.charge_type],
+        df[Colname.charge_owner],
+        df[Colname.charge_tax],
+        df[Colname.resolution],
+        df[Colname.charge_time],
+        df[Colname.charge_price],
+        metering_points[Colname.metering_point_type],
+        metering_points[Colname.settlement_method],
+        metering_points[Colname.grid_area],
+        metering_points[Colname.energy_supplier_id],
+    )
+    return df
+
+
+def _explode_subscription(charges_df: DataFrame) -> DataFrame:
+    charges_df = (
+        charges_df.withColumn(
+            Colname.date,
+            f.explode(
+                f.expr(
+                    f"sequence({Colname.from_date}, {Colname.to_date}, interval 1 day)"
+                )
+            ),
+        )
+        .filter((f.year(Colname.date) == f.year(Colname.charge_time)))
+        .filter((f.month(Colname.date) == f.month(Colname.charge_time)))
+        .drop(Colname.charge_time)
+        .withColumnRenamed(Colname.date, Colname.charge_time)
+        .select(
+            Colname.charge_key,
+            Colname.charge_code,
+            Colname.charge_type,
+            Colname.charge_owner,
+            Colname.charge_tax,
+            Colname.resolution,
+            Colname.charge_time,
+            Colname.charge_price,
+            Colname.metering_point_id,
+        )
+    )
+    return charges_df

--- a/source/databricks/calculation_engine/tests/calculation/preparation/transformations/charge_types/test_fees.py
+++ b/source/databricks/calculation_engine/tests/calculation/preparation/transformations/charge_types/test_fees.py
@@ -14,8 +14,8 @@
 
 from pyspark.sql import SparkSession
 
-import calculation.preparation.transformations.charge_types.charges_factory as factory
-from package.calculation.preparation.transformations import (
+import tests.calculation.preparation.transformations.charge_types.charges_factory as factory
+from package.calculation.preparation.transformations.charge_types import (
     get_fee_charges,
 )
 import package.codelists as e

--- a/source/databricks/calculation_engine/tests/calculation/preparation/transformations/charge_types/test_subscriptions.py
+++ b/source/databricks/calculation_engine/tests/calculation/preparation/transformations/charge_types/test_subscriptions.py
@@ -16,7 +16,6 @@ import pytest
 from datetime import datetime
 from pyspark.sql import SparkSession
 
-import calculation.preparation.transformations.charge_types.charges_factory as factory
 from package.calculation.preparation.transformations import (
     get_subscription_charges,
 )
@@ -26,6 +25,8 @@ from package.calculation_input.schemas import (
 )
 from package.calculation.wholesale.schemas.charges_schema import charges_schema
 from package.constants import Colname
+
+import tests.calculation.preparation.transformations.charge_types.charges_factory as factory
 
 
 def test__get_subscription_charges__filters_on_subscription_charge_type(

--- a/source/databricks/calculation_engine/tests/calculation/preparation/transformations/charge_types/test_tariffs.py
+++ b/source/databricks/calculation_engine/tests/calculation/preparation/transformations/charge_types/test_tariffs.py
@@ -18,8 +18,6 @@ import pytest
 import package.codelists as e
 
 from pyspark.sql import SparkSession
-import calculation.preparation.transformations.charge_types.charges_factory as factory
-
 
 from package.calculation.preparation.transformations import (
     get_tariff_charges,
@@ -32,6 +30,8 @@ from package.calculation_input.schemas import (
 from package.calculation.wholesale.schemas.charges_schema import charges_schema
 from package.constants import Colname
 from pyspark.sql import Row
+
+import tests.calculation.preparation.transformations.charge_types.charges_factory as factory
 
 
 def _create_expected_tariff_charges_row(


### PR DESCRIPTION
Seqregate charge types into separate modules for each type. In upcoming PRs there will be more charge-type-specific logic in the individual modules
