### PR TITLE
fix: Subsystem test - telemetry

### DIFF
--- a/source/dotnet/subsystem-tests/Features/Telemetry/TimerTriggerTelemetryScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Telemetry/TimerTriggerTelemetryScenario.cs
@@ -93,8 +93,8 @@ public class TimerTriggerTelemetryScenario : SubsystemTestsBase<TelemetryScenari
         var wasEventsLogged = await Fixture.WaitForTelemetryEventsAsync(
             Fixture.ScenarioState.ExpectedTelemetryEvents.AsReadOnly(),
             query,
-            queryTimeRange: new QueryTimeRange(TimeSpan.FromMinutes(15)),
-            waitTimeLimit: TimeSpan.FromMinutes(15),
+            queryTimeRange: new QueryTimeRange(TimeSpan.FromMinutes(20)),
+            waitTimeLimit: TimeSpan.FromMinutes(20),
             delay: TimeSpan.FromSeconds(60));
 
         wasEventsLogged.Should().BeTrue($"{nameof(Fixture.ScenarioState.ExpectedTelemetryEvents)} was not logged to Application Insights within time limit.");

--- a/source/dotnet/subsystem-tests/Features/Telemetry/TimerTriggerTelemetryScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Telemetry/TimerTriggerTelemetryScenario.cs
@@ -23,14 +23,14 @@ using Xunit;
 namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Telemetry;
 
 /// <summary>
-/// Verify telemetry is configured correctly so traces are logged from background services.
+/// Verify telemetry is configured correctly so traces are logged from TimerTriggers in Orchestration.
 /// </summary>
 [TestCaseOrderer(
     ordererTypeName: "Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.Orderers.ScenarioStepOrderer",
     ordererAssemblyName: "Energinet.DataHub.Wholesale.SubsystemTests")]
-public class BackgroundServiceTelemetryScenario : SubsystemTestsBase<TelemetryScenarioFixture<BackgroundServiceTelemetryScenarioState>>
+public class TimerTriggerTelemetryScenario : SubsystemTestsBase<TelemetryScenarioFixture<BackgroundServiceTelemetryScenarioState>>
 {
-    public BackgroundServiceTelemetryScenario(LazyFixtureFactory<TelemetryScenarioFixture<BackgroundServiceTelemetryScenarioState>> lazyFixtureFactory)
+    public TimerTriggerTelemetryScenario(LazyFixtureFactory<TelemetryScenarioFixture<BackgroundServiceTelemetryScenarioState>> lazyFixtureFactory)
         : base(lazyFixtureFactory)
     {
     }

--- a/source/dotnet/wholesale-api/WebApi.IntegrationTests/CompositionRootTests.cs
+++ b/source/dotnet/wholesale-api/WebApi.IntegrationTests/CompositionRootTests.cs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -48,11 +46,11 @@ public class CompositionRootTests
         var testConfiguration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["ServiceBus__ConnectionString"] = "Endpoint=sb://unknown.servicebus.windows.net/;SharedAccessKeyName=Yyy;SharedAccessKey=Xxx",
-                ["IntegrationEvents__TopicName"] = "NotEmpty",
-                ["IntegrationEvents__SubscriptionName"] = "NotEmpty",
-                ["WholesaleInbox__QueueName"] = "NotEmpty",
-                ["EdiInbox__QueueName"] = "NotEmpty",
+                ["ServiceBus:ConnectionString"] = "Endpoint=sb://unknown.servicebus.windows.net/;SharedAccessKeyName=Yyy;SharedAccessKey=Xxx",
+                ["IntegrationEvents:TopicName"] = "NotEmpty",
+                ["IntegrationEvents:SubscriptionName"] = "NotEmpty",
+                ["WholesaleInbox:QueueName"] = "NotEmpty",
+                ["EdiInbox:QueueName"] = "NotEmpty",
             })
             .Build();
 


### PR DESCRIPTION
# Description

When logging to Applications Insights (AI) it can take minutes before logs appear, so it would seem that we need to raise the wait time.

- [x] Extended wait time for telemetry to 20 minutes
- [x] Fixed composite root test as it caused CI to fail
- [x] Test deployment to sandbox_002: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/8169683073

Part of:
https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/team-mandalorian/234

Pull-request quality:
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [x] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
