### PR TITLE
fix: Ignore results from which events cannot be created instead of throwing an exception

### DIFF
--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/EventProviders/WholesaleResultEventProvider.cs
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/EventProviders/WholesaleResultEventProvider.cs
@@ -52,18 +52,11 @@ public class WholesaleResultEventProvider : ResultEventProvider, IWholesaleResul
     {
         await foreach (var wholesaleResult in _wholesaleResultQueries.GetAsync(calculation.Id).ConfigureAwait(false))
         {
-            yield return CreateEventFromWholesaleResult(wholesaleResult);
+            if (_amountPerChargeResultProducedV1Factory.CanCreate(wholesaleResult))
+                yield return CreateIntegrationEvent(_amountPerChargeResultProducedV1Factory.Create(wholesaleResult));
+
+            if (_monthlyAmountPerChargeResultProducedV1Factory.CanCreate(wholesaleResult))
+                yield return CreateIntegrationEvent(_monthlyAmountPerChargeResultProducedV1Factory.Create(wholesaleResult));
         }
-    }
-
-    private IntegrationEvent CreateEventFromWholesaleResult(WholesaleResult wholesaleResult)
-    {
-        if (_amountPerChargeResultProducedV1Factory.CanCreate(wholesaleResult))
-            return CreateIntegrationEvent(_amountPerChargeResultProducedV1Factory.Create(wholesaleResult));
-
-        if (_monthlyAmountPerChargeResultProducedV1Factory.CanCreate(wholesaleResult))
-            return CreateIntegrationEvent(_monthlyAmountPerChargeResultProducedV1Factory.Create(wholesaleResult));
-
-        throw new ArgumentException("Cannot create event from wholesale result.", nameof(wholesaleResult));
     }
 }

--- a/source/dotnet/wholesale-api/Events/Events.UnitTests/Infrastructure/IntegrationEvents/EventProviders/WholesaleResultEventProviderTests.cs
+++ b/source/dotnet/wholesale-api/Events/Events.UnitTests/Infrastructure/IntegrationEvents/EventProviders/WholesaleResultEventProviderTests.cs
@@ -99,7 +99,7 @@ public class WholesaleResultEventProviderTests
 
     [Theory]
     [InlineAutoMoqData]
-    public async Task GetAsync_WhenCannotCreateAnyEvents_ThrowsException(
+    public async Task GetAsync_WhenCannotCreateEventFromResult_IgnoresThatResult(
         [Frozen] Mock<IAmountPerChargeResultProducedV1Factory> amountPerChargeResultProducedV1FactoryMock,
         [Frozen] Mock<IMonthlyAmountPerChargeResultProducedV1Factory> monthlyAmountPerChargeResultProducedV1FactoryMock,
         [Frozen] Mock<IWholesaleResultQueries> wholesaleResultQueriesMock,
@@ -122,10 +122,10 @@ public class WholesaleResultEventProviderTests
             .Returns(false);
 
         // Act
-        var act = async () => await sut.GetAsync(wholesaleFixingCalculation).SingleAsync();
+        var actualIntegrationEvents = await sut.GetAsync(wholesaleFixingCalculation).ToListAsync();
 
         // Assert
-        await act.Should().ThrowAsync<ArgumentException>();
+        actualIntegrationEvents.Should().BeEmpty();
     }
 
     [Theory]


### PR DESCRIPTION


 
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our 
[Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Currently we don't publish subscription results, so we need to ignore those results. With this PR results are ignored if they are not tariffs.

Pull-request quality:
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
