### PR TITLE
feat: DDM can request as if either DDM or MDR

### DIFF
--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/RequestedByActorRoleValidationRuleTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/RequestedByActorRoleValidationRuleTest.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Wholesale.Edi.Models;
+using Energinet.DataHub.Wholesale.Edi.Validation.AggregatedTimeSeries.Rules;
+using FluentAssertions;
+using Xunit;
+using AggregatedTimeSeriesRequest = Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest;
+
+namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Validators;
+
+public sealed class RequestedByActorRoleValidationRuleTest
+{
+    [Theory]
+    [InlineData(ActorRoleCode.MeteredDataResponsible)]
+    [InlineData(ActorRoleCode.EnergySupplier)]
+    [InlineData(ActorRoleCode.BalanceResponsibleParty)]
+    public async Task ValidateAsync_ValidActorRole_ReturnsEmptyErrorListAsync(string actorRole)
+    {
+        // Arrange
+        var request = new AggregatedTimeSeriesRequest { RequestedByActorRole = actorRole };
+        var rule = new RequestedByActorRoleValidationRule();
+
+        // Act
+        var result = await rule.ValidateAsync(request);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("DLG")]
+    [InlineData("TSO")]
+    [InlineData("FOO")]
+    public async Task ValidateAsync_UnexpectedActorRole_ReturnsEmptyErrorListAsync(string actorRole)
+    {
+        // Arrange
+        var request = new AggregatedTimeSeriesRequest { RequestedByActorRole = actorRole };
+        var rule = new RequestedByActorRoleValidationRule();
+
+        // Act
+        var result = await rule.ValidateAsync(request);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_DdmActorRole_ReturnsDdmShouldRequestAsMdrErrorAsync()
+    {
+        // Arrange
+        var request = new AggregatedTimeSeriesRequest { RequestedByActorRole = "DDM" };
+        var rule = new RequestedByActorRoleValidationRule();
+
+        // Act
+        var result = await rule.ValidateAsync(request);
+
+        // Assert
+        result.Should().ContainSingle();
+        result
+            .Single()
+            .Message
+            .Should()
+            .Be(
+                "Rollen skal være MDR når der anmodes om beregnede energitidsserier / Role must be MDR when requesting aggregated measure data");
+
+        result.Single().ErrorCode.Should().Be("D02");
+    }
+}

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/RequestedByActorRoleValidationRuleTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/RequestedByActorRoleValidationRuleTest.cs
@@ -26,7 +26,7 @@ public sealed class RequestedByActorRoleValidationRuleTest
     [InlineData(ActorRoleCode.MeteredDataResponsible)]
     [InlineData(ActorRoleCode.EnergySupplier)]
     [InlineData(ActorRoleCode.BalanceResponsibleParty)]
-    public async Task ValidateAsync_ValidActorRole_ReturnsEmptyErrorListAsync(string actorRole)
+    public async Task ValidateAsync_WhenRequestingWithValidActorRole_ReturnsEmptyErrorListAsync(string actorRole)
     {
         // Arrange
         var request = new AggregatedTimeSeriesRequest { RequestedByActorRole = actorRole };
@@ -43,7 +43,7 @@ public sealed class RequestedByActorRoleValidationRuleTest
     [InlineData("DLG")]
     [InlineData("TSO")]
     [InlineData("FOO")]
-    public async Task ValidateAsync_UnexpectedActorRole_ReturnsEmptyErrorListAsync(string actorRole)
+    public async Task ValidateAsync_WhenRequestingWithUnexpectedActorRole_ReturnsEmptyErrorListAsync(string actorRole)
     {
         // Arrange
         var request = new AggregatedTimeSeriesRequest { RequestedByActorRole = actorRole };
@@ -57,7 +57,7 @@ public sealed class RequestedByActorRoleValidationRuleTest
     }
 
     [Fact]
-    public async Task ValidateAsync_DdmActorRole_ReturnsDdmShouldRequestAsMdrErrorAsync()
+    public async Task ValidateAsync_WhenRequestingWithDdmActorRole_ReturnsDdmShouldRequestAsMdrErrorAsync()
     {
         // Arrange
         var request = new AggregatedTimeSeriesRequest { RequestedByActorRole = "DDM" };

--- a/source/dotnet/wholesale-api/Edi/Extensions/DependencyInjection/EdiExtensions.cs
+++ b/source/dotnet/wholesale-api/Edi/Extensions/DependencyInjection/EdiExtensions.cs
@@ -65,6 +65,7 @@ public static class EdiExtensions
         services.AddSingleton<IValidationRule<AggregatedTimeSeriesRequest>, BalanceResponsibleValidationRule>();
         services.AddSingleton<IValidationRule<AggregatedTimeSeriesRequest>, SettlementSeriesVersionValidationRule>();
         services.AddScoped<IValidationRule<AggregatedTimeSeriesRequest>, GridAreaValidationRule>();
+        services.AddSingleton<IValidationRule<AggregatedTimeSeriesRequest>, RequestedByActorRoleValidationRule>();
 
         return services;
     }

--- a/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSeries/Rules/RequestedByActorRoleValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSeries/Rules/RequestedByActorRoleValidationRule.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Wholesale.Edi.Models;
+using AggregatedTimeSeriesRequest = Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest;
+
+namespace Energinet.DataHub.Wholesale.Edi.Validation.AggregatedTimeSeries.Rules;
+
+public sealed class RequestedByActorRoleValidationRule : IValidationRule<AggregatedTimeSeriesRequest>
+{
+    public Task<IList<ValidationError>> ValidateAsync(AggregatedTimeSeriesRequest subject)
+    {
+        return Task.FromResult(subject.RequestedByActorRole switch
+        {
+            ActorRoleCode.MeteredDataResponsible => new List<ValidationError>(),
+            ActorRoleCode.BalanceResponsibleParty => new List<ValidationError>(),
+            ActorRoleCode.EnergySupplier => new List<ValidationError>(),
+            "DDM" => new List<ValidationError>
+            {
+                new(
+                    "Rollen skal være MDR når der anmodes om beregnede energitidsserier / Role must be MDR when requesting aggregated measure data",
+                    "D02"),
+            },
+            _ => (IList<ValidationError>)new List<ValidationError>(),
+        });
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->
In order to support a current---albeit hopefully temporary---use case, we need a validation check on actor roles. The "hack" as it was, is to allow a DDM to make requests as if they acted as a MDR. If the DDM forgets to change their "I request as a XXX role" from DDM to MDR, they should get a async validation error.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
