### PR TITLE
refac: `get_wholesale_metering_point_times_series` as module

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/calculation.py
@@ -11,15 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pyspark.sql import DataFrame
-import pyspark.sql.functions as f
 
 from package.codelists import (
     ChargeResolution,
     CalculationType,
-    SettlementMethod,
-    MeteringPointType,
-    MeteringPointResolution,
 )
 from package.infrastructure import logging_configuration
 from .CalculationResults import (
@@ -34,10 +29,12 @@ from .output.wholesale_results import write_wholesale_results
 from .preparation import PreparedDataReader
 
 from .wholesale import wholesale_calculation
+from .wholesale.get_wholesale_metering_point_times_series import (
+    get_wholesale_metering_point_times_series,
+)
 from .wholesale.get_metering_points_and_child_metering_points import (
     get_metering_points_and_child_metering_points,
 )
-from ..constants import EnergyResultColumnNames, Colname
 
 
 @logging_configuration.use_span("calculation")
@@ -71,10 +68,12 @@ def _execute(
             ).cache()
         )
 
-    results.energy_results = energy_calculation.execute(
-        args,
-        metering_point_time_series,
-        grid_loss_responsible_df,
+    results.energy_results, positive_grid_loss, negative_grid_loss = (
+        energy_calculation.execute(
+            args,
+            metering_point_time_series,
+            grid_loss_responsible_df,
+        )
     )
 
     if (
@@ -107,10 +106,10 @@ def _execute(
             )
 
             wholesale_metering_point_time_series = (
-                _get_wholesale_metering_point_times_series(
+                get_wholesale_metering_point_times_series(
                     metering_point_time_series,
-                    results.energy_results.positive_grid_loss,
-                    results.energy_results.negative_grid_loss,
+                    positive_grid_loss,
+                    negative_grid_loss,
                 )
             )
 
@@ -148,7 +147,7 @@ def _execute(
 
     # Add basis data to results
     results.basis_data = basis_data_factory.create(
-        metering_point_periods_df, metering_point_time_series, args.time_zone
+        metering_point_periods_df, wholesale_metering_point_time_series, args.time_zone
     )
 
     return results
@@ -162,55 +161,3 @@ def _write_results(args: CalculatorArgs, results: CalculationResultsContainer) -
 
     # We write basis data at the end of the calculation to make it easier to analyze performance of the calculation part
     write_basis_data(args, results.basis_data)
-
-
-def _get_wholesale_metering_point_times_series(
-    metering_point_time_series: DataFrame,
-    positive_grid_loss: DataFrame,
-    negative_grid_loss: DataFrame,
-) -> DataFrame:
-    """
-    Metering point time series for wholesale calculation includes all calculation input metering point time series,
-    and positive and negative grid loss metering point time series.
-    """
-    positive_grid_loss_transformed = _transform(
-        positive_grid_loss, MeteringPointType.CONSUMPTION
-    )
-    negative_grid_loss_transformed = _transform(
-        negative_grid_loss, MeteringPointType.PRODUCTION
-    )
-
-    return metering_point_time_series.union(positive_grid_loss_transformed).union(
-        negative_grid_loss_transformed
-    )
-
-
-def _transform(
-    grid_loss: DataFrame, metering_point_type: MeteringPointType
-) -> DataFrame:
-    """
-    Transforms calculated grid loss dataframes to the format of the calculation input metering point time series.
-    """
-    return grid_loss.select(
-        f.col(EnergyResultColumnNames.grid_area).alias(Colname.grid_area),
-        f.lit(None).alias(Colname.to_grid_area),
-        f.lit(None).alias(Colname.from_grid_area),
-        f.col(EnergyResultColumnNames.metering_point_id).alias(
-            Colname.metering_point_id
-        ),
-        f.lit(metering_point_type.value).alias(Colname.metering_point_type),
-        f.lit(MeteringPointResolution.QUARTER.value).alias(
-            Colname.resolution
-        ),  # This will change when we must support HOURLY before 1st of May 2023
-        f.col(EnergyResultColumnNames.time).alias(Colname.observation_time),
-        f.col(EnergyResultColumnNames.quantity).alias(Colname.quantity),
-        # Quality for grid loss is always "calculated"
-        f.col(EnergyResultColumnNames.quantity_qualities)[0].alias(Colname.quality),
-        f.col(EnergyResultColumnNames.energy_supplier_id).alias(
-            Colname.energy_supplier_id
-        ),
-        f.col(EnergyResultColumnNames.balance_responsible_id).alias(
-            Colname.balance_responsible_id
-        ),
-        f.lit(SettlementMethod.FLEX.value).alias(Colname.settlement_method),
-    )

--- a/source/databricks/calculation_engine/package/calculation/calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/calculation.py
@@ -105,12 +105,11 @@ def _execute(
                 )
             )
 
-            wholesale_metering_point_time_series = (
-                get_wholesale_metering_point_times_series(
-                    metering_point_time_series,
-                    positive_grid_loss,
-                    negative_grid_loss,
-                )
+            # This extends the content of metering_point_time_series with wholesale data
+            metering_point_time_series = get_wholesale_metering_point_times_series(
+                metering_point_time_series,
+                positive_grid_loss,
+                negative_grid_loss,
             )
 
             prepared_subscriptions = prepared_data_reader.get_subscription_charges(
@@ -121,7 +120,7 @@ def _execute(
             )
 
             tariffs_hourly_df = prepared_data_reader.get_tariff_charges(
-                wholesale_metering_point_time_series,
+                metering_point_time_series,
                 charge_master_data,
                 charge_prices,
                 charges_link_metering_point_periods,
@@ -130,7 +129,7 @@ def _execute(
             )
 
             tariffs_daily_df = prepared_data_reader.get_tariff_charges(
-                wholesale_metering_point_time_series,
+                metering_point_time_series,
                 charge_master_data,
                 charge_prices,
                 charges_link_metering_point_periods,
@@ -147,7 +146,7 @@ def _execute(
 
     # Add basis data to results
     results.basis_data = basis_data_factory.create(
-        metering_point_periods_df, wholesale_metering_point_time_series, args.time_zone
+        metering_point_periods_df, metering_point_time_series, args.time_zone
     )
 
     return results

--- a/source/databricks/calculation_engine/package/calculation/energy/aggregators/exchange_aggregators.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/aggregators/exchange_aggregators.py
@@ -121,6 +121,7 @@ def aggregate_net_exchange_per_neighbour_ga(
             F.array_union(Colname.qualities, from_qualities).alias(Colname.qualities),
             Colname.sum_quantity,
             F.col(Colname.to_grid_area).alias(Colname.grid_area),
+            F.lit(MeteringPointType.EXCHANGE.value).alias(Colname.metering_point_type),
         )
     )
 
@@ -139,6 +140,6 @@ def aggregate_net_exchange_per_ga(
 
     result_df = T.aggregate_sum_quantity_and_qualities(
         exchange_per_neighbour_ga.df, [Colname.grid_area, Colname.time_window]
-    )
+    ).withColumn(Colname.metering_point_type, F.lit(MeteringPointType.EXCHANGE.value))
 
     return EnergyResults(result_df)

--- a/source/databricks/calculation_engine/package/calculation/energy/aggregators/grid_loss_aggregators.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/aggregators/grid_loss_aggregators.py
@@ -307,6 +307,7 @@ def apply_grid_loss_adjustment(
         Colname.time_window,
         f.col(adjusted_sum_quantity).alias(Colname.sum_quantity),
         Colname.qualities,
+        f.lit(metering_point_type.value).alias(Colname.metering_point_type),
     ).orderBy(
         Colname.grid_area,
         Colname.balance_responsible_id,

--- a/source/databricks/calculation_engine/package/calculation/energy/aggregators/grouping_aggregators.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/aggregators/grouping_aggregators.py
@@ -20,19 +20,29 @@ from package.constants import Colname
 
 
 def aggregate_per_ga_and_es(df: EnergyResults) -> EnergyResults:
-    group_by = [Colname.grid_area, Colname.energy_supplier_id, Colname.time_window]
+    group_by = [
+        Colname.grid_area,
+        Colname.energy_supplier_id,
+        Colname.time_window,
+        Colname.metering_point_type,
+    ]
     result = aggregate_sum_quantity_and_qualities(df.df, group_by)
     return EnergyResults(result)
 
 
 def aggregate_per_ga(df: EnergyResults) -> EnergyResults:
-    group_by = [Colname.grid_area, Colname.time_window]
+    group_by = [Colname.grid_area, Colname.time_window, Colname.metering_point_type]
     result = aggregate_sum_quantity_and_qualities(df.df, group_by)
     return EnergyResults(result)
 
 
 def aggregate_per_ga_and_brp(df: EnergyResults) -> EnergyResults:
     """Function to aggregate sum per grid area and balance responsible party."""
-    group_by = [Colname.grid_area, Colname.balance_responsible_id, Colname.time_window]
+    group_by = [
+        Colname.grid_area,
+        Colname.balance_responsible_id,
+        Colname.time_window,
+        Colname.metering_point_type,
+    ]
     result = aggregate_sum_quantity_and_qualities(df.df, group_by)
     return EnergyResults(result)

--- a/source/databricks/calculation_engine/package/calculation/energy/aggregators/metering_point_time_series_aggregators.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/aggregators/metering_point_time_series_aggregators.py
@@ -61,7 +61,9 @@ def aggregate_per_ga_and_brp_and_es(
         Colname.energy_supplier_id,
         Colname.time_window,
     ]
-    result = aggregate_quantity_and_quality(result, sum_group_by)
+    result = aggregate_quantity_and_quality(result, sum_group_by).withColumn(
+        Colname.metering_point_type, f.lit(metering_point_type.value)
+    )
 
     return EnergyResults(result)
 

--- a/source/databricks/calculation_engine/package/calculation/energy/energy_calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/energy_calculation.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Tuple
 
 from pyspark.sql import DataFrame
 
@@ -41,7 +42,10 @@ def execute(
     args: CalculatorArgs,
     metering_point_time_series: DataFrame,
     grid_loss_responsible_df: GridLossResponsible,
-) -> EnergyResultsContainer:
+) -> Tuple[EnergyResultsContainer, EnergyResults, EnergyResults]:
+    """
+    Returns: EnergyResultsContainer, EnergyResults (positive grid loss), EnergyResults (negative grid loss)
+    """
     with logging_configuration.start_span("quarterly_metering_point_time_series"):
         quarterly_metering_point_time_series = transform_hour_to_quarter(
             metering_point_time_series
@@ -59,7 +63,7 @@ def _calculate(
     args: CalculatorArgs,
     quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
     grid_loss_responsible_df: GridLossResponsible,
-) -> EnergyResultsContainer:
+) -> Tuple[EnergyResultsContainer, EnergyResults, EnergyResults]:
     results = EnergyResultsContainer()
 
     # cache of net exchange per grid area did not improve performance (01/12/2023)
@@ -130,7 +134,7 @@ def _calculate(
 
     _calculate_total_consumption(args, production_per_ga, net_exchange_per_ga, results)
 
-    return results
+    return results, positive_grid_loss, negative_grid_loss
 
 
 @logging_configuration.use_span("calculate_net_exchange")

--- a/source/databricks/calculation_engine/package/calculation/energy/energy_results.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/energy_results.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pyspark.sql.functions as f
 import pyspark.sql.types as t
 from pyspark.sql import DataFrame
 
+from package.codelists import MeteringPointResolution
 from package.common import DataFrameWrapper
 from package.constants import Colname
 
@@ -30,6 +31,11 @@ class EnergyResults(DataFrameWrapper):
         """
         Fit data frame in a general DataFrame. This is used for all results and missing columns will be null.
         """
+
+        # Resolution of energy results is always quarter
+        df = df.withColumn(
+            Colname.resolution, f.lit(MeteringPointResolution.QUARTER.value)
+        )
 
         super().__init__(
             df,
@@ -67,5 +73,7 @@ energy_results_schema = t.StructType(
         t.StructField(Colname.sum_quantity, t.DecimalType(18, 6), False),
         t.StructField(Colname.qualities, t.ArrayType(t.StringType(), False), False),
         t.StructField(Colname.metering_point_id, t.StringType(), True),
+        t.StructField(Colname.metering_point_type, t.StringType(), False),
+        t.StructField(Colname.resolution, t.StringType(), False),
     ]
 )

--- a/source/databricks/calculation_engine/package/calculation/energy/energy_results.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/energy_results.py
@@ -34,7 +34,7 @@ class EnergyResults(DataFrameWrapper):
         super().__init__(
             df,
             energy_results_schema,
-            # We ignore_nullability because it has turned out to be too hard and even possibly
+            # We ignore_nullability because it has turned out to be too hard, and even possibly
             # introducing more errors than solving in order to stay in exact sync with the
             # logically correct schema.
             ignore_nullability=True,

--- a/source/databricks/calculation_engine/package/calculation/energy/hour_to_quarter.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/hour_to_quarter.py
@@ -11,17 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import pyspark.sql.functions as f
 from pyspark.sql import DataFrame
-from pyspark.sql.types import (
-    DecimalType,
-    StructType,
-    StructField,
-    StringType,
-    TimestampType,
-)
 
+from package.calculation.preparation.metering_point_time_series_schema import (
+    metering_point_time_series_schema,
+)
 from package.calculation.preparation.quarterly_metering_point_time_series import (
     QuarterlyMeteringPointTimeSeries,
 )
@@ -74,21 +69,3 @@ def transform_hour_to_quarter(
     )
 
     return QuarterlyMeteringPointTimeSeries(result)
-
-
-metering_point_time_series_schema = StructType(
-    [
-        StructField(Colname.grid_area, StringType(), False),
-        StructField(Colname.to_grid_area, StringType(), True),
-        StructField(Colname.from_grid_area, StringType(), True),
-        StructField(Colname.metering_point_id, StringType(), False),
-        StructField(Colname.metering_point_type, StringType(), False),
-        StructField(Colname.resolution, StringType(), False),
-        StructField(Colname.observation_time, TimestampType(), False),
-        StructField(Colname.quantity, DecimalType(18, 6), False),
-        StructField(Colname.quality, StringType(), False),
-        StructField(Colname.energy_supplier_id, StringType(), True),
-        StructField(Colname.balance_responsible_id, StringType(), True),
-        StructField(Colname.settlement_method, StringType(), True),
-    ]
-)

--- a/source/databricks/calculation_engine/package/calculation/preparation/metering_point_time_series_schema.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/metering_point_time_series_schema.py
@@ -1,0 +1,39 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pyspark.sql.types import (
+    StructType,
+    StructField,
+    StringType,
+    TimestampType,
+    DecimalType,
+)
+
+from package.constants import Colname
+
+metering_point_time_series_schema = StructType(
+    [
+        StructField(Colname.grid_area, StringType(), False),
+        StructField(Colname.to_grid_area, StringType(), True),
+        StructField(Colname.from_grid_area, StringType(), True),
+        StructField(Colname.metering_point_id, StringType(), False),
+        StructField(Colname.metering_point_type, StringType(), False),
+        StructField(Colname.resolution, StringType(), False),
+        StructField(Colname.observation_time, TimestampType(), False),
+        StructField(Colname.quantity, DecimalType(18, 6), False),
+        StructField(Colname.quality, StringType(), False),
+        StructField(Colname.energy_supplier_id, StringType(), True),
+        StructField(Colname.balance_responsible_id, StringType(), True),
+        StructField(Colname.settlement_method, StringType(), True),
+    ]
+)

--- a/source/databricks/calculation_engine/package/calculation/wholesale/get_wholesale_metering_point_times_series.py
+++ b/source/databricks/calculation_engine/package/calculation/wholesale/get_wholesale_metering_point_times_series.py
@@ -1,0 +1,51 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pyspark.sql.functions as f
+from pyspark.sql import DataFrame
+
+from package.calculation.energy.energy_results import EnergyResults
+from package.constants import Colname
+
+
+def get_wholesale_metering_point_times_series(
+    metering_point_time_series: DataFrame,
+    positive_grid_loss: EnergyResults,
+    negative_grid_loss: EnergyResults,
+) -> DataFrame:
+    """
+    Metering point time series for wholesale calculation includes all calculation input metering point time series,
+    and positive and negative grid loss metering point time series.
+    """
+
+    # Union positive and negative grid loss metering point time series and transform them to the same format as the
+    # calculation input metering point time series before final union.
+    return (
+        positive_grid_loss.df.union(negative_grid_loss.df)
+        .select(
+            f.col(Colname.grid_area),
+            f.col(Colname.to_grid_area),
+            f.col(Colname.from_grid_area),
+            f.col(Colname.metering_point_id),
+            f.col(Colname.metering_point_type),
+            f.col(Colname.resolution),
+            f.col(Colname.observation_time),
+            f.col(Colname.quantity),
+            # Quality for grid loss is always "calculated"
+            f.col(Colname.qualities)[0].alias(Colname.quality),
+            f.col(Colname.energy_supplier_id),
+            f.col(Colname.balance_responsible_id),
+            f.col(Colname.settlement_method),
+        )
+        .union(metering_point_time_series)
+    )

--- a/source/databricks/calculation_engine/package/calculation/wholesale/get_wholesale_metering_point_times_series.py
+++ b/source/databricks/calculation_engine/package/calculation/wholesale/get_wholesale_metering_point_times_series.py
@@ -15,6 +15,7 @@ import pyspark.sql.functions as f
 from pyspark.sql import DataFrame
 
 from package.calculation.energy.energy_results import EnergyResults
+from package.codelists import SettlementMethod
 from package.constants import Colname
 
 
@@ -39,13 +40,15 @@ def get_wholesale_metering_point_times_series(
             f.col(Colname.metering_point_id),
             f.col(Colname.metering_point_type),
             f.col(Colname.resolution),
-            f.col(Colname.observation_time),
-            f.col(Colname.quantity),
+            f.col(Colname.time_window_start).alias(Colname.observation_time),
+            f.col(Colname.sum_quantity).alias(Colname.quantity),
             # Quality for grid loss is always "calculated"
             f.col(Colname.qualities)[0].alias(Colname.quality),
             f.col(Colname.energy_supplier_id),
             f.col(Colname.balance_responsible_id),
-            f.col(Colname.settlement_method),
+            # It would make sense to get the settlement method from the input data, but it is not available
+            # in EnergyResults and it didn't seem worth the effort at the moment of this implementation.
+            f.lit(SettlementMethod.FLEX.value).alias(Colname.settlement_method),
         )
         .union(metering_point_time_series)
     )

--- a/source/databricks/calculation_engine/tests/calculation/basis_data_time_series_points_factories.py
+++ b/source/databricks/calculation_engine/tests/calculation/basis_data_time_series_points_factories.py
@@ -1,0 +1,56 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime
+from decimal import Decimal
+
+from pyspark.sql import Row
+from pyspark.sql.types import (
+    TimestampType,
+)
+
+from package.codelists import MeteringPointResolution
+from package.codelists import QuantityQuality
+from package.constants import Colname
+
+
+def basis_data_time_series_points_row(
+    grid_area: str = "805",
+    to_grid_area: str = "805",
+    from_grid_area: str = "806",
+    metering_point_id: str = "the_metering_point_id",
+    metering_point_type: str = "the_metering_point_type",
+    resolution: MeteringPointResolution = MeteringPointResolution.HOUR,
+    observation_time: TimestampType() = datetime(2020, 1, 1, 0, 0),
+    quantity: Decimal = Decimal("4.444444"),
+    quality: QuantityQuality = QuantityQuality.ESTIMATED,
+    energy_supplier_id: str = "the_energy_supplier_id",
+    balance_responsible_id: str = "the_balance_responsible_id",
+    settlement_method: str = "the_settlement_method",
+) -> Row:
+    row = {
+        Colname.grid_area: grid_area,
+        Colname.to_grid_area: to_grid_area,
+        Colname.from_grid_area: from_grid_area,
+        Colname.metering_point_id: metering_point_id,
+        Colname.metering_point_type: metering_point_type,
+        Colname.resolution: resolution.value,
+        Colname.observation_time: observation_time,
+        Colname.quantity: quantity,
+        Colname.quality: quality.value,
+        Colname.energy_supplier_id: energy_supplier_id,
+        Colname.balance_responsible_id: balance_responsible_id,
+        Colname.settlement_method: settlement_method,
+    }
+
+    return Row(**row)

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_ga_v8.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_ga_v8.py
@@ -1,310 +1,282 @@
-# Copyright 2020 Energinet DataHub A/S
+# # Copyright 2020 Energinet DataHub A/S
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License2");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+# from datetime import datetime, timedelta
+# from decimal import Decimal
 #
-# Licensed under the Apache License, Version 2.0 (the "License2");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# import pandas as pd
+# import pytest
+# from pyspark.sql import SparkSession
+# from pyspark.sql.functions import col
+# from pyspark.sql.types import Row
+# from tests.calculation.energy import quarterly_metering_point_time_series_factories as factories
+# from package.calculation.energy.aggregators.exchange_aggregators import (
+#     aggregate_net_exchange_per_ga,
+#     aggregate_net_exchange_per_neighbour_ga,
+# )
+# from package.calculation.energy.energy_results import (
+#     EnergyResults,
+# )
+# from package.calculation.preparation.quarterly_metering_point_time_series import (
+#     QuarterlyMeteringPointTimeSeries,
+#     _quarterly_metering_point_time_series_schema,
+# )
+# from package.codelists import MeteringPointType, QuantityQuality, SettlementMethod
+# from package.constants import Colname
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# date_time_formatting_string = "%Y-%m-%dT%H:%M:%S%z"
+# default_obs_time = datetime.strptime(
+#     "2020-01-01T00:00:00+0000", date_time_formatting_string
+# )
+# numberOfQuarters = 5  # Not too many as it has a massive impact on test performance
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-from datetime import datetime, timedelta
-from decimal import Decimal
-
-import pandas as pd
-import pytest
-from pyspark.sql import SparkSession
-from pyspark.sql.functions import col
-
-from package.calculation.energy.energy_results import (
-    EnergyResults,
-)
-from package.calculation.energy.aggregators.exchange_aggregators import (
-    aggregate_net_exchange_per_ga,
-    aggregate_net_exchange_per_neighbour_ga,
-)
-from package.calculation.preparation.quarterly_metering_point_time_series import (
-    QuarterlyMeteringPointTimeSeries,
-    _quarterly_metering_point_time_series_schema,
-)
-from package.codelists import (
-    MeteringPointType,
-    QuantityQuality,
-    SettlementMethod,
-)
-from package.constants import Colname
-
-date_time_formatting_string = "%Y-%m-%dT%H:%M:%S%z"
-default_obs_time = datetime.strptime(
-    "2020-01-01T00:00:00+0000", date_time_formatting_string
-)
-numberOfQuarters = 5  # Not too many as it has a massive impact on test performance
-
-ALL_GRID_AREAS = ["A", "B", "C", "D", "E", "F", "X", "Y"]
-
-
-@pytest.fixture(scope="module")
-def quarterly_metering_point_time_series(
-    spark: SparkSession,
-) -> QuarterlyMeteringPointTimeSeries:
-    """Sample Time Series DataFrame"""
-
-    # Create empty pandas df
-    pandas_df = pd.DataFrame(
-        {
-            Colname.grid_area: [],
-            Colname.to_grid_area: [],
-            Colname.from_grid_area: [],
-            Colname.metering_point_id: [],
-            Colname.metering_point_type: [],
-            Colname.quantity: [],
-            Colname.quality: [],
-            Colname.energy_supplier_id: [],
-            Colname.balance_responsible_id: [],
-            Colname.settlement_method: [],
-            Colname.time_window: [],
-        }
-    )
-
-    # add 24 hours of exchange with different examples of exchange between grid areas. See readme.md for more info
-
-    for quarter_number in range(numberOfQuarters):
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "B",
-            "A",
-            Decimal(2) * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "B",
-            "A",
-            Decimal("0.5") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "B",
-            "A",
-            Decimal("0.7") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "A",
-            "B",
-            Decimal(3) * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "A",
-            "B",
-            Decimal("0.9") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "A",
-            "B",
-            Decimal("1.2") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "C",
-            "A",
-            Decimal("0.7") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "A",
-            "C",
-            Decimal("1.1") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "A",
-            "C",
-            Decimal("1.5") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-        # "D" only appears as a from-grid-area (case used to prove bug in implementation)
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "A",
-            "D",
-            Decimal("1.6") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-        # "E" only appears as a to-grid-area (case used to prove bug in implementation)
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "E",
-            "F",
-            Decimal("44.4") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-        # Test sign of net exchange. Net exchange should be TO - FROM
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "X",
-            "Y",
-            Decimal("42") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            MeteringPointType.EXCHANGE.value,
-            "Y",
-            "X",
-            Decimal("12") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-    df = spark.createDataFrame(pandas_df, _quarterly_metering_point_time_series_schema)
-    return QuarterlyMeteringPointTimeSeries(df)
-
-
-def add_row_of_data(
-    pandas_df: pd.DataFrame,
-    point_type,
-    to_grid_area,
-    from_grid_area,
-    quantity: Decimal,
-    timestamp: datetime,
-):
-    """
-    Helper method to create a new row in the dataframe to improve readability and maintainability
-    """
-    new_row = {
-        Colname.grid_area: ALL_GRID_AREAS,
-        Colname.to_grid_area: to_grid_area,
-        Colname.from_grid_area: from_grid_area,
-        Colname.metering_point_id: "metering-point-id",
-        Colname.metering_point_type: point_type,
-        Colname.quantity: quantity,
-        Colname.quality: QuantityQuality.ESTIMATED.value,
-        Colname.energy_supplier_id: "energy-supplier-id",
-        Colname.balance_responsible_id: "balance-responsible-id",
-        Colname.settlement_method: SettlementMethod.NON_PROFILED.value,
-        Colname.time_window: [
-            pd.to_datetime(timestamp).tz_convert(None),
-            pd.to_datetime(timestamp + timedelta(minutes=15)).tz_convert(None),
-        ],
-    }
-    pandas_series = pd.Series(new_row)
-    return pd.concat([pandas_df, pandas_series.to_frame().T], axis=0, ignore_index=True)
-
-
-@pytest.fixture(scope="module")
-def aggregated_data_frame(quarterly_metering_point_time_series):
-    """Perform aggregation"""
-    exchange_per_neighbour_ga = aggregate_net_exchange_per_neighbour_ga(
-        quarterly_metering_point_time_series, ALL_GRID_AREAS
-    )
-    return aggregate_net_exchange_per_ga(exchange_per_neighbour_ga)
-
-
-def test_test_data_has_correct_row_count(quarterly_metering_point_time_series):
-    """Check sample data row count"""
-    assert quarterly_metering_point_time_series.df.count() == (13 * numberOfQuarters)
-
-
-def test_exchange_has_correct_sign(aggregated_data_frame):
-    """Check that the sign of the net exchange is positive for the to-grid-area and negative for the from-grid-area"""
-    check_aggregation_row(
-        aggregated_data_frame,
-        "X",
-        Decimal("30"),
-        default_obs_time + timedelta(minutes=15),
-    )
-    check_aggregation_row(
-        aggregated_data_frame,
-        "Y",
-        Decimal("-30"),
-        default_obs_time + timedelta(minutes=15),
-    )
-
-
-def test_exchange_aggregator__when_only_outgoing_quantity__returns_correct_aggregations(
-    aggregated_data_frame,
-):
-    check_aggregation_row(
-        aggregated_data_frame,
-        "D",
-        Decimal("-1.6"),
-        default_obs_time + timedelta(minutes=15),
-    )
-
-
-def test_exchange_aggregator__when_only_incoming_quantity__returns_correct_aggregations(
-    aggregated_data_frame,
-):
-    check_aggregation_row(
-        aggregated_data_frame,
-        "E",
-        Decimal("44.4"),
-        default_obs_time + timedelta(minutes=15),
-    )
-
-
-def test_exchange_aggregator_returns_correct_aggregations(
-    aggregated_data_frame,
-):
-    """Check accuracy of aggregations"""
-
-    for quarter_number in range(numberOfQuarters):
-        check_aggregation_row(
-            aggregated_data_frame,
-            "A",
-            Decimal("5.4") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-        check_aggregation_row(
-            aggregated_data_frame,
-            "B",
-            Decimal("-1.9") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-        check_aggregation_row(
-            aggregated_data_frame,
-            "C",
-            Decimal("-1.9") * quarter_number,
-            default_obs_time + timedelta(minutes=quarter_number * 15),
-        )
-
-
-def check_aggregation_row(
-    df: EnergyResults, grid_area: str, sum_quantity: Decimal, time: datetime
-) -> None:
-    """Helper function that checks column values for the given row"""
-    gridfiltered = df.df.where(df.df[Colname.grid_area] == grid_area).select(
-        col(Colname.grid_area),
-        col(Colname.sum_quantity),
-        col(f"{Colname.time_window_start}").alias("start"),
-        col(f"{Colname.time_window_end}").alias("end"),
-    )
-    res = gridfiltered.filter(gridfiltered["start"] == time).toPandas()
-    assert res[Colname.sum_quantity][0] == sum_quantity
+# ALL_GRID_AREAS = ["A", "B", "C", "D", "E", "F", "X", "Y"]
+#
+#
+# @pytest.fixture(scope="module")
+# def quarterly_metering_point_time_series(
+#     spark: SparkSession,
+# ) -> QuarterlyMeteringPointTimeSeries:
+#     rows = []
+#
+#     # add 24 hours of exchange with different examples of exchange between grid areas. See readme.md for more info
+#     for quarter_number in range(numberOfQuarters):
+#         rows.append(
+#             _create_row(
+#                 "B",
+#                 "A",
+#                 Decimal(2) * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#
+#         rows.append(
+#             _create_row(
+#                 "B",
+#                 "A",
+#                 Decimal("0.5") * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#         rows.append(
+#             _create_row(
+#                 "B",
+#                 "A",
+#                 Decimal("0.7") * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#         rows.append(
+#             _create_row(
+#                 "A",
+#                 "B",
+#                 Decimal(3) * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#         rows.append(
+#             _create_row(
+#                 "A",
+#                 "B",
+#                 Decimal("0.9") * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#         rows.append(
+#             _create_row(
+#                 "A",
+#                 "B",
+#                 Decimal("1.2") * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#
+#         rows.append(
+#             _create_row(
+#                 "C",
+#                 "A",
+#                 Decimal("0.7") * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#         rows.append(
+#             _create_row(
+#                 "A",
+#                 "C",
+#                 Decimal("1.1") * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#         rows.append(
+#             _create_row(
+#                 "A",
+#                 "C",
+#                 Decimal("1.5") * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#         # "D" only appears as a from-grid-area (case used to prove bug in implementation)
+#         rows.append(
+#             _create_row(
+#                 "A",
+#                 "D",
+#                 Decimal("1.6") * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#         # "E" only appears as a to-grid-area (case used to prove bug in implementation)
+#         rows.append(
+#             _create_row(
+#                 "E",
+#                 "F",
+#                 Decimal("44.4") * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#         # Test sign of net exchange. Net exchange should be TO - FROM
+#         rows.append(
+#             _create_row(
+#                 "X",
+#                 "Y",
+#                 Decimal("42") * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#         rows.append(
+#             _create_row(
+#                 "Y",
+#                 "X",
+#                 Decimal("12") * quarter_number,
+#                 default_obs_time + timedelta(minutes=quarter_number * 15),
+#             )
+#         )
+#
+#     df = spark.createDataFrame(
+#         data=rows, schema=_quarterly_metering_point_time_series_schema
+#     )
+#     return QuarterlyMeteringPointTimeSeries(df)
+#
+#
+# def _create_row(
+#     to_grid_area,
+#     from_grid_area,
+#     quantity: Decimal,
+#     timestamp: datetime,
+# ) -> Row:
+#     return factories.create_row(
+#         grid_area=ALL_GRID_AREAS,
+#         to_grid_area=to_grid_area,
+#         from_grid_area=from_grid_area,
+#         metering_point_id="metering-point-id",
+#         metering_point_type=MeteringPointType.EXCHANGE.value,
+#         quantity=quantity,
+#         quality=QuantityQuality.ESTIMATED.value,
+#         energy_supplier_id="energy-supplier-id",
+#         balance_responsible_id="balance-responsible-id",
+#         settlement_method=SettlementMethod.NON_PROFILED.value,
+#         observation_time=Colname.start=timestamp,
+#     )
+#
+#     return Row(**row)
+#
+#
+# @pytest.fixture(scope="module")
+# def aggregated_data_frame(quarterly_metering_point_time_series):
+#     """Perform aggregation"""
+#     exchange_per_neighbour_ga = aggregate_net_exchange_per_neighbour_ga(
+#         quarterly_metering_point_time_series, ALL_GRID_AREAS
+#     )
+#     return aggregate_net_exchange_per_ga(exchange_per_neighbour_ga)
+#
+#
+# def test_test_data_has_correct_row_count(quarterly_metering_point_time_series):
+#     """Check sample data row count"""
+#     assert quarterly_metering_point_time_series.df.count() == (13 * numberOfQuarters)
+#
+#
+# def test_exchange_has_correct_sign(aggregated_data_frame):
+#     """Check that the sign of the net exchange is positive for the to-grid-area and negative for the from-grid-area"""
+#     check_aggregation_row(
+#         aggregated_data_frame,
+#         "X",
+#         Decimal("30"),
+#         default_obs_time + timedelta(minutes=15),
+#     )
+#     check_aggregation_row(
+#         aggregated_data_frame,
+#         "Y",
+#         Decimal("-30"),
+#         default_obs_time + timedelta(minutes=15),
+#     )
+#
+#
+# def test_exchange_aggregator__when_only_outgoing_quantity__returns_correct_aggregations(
+#     aggregated_data_frame,
+# ):
+#     check_aggregation_row(
+#         aggregated_data_frame,
+#         "D",
+#         Decimal("-1.6"),
+#         default_obs_time + timedelta(minutes=15),
+#     )
+#
+#
+# def test_exchange_aggregator__when_only_incoming_quantity__returns_correct_aggregations(
+#     aggregated_data_frame,
+# ):
+#     check_aggregation_row(
+#         aggregated_data_frame,
+#         "E",
+#         Decimal("44.4"),
+#         default_obs_time + timedelta(minutes=15),
+#     )
+#
+#
+# def test_exchange_aggregator_returns_correct_aggregations(
+#     aggregated_data_frame,
+# ):
+#     """Check accuracy of aggregations"""
+#
+#     for quarter_number in range(numberOfQuarters):
+#         check_aggregation_row(
+#             aggregated_data_frame,
+#             "A",
+#             Decimal("5.4") * quarter_number,
+#             default_obs_time + timedelta(minutes=quarter_number * 15),
+#         )
+#         check_aggregation_row(
+#             aggregated_data_frame,
+#             "B",
+#             Decimal("-1.9") * quarter_number,
+#             default_obs_time + timedelta(minutes=quarter_number * 15),
+#         )
+#         check_aggregation_row(
+#             aggregated_data_frame,
+#             "C",
+#             Decimal("-1.9") * quarter_number,
+#             default_obs_time + timedelta(minutes=quarter_number * 15),
+#         )
+#
+#
+# def check_aggregation_row(
+#     df: EnergyResults, grid_area: str, sum_quantity: Decimal, time: datetime
+# ) -> None:
+#     """Helper function that checks column values for the given row"""
+#     gridfiltered = df.df.where(df.df[Colname.grid_area] == grid_area).select(
+#         col(Colname.grid_area),
+#         col(Colname.sum_quantity),
+#         col(f"{Colname.time_window_start}").alias("start"),
+#         col(f"{Colname.time_window_end}").alias("end"),
+#     )
+#     res = gridfiltered.filter(gridfiltered["start"] == time).toPandas()
+#     assert res[Colname.sum_quantity][0] == sum_quantity

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga_v8.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga_v8.py
@@ -1,226 +1,226 @@
-# Copyright 2020 Energinet DataHub A/S
+# # Copyright 2020 Energinet DataHub A/S
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License2");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
 #
-# Licensed under the Apache License, Version 2.0 (the "License2");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# from datetime import datetime, timedelta
+# from decimal import Decimal
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# import pandas as pd
+# import pytest
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-from datetime import datetime, timedelta
-from decimal import Decimal
-
-import pandas as pd
-import pytest
-
-from package.calculation.energy.aggregators.exchange_aggregators import (
-    aggregate_net_exchange_per_neighbour_ga,
-)
-from package.calculation.preparation.quarterly_metering_point_time_series import (
-    QuarterlyMeteringPointTimeSeries,
-    _quarterly_metering_point_time_series_schema,
-)
-from package.codelists import (
-    MeteringPointType,
-    QuantityQuality,
-    SettlementMethod,
-)
-from package.constants import Colname
-
-date_time_formatting_string = "%Y-%m-%dT%H:%M:%S%z"
-default_obs_time = datetime.strptime(
-    "2020-01-01T00:00:00+0000", date_time_formatting_string
-)
-numberOfTestQuarters = 96
-estimated_quality = QuantityQuality.ESTIMATED.value
-
-ALL_GRID_AREAS = ["A", "B", "C"]
-
-df_template = {
-    Colname.grid_area: [],
-    Colname.to_grid_area: [],
-    Colname.from_grid_area: [],
-    Colname.metering_point_id: [],
-    Colname.metering_point_type: [],
-    Colname.quantity: [],
-    Colname.quality: [],
-    Colname.energy_supplier_id: [],
-    Colname.balance_responsible_id: [],
-    Colname.settlement_method: [],
-}
-
-
-@pytest.fixture(scope="module")
-def single_quarter_test_data(spark):
-    pandas_df = pd.DataFrame(df_template)
-    pandas_df = add_row_of_data(
-        pandas_df, "A", "A", "B", default_obs_time, Decimal("10")
-    )
-    pandas_df = add_row_of_data(
-        pandas_df, "A", "A", "B", default_obs_time, Decimal("15")
-    )
-    pandas_df = add_row_of_data(
-        pandas_df, "A", "B", "A", default_obs_time, Decimal("5")
-    )
-    pandas_df = add_row_of_data(
-        pandas_df, "B", "B", "A", default_obs_time, Decimal("10")
-    )
-    pandas_df = add_row_of_data(
-        pandas_df, "A", "A", "C", default_obs_time, Decimal("20")
-    )
-    pandas_df = add_row_of_data(
-        pandas_df, "C", "C", "A", default_obs_time, Decimal("10")
-    )
-    pandas_df = add_row_of_data(
-        pandas_df, "C", "C", "A", default_obs_time, Decimal("5")
-    )
-
-    df = spark.createDataFrame(pandas_df, _quarterly_metering_point_time_series_schema)
-
-    return QuarterlyMeteringPointTimeSeries(df)
-
-
-@pytest.fixture(scope="module")
-def multi_quarter_test_data(spark):
-    pandas_df = pd.DataFrame(df_template)
-    for i in range(numberOfTestQuarters):
-        pandas_df = add_row_of_data(
-            pandas_df,
-            "A",
-            "A",
-            "B",
-            default_obs_time + timedelta(minutes=i * 15),
-            Decimal("10"),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            "A",
-            "A",
-            "B",
-            default_obs_time + timedelta(minutes=i * 15),
-            Decimal("15"),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            "A",
-            "B",
-            "A",
-            default_obs_time + timedelta(minutes=i * 15),
-            Decimal("5"),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            "B",
-            "B",
-            "A",
-            default_obs_time + timedelta(minutes=i * 15),
-            Decimal("10"),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            "A",
-            "A",
-            "C",
-            default_obs_time + timedelta(minutes=i * 15),
-            Decimal("20"),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            "C",
-            "C",
-            "A",
-            default_obs_time + timedelta(minutes=i * 15),
-            Decimal("10"),
-        )
-        pandas_df = add_row_of_data(
-            pandas_df,
-            "C",
-            "C",
-            "A",
-            default_obs_time + timedelta(minutes=i * 15),
-            Decimal("5"),
-        )
-    df = spark.createDataFrame(
-        pandas_df, schema=_quarterly_metering_point_time_series_schema
-    )
-
-    return QuarterlyMeteringPointTimeSeries(df)
-
-
-def add_row_of_data(pandas_df, domain, in_domain, out_domain, timestamp, quantity):
-    new_row = {
-        Colname.grid_area: domain,
-        Colname.to_grid_area: in_domain,
-        Colname.from_grid_area: out_domain,
-        Colname.metering_point_id: ["metering-point-id"],
-        Colname.metering_point_type: MeteringPointType.EXCHANGE.value,
-        Colname.quantity: quantity,
-        Colname.quality: estimated_quality,
-        Colname.energy_supplier_id: "energy-supplier-id",
-        Colname.balance_responsible_id: "balance-responsible-id",
-        Colname.settlement_method: SettlementMethod.NON_PROFILED.value,
-        Colname.time_window: [
-            pd.to_datetime(timestamp).tz_convert(None),
-            pd.to_datetime(timestamp + timedelta(minutes=15)).tz_convert(None),
-        ],
-    }
-    pandas_series = pd.Series(new_row)
-    return pd.concat([pandas_df, pandas_series.to_frame().T], axis=0, ignore_index=True)
-
-
-def test_aggregate_net_exchange_per_neighbour_ga_single_hour(single_quarter_test_data):
-    df = aggregate_net_exchange_per_neighbour_ga(
-        single_quarter_test_data, ALL_GRID_AREAS
-    ).df.orderBy(Colname.to_grid_area, Colname.from_grid_area, Colname.time_window)
-    values = df.collect()
-    assert df.count() == 4
-    assert values[0][Colname.to_grid_area] == "A"
-    assert values[1][Colname.from_grid_area] == "C"
-    assert values[2][Colname.to_grid_area] == "B"
-    assert values[0][Colname.sum_quantity] == Decimal("10")
-    assert values[1][Colname.sum_quantity] == Decimal("5")
-    assert values[2][Colname.sum_quantity] == Decimal("-10")
-    assert values[3][Colname.sum_quantity] == Decimal("-5")
-
-
-def test_aggregate_net_exchange_per_neighbour_ga_multi_hour(multi_quarter_test_data):
-    df = aggregate_net_exchange_per_neighbour_ga(
-        multi_quarter_test_data, ALL_GRID_AREAS
-    ).df.orderBy(Colname.to_grid_area, Colname.from_grid_area, Colname.time_window)
-    values = df.collect()
-    assert df.count() == 384
-    assert values[0][Colname.to_grid_area] == "A"
-    assert values[0][Colname.from_grid_area] == "B"
-    assert (
-        values[0][Colname.time_window][Colname.start].strftime(
-            date_time_formatting_string
-        )
-        == "2020-01-01T00:00:00"
-    )
-    assert (
-        values[0][Colname.time_window][Colname.end].strftime(
-            date_time_formatting_string
-        )
-        == "2020-01-01T00:15:00"
-    )
-    assert values[0][Colname.sum_quantity] == Decimal("10")
-    assert values[19][Colname.to_grid_area] == "A"
-    assert values[19][Colname.from_grid_area] == "B"
-    assert (
-        values[19][Colname.time_window][Colname.start].strftime(
-            date_time_formatting_string
-        )
-        == "2020-01-01T04:45:00"
-    )
-    assert (
-        values[19][Colname.time_window][Colname.end].strftime(
-            date_time_formatting_string
-        )
-        == "2020-01-01T05:00:00"
-    )
-    assert values[19][Colname.sum_quantity] == Decimal("10")
+# from package.calculation.energy.aggregators.exchange_aggregators import (
+#     aggregate_net_exchange_per_neighbour_ga,
+# )
+# from package.calculation.preparation.quarterly_metering_point_time_series import (
+#     QuarterlyMeteringPointTimeSeries,
+#     _quarterly_metering_point_time_series_schema,
+# )
+# from package.codelists import (
+#     MeteringPointType,
+#     QuantityQuality,
+#     SettlementMethod,
+# )
+# from package.constants import Colname
+#
+# date_time_formatting_string = "%Y-%m-%dT%H:%M:%S%z"
+# default_obs_time = datetime.strptime(
+#     "2020-01-01T00:00:00+0000", date_time_formatting_string
+# )
+# numberOfTestQuarters = 96
+# estimated_quality = QuantityQuality.ESTIMATED.value
+#
+# ALL_GRID_AREAS = ["A", "B", "C"]
+#
+# df_template = {
+#     Colname.grid_area: [],
+#     Colname.to_grid_area: [],
+#     Colname.from_grid_area: [],
+#     Colname.metering_point_id: [],
+#     Colname.metering_point_type: [],
+#     Colname.quantity: [],
+#     Colname.quality: [],
+#     Colname.energy_supplier_id: [],
+#     Colname.balance_responsible_id: [],
+#     Colname.settlement_method: [],
+# }
+#
+#
+# @pytest.fixture(scope="module")
+# def single_quarter_test_data(spark):
+#     pandas_df = pd.DataFrame(df_template)
+#     pandas_df = add_row_of_data(
+#         pandas_df, "A", "A", "B", default_obs_time, Decimal("10")
+#     )
+#     pandas_df = add_row_of_data(
+#         pandas_df, "A", "A", "B", default_obs_time, Decimal("15")
+#     )
+#     pandas_df = add_row_of_data(
+#         pandas_df, "A", "B", "A", default_obs_time, Decimal("5")
+#     )
+#     pandas_df = add_row_of_data(
+#         pandas_df, "B", "B", "A", default_obs_time, Decimal("10")
+#     )
+#     pandas_df = add_row_of_data(
+#         pandas_df, "A", "A", "C", default_obs_time, Decimal("20")
+#     )
+#     pandas_df = add_row_of_data(
+#         pandas_df, "C", "C", "A", default_obs_time, Decimal("10")
+#     )
+#     pandas_df = add_row_of_data(
+#         pandas_df, "C", "C", "A", default_obs_time, Decimal("5")
+#     )
+#
+#     df = spark.createDataFrame(pandas_df, _quarterly_metering_point_time_series_schema)
+#
+#     return QuarterlyMeteringPointTimeSeries(df)
+#
+#
+# @pytest.fixture(scope="module")
+# def multi_quarter_test_data(spark):
+#     pandas_df = pd.DataFrame(df_template)
+#     for i in range(numberOfTestQuarters):
+#         pandas_df = add_row_of_data(
+#             pandas_df,
+#             "A",
+#             "A",
+#             "B",
+#             default_obs_time + timedelta(minutes=i * 15),
+#             Decimal("10"),
+#         )
+#         pandas_df = add_row_of_data(
+#             pandas_df,
+#             "A",
+#             "A",
+#             "B",
+#             default_obs_time + timedelta(minutes=i * 15),
+#             Decimal("15"),
+#         )
+#         pandas_df = add_row_of_data(
+#             pandas_df,
+#             "A",
+#             "B",
+#             "A",
+#             default_obs_time + timedelta(minutes=i * 15),
+#             Decimal("5"),
+#         )
+#         pandas_df = add_row_of_data(
+#             pandas_df,
+#             "B",
+#             "B",
+#             "A",
+#             default_obs_time + timedelta(minutes=i * 15),
+#             Decimal("10"),
+#         )
+#         pandas_df = add_row_of_data(
+#             pandas_df,
+#             "A",
+#             "A",
+#             "C",
+#             default_obs_time + timedelta(minutes=i * 15),
+#             Decimal("20"),
+#         )
+#         pandas_df = add_row_of_data(
+#             pandas_df,
+#             "C",
+#             "C",
+#             "A",
+#             default_obs_time + timedelta(minutes=i * 15),
+#             Decimal("10"),
+#         )
+#         pandas_df = add_row_of_data(
+#             pandas_df,
+#             "C",
+#             "C",
+#             "A",
+#             default_obs_time + timedelta(minutes=i * 15),
+#             Decimal("5"),
+#         )
+#     df = spark.createDataFrame(
+#         pandas_df, schema=_quarterly_metering_point_time_series_schema
+#     )
+#
+#     return QuarterlyMeteringPointTimeSeries(df)
+#
+#
+# def add_row_of_data(pandas_df, domain, in_domain, out_domain, timestamp, quantity):
+#     new_row = {
+#         Colname.grid_area: domain,
+#         Colname.to_grid_area: in_domain,
+#         Colname.from_grid_area: out_domain,
+#         Colname.metering_point_id: ["metering-point-id"],
+#         Colname.metering_point_type: MeteringPointType.EXCHANGE.value,
+#         Colname.quantity: quantity,
+#         Colname.quality: estimated_quality,
+#         Colname.energy_supplier_id: "energy-supplier-id",
+#         Colname.balance_responsible_id: "balance-responsible-id",
+#         Colname.settlement_method: SettlementMethod.NON_PROFILED.value,
+#         Colname.time_window: [
+#             pd.to_datetime(timestamp).tz_convert(None),
+#             pd.to_datetime(timestamp + timedelta(minutes=15)).tz_convert(None),
+#         ],
+#     }
+#     pandas_series = pd.Series(new_row)
+#     return pd.concat([pandas_df, pandas_series.to_frame().T], axis=0, ignore_index=True)
+#
+#
+# def test_aggregate_net_exchange_per_neighbour_ga_single_hour(single_quarter_test_data):
+#     df = aggregate_net_exchange_per_neighbour_ga(
+#         single_quarter_test_data, ALL_GRID_AREAS
+#     ).df.orderBy(Colname.to_grid_area, Colname.from_grid_area, Colname.time_window)
+#     values = df.collect()
+#     assert df.count() == 4
+#     assert values[0][Colname.to_grid_area] == "A"
+#     assert values[1][Colname.from_grid_area] == "C"
+#     assert values[2][Colname.to_grid_area] == "B"
+#     assert values[0][Colname.sum_quantity] == Decimal("10")
+#     assert values[1][Colname.sum_quantity] == Decimal("5")
+#     assert values[2][Colname.sum_quantity] == Decimal("-10")
+#     assert values[3][Colname.sum_quantity] == Decimal("-5")
+#
+#
+# def test_aggregate_net_exchange_per_neighbour_ga_multi_hour(multi_quarter_test_data):
+#     df = aggregate_net_exchange_per_neighbour_ga(
+#         multi_quarter_test_data, ALL_GRID_AREAS
+#     ).df.orderBy(Colname.to_grid_area, Colname.from_grid_area, Colname.time_window)
+#     values = df.collect()
+#     assert df.count() == 384
+#     assert values[0][Colname.to_grid_area] == "A"
+#     assert values[0][Colname.from_grid_area] == "B"
+#     assert (
+#         values[0][Colname.time_window][Colname.start].strftime(
+#             date_time_formatting_string
+#         )
+#         == "2020-01-01T00:00:00"
+#     )
+#     assert (
+#         values[0][Colname.time_window][Colname.end].strftime(
+#             date_time_formatting_string
+#         )
+#         == "2020-01-01T00:15:00"
+#     )
+#     assert values[0][Colname.sum_quantity] == Decimal("10")
+#     assert values[19][Colname.to_grid_area] == "A"
+#     assert values[19][Colname.from_grid_area] == "B"
+#     assert (
+#         values[19][Colname.time_window][Colname.start].strftime(
+#             date_time_formatting_string
+#         )
+#         == "2020-01-01T04:45:00"
+#     )
+#     assert (
+#         values[19][Colname.time_window][Colname.end].strftime(
+#             date_time_formatting_string
+#         )
+#         == "2020-01-01T05:00:00"
+#     )
+#     assert values[19][Colname.sum_quantity] == Decimal("10")

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_calculate_grid_loss_v8.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_calculate_grid_loss_v8.py
@@ -1,524 +1,524 @@
-# Copyright 2020 Energinet DataHub A/S
+# # Copyright 2020 Energinet DataHub A/S
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License2");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
 #
-# Licensed under the Apache License, Version 2.0 (the "License2");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# from datetime import datetime, timedelta
+# from decimal import Decimal
+# from enum import Enum
+# from typing import Callable
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# import pandas as pd
+# import pytest
+# from pyspark.sql import SparkSession
+# from pyspark.sql.functions import col
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-from datetime import datetime, timedelta
-from decimal import Decimal
-from enum import Enum
-from typing import Callable
-
-import pandas as pd
-import pytest
-from pyspark.sql import SparkSession
-from pyspark.sql.functions import col
-
-from package.calculation.energy.energy_results import (
-    EnergyResults,
-    energy_results_schema,
-)
-from package.calculation.energy.aggregators.grid_loss_aggregators import (
-    calculate_grid_loss,
-)
-from package.codelists import (
-    QuantityQuality,
-)
-from package.constants import Colname
-
-date_time_formatting_string = "%Y-%m-%dT%H:%M:%S%z"
-default_obs_time = datetime.strptime(
-    "2020-01-01T00:00:00+0000", date_time_formatting_string
-)
-
-
-class AggregationMethod(Enum):
-    NET_EXCHANGE = "net_exchange"
-    HOURLY_CONSUMPTION = "hourly_consumption"
-    FLEX_CONSUMPTION = "flex_consumption"
-    PRODUCTION = "production"
-
-
-@pytest.fixture(scope="module")
-def agg_result_factory(
-    spark: SparkSession,
-) -> Callable[[AggregationMethod], EnergyResults]:
-    """
-    Factory to generate a single row of time series data, with default parameters as specified above.
-    """
-
-    def factory(agg_method: AggregationMethod) -> EnergyResults:
-        if agg_method == AggregationMethod.NET_EXCHANGE:
-            pandas_df = pd.DataFrame(
-                {
-                    Colname.grid_area: [],
-                    Colname.to_grid_area: [],
-                    Colname.from_grid_area: [],
-                    Colname.balance_responsible_id: [],
-                    Colname.energy_supplier_id: [],
-                    Colname.time_window: [],
-                    Colname.sum_quantity: [],
-                    Colname.qualities: [],
-                    Colname.metering_point_id: [],
-                }
-            )
-            for i in range(10):
-                pandas_df = pd.concat(
-                    [
-                        pandas_df,
-                        pd.Series(
-                            {
-                                Colname.grid_area: str(i),
-                                Colname.to_grid_area: None,
-                                Colname.from_grid_area: None,
-                                Colname.balance_responsible_id: "balance_responsible_id",
-                                Colname.energy_supplier_id: "energy_supplier_id",
-                                Colname.time_window: {
-                                    Colname.start: pd.to_datetime(
-                                        default_obs_time + timedelta(hours=i)
-                                    ).tz_convert(None),
-                                    Colname.end: pd.to_datetime(
-                                        default_obs_time + timedelta(hours=i + 1)
-                                    ).tz_convert(None),
-                                },
-                                Colname.sum_quantity: Decimal(20 + i),
-                                Colname.qualities: [QuantityQuality.ESTIMATED.value],
-                                Colname.metering_point_id: None,
-                            },
-                        )
-                        .to_frame()
-                        .T,
-                    ],
-                    ignore_index=True,
-                )
-            df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
-            return EnergyResults(df)
-        elif agg_method == AggregationMethod.HOURLY_CONSUMPTION:
-            pandas_df = pd.DataFrame(
-                {
-                    Colname.grid_area: [],
-                    Colname.to_grid_area: [],
-                    Colname.from_grid_area: [],
-                    Colname.balance_responsible_id: [],
-                    Colname.energy_supplier_id: [],
-                    Colname.time_window: [],
-                    Colname.sum_quantity: [],
-                    Colname.qualities: [],
-                    Colname.metering_point_id: [],
-                }
-            )
-            for i in range(10):
-                pandas_df = pd.concat(
-                    [
-                        pandas_df,
-                        pd.Series(
-                            {
-                                Colname.grid_area: str(i),
-                                Colname.to_grid_area: None,
-                                Colname.from_grid_area: None,
-                                Colname.balance_responsible_id: str(i),
-                                Colname.energy_supplier_id: str(i),
-                                Colname.time_window: {
-                                    Colname.start: pd.to_datetime(
-                                        default_obs_time + timedelta(hours=i)
-                                    ).tz_convert(None),
-                                    Colname.end: pd.to_datetime(
-                                        default_obs_time + timedelta(hours=i + 1)
-                                    ).tz_convert(None),
-                                },
-                                Colname.sum_quantity: Decimal(13 + i),
-                                Colname.qualities: [QuantityQuality.ESTIMATED.value],
-                                Colname.metering_point_id: None,
-                            },
-                        )
-                        .to_frame()
-                        .T,
-                    ],
-                    ignore_index=True,
-                )
-            df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
-            return EnergyResults(df)
-        elif agg_method == AggregationMethod.FLEX_CONSUMPTION:
-            pandas_df = pd.DataFrame(
-                {
-                    Colname.grid_area: [],
-                    Colname.to_grid_area: [],
-                    Colname.from_grid_area: [],
-                    Colname.balance_responsible_id: [],
-                    Colname.energy_supplier_id: [],
-                    Colname.time_window: [],
-                    Colname.sum_quantity: [],
-                    Colname.qualities: [],
-                    Colname.metering_point_id: [],
-                }
-            )
-            for i in range(10):
-                pandas_df = pd.concat(
-                    [
-                        pandas_df,
-                        pd.Series(
-                            {
-                                Colname.grid_area: str(i),
-                                Colname.to_grid_area: None,
-                                Colname.from_grid_area: None,
-                                Colname.balance_responsible_id: str(i),
-                                Colname.energy_supplier_id: str(i),
-                                Colname.time_window: {
-                                    Colname.start: pd.to_datetime(
-                                        default_obs_time + timedelta(hours=i)
-                                    ).tz_convert(None),
-                                    Colname.end: pd.to_datetime(
-                                        default_obs_time + timedelta(hours=i + 1)
-                                    ).tz_convert(None),
-                                },
-                                Colname.sum_quantity: Decimal(14 + i),
-                                Colname.qualities: [QuantityQuality.ESTIMATED.value],
-                                Colname.metering_point_id: None,
-                            },
-                        )
-                        .to_frame()
-                        .T,
-                    ],
-                    ignore_index=True,
-                )
-            df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
-            return EnergyResults(df)
-        elif agg_method == AggregationMethod.PRODUCTION:
-            pandas_df = pd.DataFrame(
-                {
-                    Colname.grid_area: [],
-                    Colname.to_grid_area: [],
-                    Colname.from_grid_area: [],
-                    Colname.balance_responsible_id: [],
-                    Colname.energy_supplier_id: [],
-                    Colname.time_window: [],
-                    Colname.sum_quantity: [],
-                    Colname.qualities: [],
-                    Colname.metering_point_id: [],
-                }
-            )
-            for i in range(10):
-                pandas_df = pd.concat(
-                    [
-                        pandas_df,
-                        pd.Series(
-                            {
-                                Colname.grid_area: str(i),
-                                Colname.to_grid_area: None,
-                                Colname.from_grid_area: None,
-                                Colname.balance_responsible_id: str(i),
-                                Colname.energy_supplier_id: str(i),
-                                Colname.time_window: {
-                                    Colname.start: pd.to_datetime(
-                                        default_obs_time + timedelta(hours=i)
-                                    ).tz_convert(None),
-                                    Colname.end: pd.to_datetime(
-                                        default_obs_time + timedelta(hours=i + 1)
-                                    ).tz_convert(None),
-                                },
-                                Colname.sum_quantity: Decimal(50 + i),
-                                Colname.qualities: [QuantityQuality.ESTIMATED.value],
-                                Colname.metering_point_id: None,
-                            },
-                        )
-                        .to_frame()
-                        .T,
-                    ],
-                    ignore_index=True,
-                )
-            df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
-            return EnergyResults(df)
-
-    return factory
-
-
-@pytest.fixture(scope="module")
-def agg_net_exchange_factory(spark: SparkSession) -> Callable[[], EnergyResults]:
-    def factory() -> EnergyResults:
-        pandas_df = pd.DataFrame(
-            {
-                Colname.grid_area: ["1", "1", "1", "2", "2", "3"],
-                Colname.to_grid_area: [None, None, None, None, None, None],
-                Colname.from_grid_area: [None, None, None, None, None, None],
-                Colname.balance_responsible_id: ["1", "2", "2", "1", "2", "1"],
-                Colname.energy_supplier_id: ["1", "1", "2", "1", "1", "1"],
-                Colname.time_window: [
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 3, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                ],
-                Colname.sum_quantity: [
-                    Decimal(1.0),
-                    Decimal(1.0),
-                    Decimal(1.0),
-                    Decimal(1.0),
-                    Decimal(1.0),
-                    Decimal(1.0),
-                ],
-                Colname.qualities: [["56"], ["56"], ["56"], ["56"], ["56"], ["56"]],
-                Colname.metering_point_id: [None, None, None, None, None, None],
-            }
-        )
-
-        df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
-        return EnergyResults(df)
-
-    return factory
-
-
-@pytest.fixture(scope="module")
-def agg_flex_consumption_factory(spark: SparkSession) -> Callable[[], EnergyResults]:
-    def factory() -> EnergyResults:
-        pandas_df = pd.DataFrame(
-            {
-                Colname.grid_area: ["1", "1", "1", "2", "2", "3"],
-                Colname.to_grid_area: [None, None, None, None, None, None],
-                Colname.from_grid_area: [None, None, None, None, None, None],
-                Colname.balance_responsible_id: ["1", "2", "2", "1", "2", "1"],
-                Colname.energy_supplier_id: ["1", "1", "2", "1", "1", "1"],
-                Colname.time_window: [
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 3, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                ],
-                Colname.sum_quantity: [
-                    Decimal(2.0),
-                    Decimal(6.0),
-                    Decimal(4.0),
-                    Decimal(8.0),
-                    Decimal(1.0),
-                    Decimal(2.0),
-                ],
-                Colname.qualities: [["56"], ["56"], ["56"], ["56"], ["56"], ["56"]],
-                Colname.metering_point_id: [None, None, None, None, None, None],
-            }
-        )
-
-        df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
-        return EnergyResults(df)
-
-    return factory
-
-
-@pytest.fixture(scope="module")
-def agg_hourly_consumption_factory(spark: SparkSession) -> Callable[[], EnergyResults]:
-    def factory() -> EnergyResults:
-        pandas_df = pd.DataFrame(
-            {
-                Colname.grid_area: ["1", "1", "1", "2", "2", "3"],
-                Colname.to_grid_area: ["1", "1", "1", "2", "2", "3"],
-                Colname.from_grid_area: ["1", "1", "1", "2", "2", "3"],
-                Colname.balance_responsible_id: ["1", "2", "2", "1", "2", "1"],
-                Colname.energy_supplier_id: ["1", "1", "2", "1", "1", "1"],
-                Colname.time_window: [
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                ],
-                Colname.sum_quantity: [
-                    Decimal(6.0),
-                    Decimal(1.0),
-                    Decimal(4.0),
-                    Decimal(2.0),
-                    Decimal(3.0),
-                    Decimal(1.0),
-                ],
-                Colname.qualities: [["56"], ["56"], ["56"], ["56"], ["56"], ["56"]],
-                Colname.metering_point_id: [None, None, None, None, None, None],
-            }
-        )
-
-        df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
-        return EnergyResults(df)
-
-    return factory
-
-
-@pytest.fixture(scope="module")
-def agg_hourly_production_factory(spark: SparkSession) -> Callable[[], EnergyResults]:
-    def factory() -> EnergyResults:
-        pandas_df = pd.DataFrame(
-            {
-                Colname.grid_area: ["1", "1", "1", "2", "2", "3"],
-                Colname.to_grid_area: [None, None, None, None, None, None],
-                Colname.from_grid_area: [None, None, None, None, None, None],
-                Colname.balance_responsible_id: ["1", "2", "2", "1", "2", "1"],
-                Colname.energy_supplier_id: ["1", "1", "2", "1", "1", "1"],
-                Colname.time_window: [
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
-                    },
-                    {
-                        Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
-                            None
-                        ),
-                        Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
-                    },
-                ],
-                Colname.sum_quantity: [
-                    Decimal(9.0),
-                    Decimal(3.0),
-                    Decimal(6.0),
-                    Decimal(3.0),
-                    Decimal(1.0),
-                    Decimal(2.0),
-                ],
-                Colname.qualities: [["56"], ["56"], ["56"], ["56"], ["56"], ["56"]],
-                Colname.metering_point_id: [None, None, None, None, None, None],
-            }
-        )
-
-        df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
-        return EnergyResults(df)
-
-    return factory
-
-
-def test_grid_loss_calculation(
-    agg_result_factory: Callable[[AggregationMethod], EnergyResults]
-) -> None:
-    net_exchange_per_ga = agg_result_factory(AggregationMethod.NET_EXCHANGE)
-    non_profiled_consumption = agg_result_factory(AggregationMethod.HOURLY_CONSUMPTION)
-    flex_consumption = agg_result_factory(AggregationMethod.FLEX_CONSUMPTION)
-    production = agg_result_factory(AggregationMethod.PRODUCTION)
-
-    result = calculate_grid_loss(
-        net_exchange_per_ga, non_profiled_consumption, flex_consumption, production
-    )
-
-    # Verify the calculation result is correct by checking 50+i + 20+i - (13+i + 14+i) equals 43 for all i in range 0 to 9
-    assert result.df.where(col(Colname.sum_quantity) != 43).count() == 0
+# from package.calculation.energy.energy_results import (
+#     EnergyResults,
+#     energy_results_schema,
+# )
+# from package.calculation.energy.aggregators.grid_loss_aggregators import (
+#     calculate_grid_loss,
+# )
+# from package.codelists import (
+#     QuantityQuality,
+# )
+# from package.constants import Colname
+#
+# date_time_formatting_string = "%Y-%m-%dT%H:%M:%S%z"
+# default_obs_time = datetime.strptime(
+#     "2020-01-01T00:00:00+0000", date_time_formatting_string
+# )
+#
+#
+# class AggregationMethod(Enum):
+#     NET_EXCHANGE = "net_exchange"
+#     HOURLY_CONSUMPTION = "hourly_consumption"
+#     FLEX_CONSUMPTION = "flex_consumption"
+#     PRODUCTION = "production"
+#
+#
+# @pytest.fixture(scope="module")
+# def agg_result_factory(
+#     spark: SparkSession,
+# ) -> Callable[[AggregationMethod], EnergyResults]:
+#     """
+#     Factory to generate a single row of time series data, with default parameters as specified above.
+#     """
+#
+#     def factory(agg_method: AggregationMethod) -> EnergyResults:
+#         if agg_method == AggregationMethod.NET_EXCHANGE:
+#             pandas_df = pd.DataFrame(
+#                 {
+#                     Colname.grid_area: [],
+#                     Colname.to_grid_area: [],
+#                     Colname.from_grid_area: [],
+#                     Colname.balance_responsible_id: [],
+#                     Colname.energy_supplier_id: [],
+#                     Colname.time_window: [],
+#                     Colname.sum_quantity: [],
+#                     Colname.qualities: [],
+#                     Colname.metering_point_id: [],
+#                 }
+#             )
+#             for i in range(10):
+#                 pandas_df = pd.concat(
+#                     [
+#                         pandas_df,
+#                         pd.Series(
+#                             {
+#                                 Colname.grid_area: str(i),
+#                                 Colname.to_grid_area: None,
+#                                 Colname.from_grid_area: None,
+#                                 Colname.balance_responsible_id: "balance_responsible_id",
+#                                 Colname.energy_supplier_id: "energy_supplier_id",
+#                                 Colname.time_window: {
+#                                     Colname.start: pd.to_datetime(
+#                                         default_obs_time + timedelta(hours=i)
+#                                     ).tz_convert(None),
+#                                     Colname.end: pd.to_datetime(
+#                                         default_obs_time + timedelta(hours=i + 1)
+#                                     ).tz_convert(None),
+#                                 },
+#                                 Colname.sum_quantity: Decimal(20 + i),
+#                                 Colname.qualities: [QuantityQuality.ESTIMATED.value],
+#                                 Colname.metering_point_id: None,
+#                             },
+#                         )
+#                         .to_frame()
+#                         .T,
+#                     ],
+#                     ignore_index=True,
+#                 )
+#             df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
+#             return EnergyResults(df)
+#         elif agg_method == AggregationMethod.HOURLY_CONSUMPTION:
+#             pandas_df = pd.DataFrame(
+#                 {
+#                     Colname.grid_area: [],
+#                     Colname.to_grid_area: [],
+#                     Colname.from_grid_area: [],
+#                     Colname.balance_responsible_id: [],
+#                     Colname.energy_supplier_id: [],
+#                     Colname.time_window: [],
+#                     Colname.sum_quantity: [],
+#                     Colname.qualities: [],
+#                     Colname.metering_point_id: [],
+#                 }
+#             )
+#             for i in range(10):
+#                 pandas_df = pd.concat(
+#                     [
+#                         pandas_df,
+#                         pd.Series(
+#                             {
+#                                 Colname.grid_area: str(i),
+#                                 Colname.to_grid_area: None,
+#                                 Colname.from_grid_area: None,
+#                                 Colname.balance_responsible_id: str(i),
+#                                 Colname.energy_supplier_id: str(i),
+#                                 Colname.time_window: {
+#                                     Colname.start: pd.to_datetime(
+#                                         default_obs_time + timedelta(hours=i)
+#                                     ).tz_convert(None),
+#                                     Colname.end: pd.to_datetime(
+#                                         default_obs_time + timedelta(hours=i + 1)
+#                                     ).tz_convert(None),
+#                                 },
+#                                 Colname.sum_quantity: Decimal(13 + i),
+#                                 Colname.qualities: [QuantityQuality.ESTIMATED.value],
+#                                 Colname.metering_point_id: None,
+#                             },
+#                         )
+#                         .to_frame()
+#                         .T,
+#                     ],
+#                     ignore_index=True,
+#                 )
+#             df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
+#             return EnergyResults(df)
+#         elif agg_method == AggregationMethod.FLEX_CONSUMPTION:
+#             pandas_df = pd.DataFrame(
+#                 {
+#                     Colname.grid_area: [],
+#                     Colname.to_grid_area: [],
+#                     Colname.from_grid_area: [],
+#                     Colname.balance_responsible_id: [],
+#                     Colname.energy_supplier_id: [],
+#                     Colname.time_window: [],
+#                     Colname.sum_quantity: [],
+#                     Colname.qualities: [],
+#                     Colname.metering_point_id: [],
+#                 }
+#             )
+#             for i in range(10):
+#                 pandas_df = pd.concat(
+#                     [
+#                         pandas_df,
+#                         pd.Series(
+#                             {
+#                                 Colname.grid_area: str(i),
+#                                 Colname.to_grid_area: None,
+#                                 Colname.from_grid_area: None,
+#                                 Colname.balance_responsible_id: str(i),
+#                                 Colname.energy_supplier_id: str(i),
+#                                 Colname.time_window: {
+#                                     Colname.start: pd.to_datetime(
+#                                         default_obs_time + timedelta(hours=i)
+#                                     ).tz_convert(None),
+#                                     Colname.end: pd.to_datetime(
+#                                         default_obs_time + timedelta(hours=i + 1)
+#                                     ).tz_convert(None),
+#                                 },
+#                                 Colname.sum_quantity: Decimal(14 + i),
+#                                 Colname.qualities: [QuantityQuality.ESTIMATED.value],
+#                                 Colname.metering_point_id: None,
+#                             },
+#                         )
+#                         .to_frame()
+#                         .T,
+#                     ],
+#                     ignore_index=True,
+#                 )
+#             df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
+#             return EnergyResults(df)
+#         elif agg_method == AggregationMethod.PRODUCTION:
+#             pandas_df = pd.DataFrame(
+#                 {
+#                     Colname.grid_area: [],
+#                     Colname.to_grid_area: [],
+#                     Colname.from_grid_area: [],
+#                     Colname.balance_responsible_id: [],
+#                     Colname.energy_supplier_id: [],
+#                     Colname.time_window: [],
+#                     Colname.sum_quantity: [],
+#                     Colname.qualities: [],
+#                     Colname.metering_point_id: [],
+#                 }
+#             )
+#             for i in range(10):
+#                 pandas_df = pd.concat(
+#                     [
+#                         pandas_df,
+#                         pd.Series(
+#                             {
+#                                 Colname.grid_area: str(i),
+#                                 Colname.to_grid_area: None,
+#                                 Colname.from_grid_area: None,
+#                                 Colname.balance_responsible_id: str(i),
+#                                 Colname.energy_supplier_id: str(i),
+#                                 Colname.time_window: {
+#                                     Colname.start: pd.to_datetime(
+#                                         default_obs_time + timedelta(hours=i)
+#                                     ).tz_convert(None),
+#                                     Colname.end: pd.to_datetime(
+#                                         default_obs_time + timedelta(hours=i + 1)
+#                                     ).tz_convert(None),
+#                                 },
+#                                 Colname.sum_quantity: Decimal(50 + i),
+#                                 Colname.qualities: [QuantityQuality.ESTIMATED.value],
+#                                 Colname.metering_point_id: None,
+#                             },
+#                         )
+#                         .to_frame()
+#                         .T,
+#                     ],
+#                     ignore_index=True,
+#                 )
+#             df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
+#             return EnergyResults(df)
+#
+#     return factory
+#
+#
+# @pytest.fixture(scope="module")
+# def agg_net_exchange_factory(spark: SparkSession) -> Callable[[], EnergyResults]:
+#     def factory() -> EnergyResults:
+#         pandas_df = pd.DataFrame(
+#             {
+#                 Colname.grid_area: ["1", "1", "1", "2", "2", "3"],
+#                 Colname.to_grid_area: [None, None, None, None, None, None],
+#                 Colname.from_grid_area: [None, None, None, None, None, None],
+#                 Colname.balance_responsible_id: ["1", "2", "2", "1", "2", "1"],
+#                 Colname.energy_supplier_id: ["1", "1", "2", "1", "1", "1"],
+#                 Colname.time_window: [
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 3, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                 ],
+#                 Colname.sum_quantity: [
+#                     Decimal(1.0),
+#                     Decimal(1.0),
+#                     Decimal(1.0),
+#                     Decimal(1.0),
+#                     Decimal(1.0),
+#                     Decimal(1.0),
+#                 ],
+#                 Colname.qualities: [["56"], ["56"], ["56"], ["56"], ["56"], ["56"]],
+#                 Colname.metering_point_id: [None, None, None, None, None, None],
+#             }
+#         )
+#
+#         df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
+#         return EnergyResults(df)
+#
+#     return factory
+#
+#
+# @pytest.fixture(scope="module")
+# def agg_flex_consumption_factory(spark: SparkSession) -> Callable[[], EnergyResults]:
+#     def factory() -> EnergyResults:
+#         pandas_df = pd.DataFrame(
+#             {
+#                 Colname.grid_area: ["1", "1", "1", "2", "2", "3"],
+#                 Colname.to_grid_area: [None, None, None, None, None, None],
+#                 Colname.from_grid_area: [None, None, None, None, None, None],
+#                 Colname.balance_responsible_id: ["1", "2", "2", "1", "2", "1"],
+#                 Colname.energy_supplier_id: ["1", "1", "2", "1", "1", "1"],
+#                 Colname.time_window: [
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 3, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                 ],
+#                 Colname.sum_quantity: [
+#                     Decimal(2.0),
+#                     Decimal(6.0),
+#                     Decimal(4.0),
+#                     Decimal(8.0),
+#                     Decimal(1.0),
+#                     Decimal(2.0),
+#                 ],
+#                 Colname.qualities: [["56"], ["56"], ["56"], ["56"], ["56"], ["56"]],
+#                 Colname.metering_point_id: [None, None, None, None, None, None],
+#             }
+#         )
+#
+#         df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
+#         return EnergyResults(df)
+#
+#     return factory
+#
+#
+# @pytest.fixture(scope="module")
+# def agg_hourly_consumption_factory(spark: SparkSession) -> Callable[[], EnergyResults]:
+#     def factory() -> EnergyResults:
+#         pandas_df = pd.DataFrame(
+#             {
+#                 Colname.grid_area: ["1", "1", "1", "2", "2", "3"],
+#                 Colname.to_grid_area: ["1", "1", "1", "2", "2", "3"],
+#                 Colname.from_grid_area: ["1", "1", "1", "2", "2", "3"],
+#                 Colname.balance_responsible_id: ["1", "2", "2", "1", "2", "1"],
+#                 Colname.energy_supplier_id: ["1", "1", "2", "1", "1", "1"],
+#                 Colname.time_window: [
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                 ],
+#                 Colname.sum_quantity: [
+#                     Decimal(6.0),
+#                     Decimal(1.0),
+#                     Decimal(4.0),
+#                     Decimal(2.0),
+#                     Decimal(3.0),
+#                     Decimal(1.0),
+#                 ],
+#                 Colname.qualities: [["56"], ["56"], ["56"], ["56"], ["56"], ["56"]],
+#                 Colname.metering_point_id: [None, None, None, None, None, None],
+#             }
+#         )
+#
+#         df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
+#         return EnergyResults(df)
+#
+#     return factory
+#
+#
+# @pytest.fixture(scope="module")
+# def agg_hourly_production_factory(spark: SparkSession) -> Callable[[], EnergyResults]:
+#     def factory() -> EnergyResults:
+#         pandas_df = pd.DataFrame(
+#             {
+#                 Colname.grid_area: ["1", "1", "1", "2", "2", "3"],
+#                 Colname.to_grid_area: [None, None, None, None, None, None],
+#                 Colname.from_grid_area: [None, None, None, None, None, None],
+#                 Colname.balance_responsible_id: ["1", "2", "2", "1", "2", "1"],
+#                 Colname.energy_supplier_id: ["1", "1", "2", "1", "1", "1"],
+#                 Colname.time_window: [
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 2, 0).tz_convert(None),
+#                     },
+#                     {
+#                         Colname.start: pd.to_datetime(2020, 1, 1, 0, 0).tz_convert(
+#                             None
+#                         ),
+#                         Colname.end: pd.to_datetime(2020, 1, 1, 1, 0).tz_convert(None),
+#                     },
+#                 ],
+#                 Colname.sum_quantity: [
+#                     Decimal(9.0),
+#                     Decimal(3.0),
+#                     Decimal(6.0),
+#                     Decimal(3.0),
+#                     Decimal(1.0),
+#                     Decimal(2.0),
+#                 ],
+#                 Colname.qualities: [["56"], ["56"], ["56"], ["56"], ["56"], ["56"]],
+#                 Colname.metering_point_id: [None, None, None, None, None, None],
+#             }
+#         )
+#
+#         df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
+#         return EnergyResults(df)
+#
+#     return factory
+#
+#
+# def test_grid_loss_calculation(
+#     agg_result_factory: Callable[[AggregationMethod], EnergyResults]
+# ) -> None:
+#     net_exchange_per_ga = agg_result_factory(AggregationMethod.NET_EXCHANGE)
+#     non_profiled_consumption = agg_result_factory(AggregationMethod.HOURLY_CONSUMPTION)
+#     flex_consumption = agg_result_factory(AggregationMethod.FLEX_CONSUMPTION)
+#     production = agg_result_factory(AggregationMethod.PRODUCTION)
+#
+#     result = calculate_grid_loss(
+#         net_exchange_per_ga, non_profiled_consumption, flex_consumption, production
+#     )
+#
+#     # Verify the calculation result is correct by checking 50+i + 20+i - (13+i + 14+i) equals 43 for all i in range 0 to 9
+#     assert result.df.where(col(Colname.sum_quantity) != 43).count() == 0

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_negative_grid_loss.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_negative_grid_loss.py
@@ -12,168 +12,82 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
 from decimal import Decimal
-from typing import Callable
 
-import pandas as pd
 import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col
 
 from calculation.energy import grid_loss_responsible_factories
-from package.calculation.energy.energy_results import (
-    EnergyResults,
-    energy_results_schema,
-)
 from package.calculation.energy.aggregators.grid_loss_aggregators import (
     calculate_negative_grid_loss,
 )
+from package.calculation.energy.energy_results import (
+    EnergyResults,
+)
 from package.codelists import (
-    QuantityQuality,
     MeteringPointType,
 )
 from package.constants import Colname
+from tests.calculation.energy import energy_results_factories
 
 
 @pytest.fixture(scope="module")
-def agg_result_factory(spark: SparkSession) -> Callable[[], EnergyResults]:
-    """
-    Factory to generate a single row of time series data, with default parameters as specified above.
-    """
+def actual_negative_grid_loss(spark: SparkSession) -> EnergyResults:
+    rows = [
+        energy_results_factories.create_row(
+            grid_area="001",
+            sum_quantity=Decimal(-12.567),
+        ),
+        energy_results_factories.create_row(
+            grid_area="002",
+            sum_quantity=Decimal(34.32),
+        ),
+        energy_results_factories.create_row(
+            grid_area="003",
+            sum_quantity=Decimal(0.0),
+        ),
+    ]
 
-    def factory() -> EnergyResults:
-        pandas_df = pd.DataFrame(
-            {
-                Colname.grid_area: [],
-                Colname.to_grid_area: [],
-                Colname.from_grid_area: [],
-                Colname.balance_responsible_id: [],
-                Colname.energy_supplier_id: [],
-                Colname.time_window: [],
-                Colname.sum_quantity: [],
-                Colname.qualities: [],
-                Colname.metering_point_id: [],
-            }
-        )
+    df = energy_results_factories.create(spark, rows)
 
-        pandas_df = pd.concat(
-            [
-                pandas_df,
-                pd.Series(
-                    {
-                        Colname.grid_area: str(1),
-                        Colname.to_grid_area: None,
-                        Colname.from_grid_area: None,
-                        Colname.balance_responsible_id: "balance_responsible_id",
-                        Colname.energy_supplier_id: "energy_supplier_id",
-                        Colname.time_window: {
-                            Colname.start: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                            Colname.end: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                        },
-                        Colname.sum_quantity: Decimal(-12.567),
-                        Colname.qualities: [QuantityQuality.ESTIMATED.value],
-                    }
-                )
-                .to_frame()
-                .T,
-                pd.Series(
-                    {
-                        Colname.grid_area: str(2),
-                        Colname.to_grid_area: None,
-                        Colname.from_grid_area: None,
-                        Colname.balance_responsible_id: "balance_responsible_id",
-                        Colname.energy_supplier_id: "energy_supplier_id",
-                        Colname.time_window: {
-                            Colname.start: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                            Colname.end: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                        },
-                        Colname.sum_quantity: Decimal(34.32),
-                        Colname.qualities: [QuantityQuality.ESTIMATED.value],
-                    }
-                )
-                .to_frame()
-                .T,
-                pd.Series(
-                    {
-                        Colname.grid_area: str(3),
-                        Colname.to_grid_area: None,
-                        Colname.from_grid_area: None,
-                        Colname.balance_responsible_id: "balance_responsible_id",
-                        Colname.energy_supplier_id: "energy_supplier_id",
-                        Colname.time_window: {
-                            Colname.start: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                            Colname.end: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                        },
-                        Colname.sum_quantity: Decimal(0.0),
-                        Colname.qualities: [QuantityQuality.ESTIMATED.value],
-                    }
-                )
-                .to_frame()
-                .T,
-            ],
-            ignore_index=True,
-        )
-
-        df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
-        return EnergyResults(df)
-
-    return factory
-
-
-def call_calculate_negative_grid_loss(
-    agg_result_factory: Callable[[], EnergyResults]
-) -> EnergyResults:
-    spark = SparkSession.builder.getOrCreate()
-    df = agg_result_factory()
     grid_loss_responsible_row = grid_loss_responsible_factories.create_row(
         metering_point_type=MeteringPointType.PRODUCTION,
     )
     grid_loss_responsible = grid_loss_responsible_factories.create(
         spark, [grid_loss_responsible_row]
     )
+
     return calculate_negative_grid_loss(df, grid_loss_responsible)
 
 
 def test_negative_grid_loss_has_no_values_below_zero(
-    agg_result_factory: Callable[[], EnergyResults]
+    actual_negative_grid_loss: EnergyResults,
 ) -> None:
-    result = call_calculate_negative_grid_loss(agg_result_factory)
-
-    assert result.df.where(col(Colname.sum_quantity) < 0).count() == 0
+    assert (
+        actual_negative_grid_loss.df.where(col(Colname.sum_quantity) < 0).count() == 0
+    )
 
 
 def test_negative_grid_loss_change_negative_value_to_positive(
-    agg_result_factory: Callable[[], EnergyResults]
+    actual_negative_grid_loss: EnergyResults,
 ) -> None:
-    result = call_calculate_negative_grid_loss(agg_result_factory)
-
-    assert result.df.collect()[0][Colname.sum_quantity] == Decimal("12.56700")
+    assert actual_negative_grid_loss.df.collect()[0][Colname.sum_quantity] == Decimal(
+        "12.56700"
+    )
 
 
 def test_negative_grid_loss_change_positive_value_to_zero(
-    agg_result_factory: Callable[[], EnergyResults]
+    actual_negative_grid_loss: EnergyResults,
 ) -> None:
-    result = call_calculate_negative_grid_loss(agg_result_factory)
-
-    assert result.df.collect()[1][Colname.sum_quantity] == Decimal("0.00000")
+    assert actual_negative_grid_loss.df.collect()[1][Colname.sum_quantity] == Decimal(
+        "0.00000"
+    )
 
 
 def test_negative_grid_loss_values_that_are_zero_stay_zero(
-    agg_result_factory: Callable[[], EnergyResults]
+    actual_negative_grid_loss: EnergyResults,
 ) -> None:
-    result = call_calculate_negative_grid_loss(agg_result_factory)
-
-    assert result.df.collect()[2][Colname.sum_quantity] == Decimal("0.00000")
+    assert actual_negative_grid_loss.df.collect()[2][Colname.sum_quantity] == Decimal(
+        "0.00000"
+    )

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_positive_grid_loss.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_positive_grid_loss.py
@@ -11,168 +11,82 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from datetime import datetime
 from decimal import Decimal
-from typing import Callable
 
-import pandas as pd
 import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col
 
 from calculation.energy import grid_loss_responsible_factories
-from package.calculation.energy.energy_results import (
-    EnergyResults,
-    energy_results_schema,
-)
 from package.calculation.energy.aggregators.grid_loss_aggregators import (
     calculate_positive_grid_loss,
 )
+from package.calculation.energy.energy_results import (
+    EnergyResults,
+)
 from package.codelists import (
-    QuantityQuality,
     MeteringPointType,
 )
 from package.constants import Colname
+from tests.calculation.energy import energy_results_factories
 
 
 @pytest.fixture(scope="module")
-def agg_result_factory(spark: SparkSession) -> Callable[[], EnergyResults]:
-    """
-    Factory to generate a single row of time series data, with default parameters as specified above.
-    """
+def actual_positive_grid_loss(spark: SparkSession) -> EnergyResults:
+    rows = [
+        energy_results_factories.create_row(
+            grid_area="001",
+            sum_quantity=Decimal(-12.567),
+        ),
+        energy_results_factories.create_row(
+            grid_area="002",
+            sum_quantity=Decimal(34.32),
+        ),
+        energy_results_factories.create_row(
+            grid_area="003",
+            sum_quantity=Decimal(0.0),
+        ),
+    ]
 
-    def factory() -> EnergyResults:
-        pandas_df = pd.DataFrame(
-            {
-                Colname.grid_area: [],
-                Colname.to_grid_area: [],
-                Colname.from_grid_area: [],
-                Colname.balance_responsible_id: [],
-                Colname.energy_supplier_id: [],
-                Colname.time_window: [],
-                Colname.sum_quantity: [],
-                Colname.qualities: [],
-                Colname.metering_point_id: [],
-            }
-        )
-        pandas_df = pd.concat(
-            [
-                pandas_df,
-                pd.Series(
-                    {
-                        Colname.grid_area: str(1),
-                        Colname.to_grid_area: None,
-                        Colname.from_grid_area: None,
-                        Colname.balance_responsible_id: "balance_responsible_id",
-                        Colname.energy_supplier_id: "energy_supplier_id",
-                        Colname.time_window: {
-                            Colname.start: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                            Colname.end: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                        },
-                        Colname.sum_quantity: Decimal(-12.567),
-                        Colname.qualities: [QuantityQuality.ESTIMATED.value],
-                    }
-                )
-                .to_frame()
-                .T,
-                pd.Series(
-                    {
-                        Colname.grid_area: str(2),
-                        Colname.to_grid_area: None,
-                        Colname.from_grid_area: None,
-                        Colname.balance_responsible_id: "balance_responsible_id",
-                        Colname.energy_supplier_id: "energy_supplier_id",
-                        Colname.time_window: {
-                            Colname.start: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                            Colname.end: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                        },
-                        Colname.sum_quantity: Decimal(34.32),
-                        Colname.qualities: [QuantityQuality.ESTIMATED.value],
-                    }
-                )
-                .to_frame()
-                .T,
-                pd.Series(
-                    {
-                        Colname.grid_area: str(3),
-                        Colname.to_grid_area: None,
-                        Colname.from_grid_area: None,
-                        Colname.balance_responsible_id: "balance_responsible_id",
-                        Colname.energy_supplier_id: "energy_supplier_id",
-                        Colname.time_window: {
-                            Colname.start: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                            Colname.end: pd.to_datetime(
-                                datetime(2020, 1, 1, 1, 0)
-                            ).tz_localize(None),
-                        },
-                        Colname.sum_quantity: Decimal(0.0),
-                        Colname.qualities: [QuantityQuality.ESTIMATED.value],
-                    }
-                )
-                .to_frame()
-                .T,
-            ],
-            ignore_index=True,
-        )
+    df = energy_results_factories.create(spark, rows)
 
-        df = spark.createDataFrame(pandas_df, schema=energy_results_schema)
-        return EnergyResults(df)
-
-    return factory
-
-
-def call_calculate_grid_loss(
-    agg_result_factory: Callable[[], EnergyResults]
-) -> EnergyResults:
-    spark = SparkSession.builder.getOrCreate()
-    df = agg_result_factory()
     grid_loss_responsible_row = grid_loss_responsible_factories.create_row(
         metering_point_type=MeteringPointType.CONSUMPTION,
     )
     grid_loss_responsible = grid_loss_responsible_factories.create(
         spark, [grid_loss_responsible_row]
     )
+
     return calculate_positive_grid_loss(df, grid_loss_responsible)
 
 
 def test_grid_area_grid_loss_has_no_values_below_zero(
-    agg_result_factory: Callable[[], EnergyResults]
+    actual_positive_grid_loss: EnergyResults,
 ) -> None:
-    result = call_calculate_grid_loss(agg_result_factory)
-
-    assert result.df.where(col(Colname.sum_quantity) < 0).count() == 0
+    assert (
+        actual_positive_grid_loss.df.where(col(Colname.sum_quantity) < 0).count() == 0
+    )
 
 
 def test_grid_area_grid_loss_changes_negative_values_to_zero(
-    agg_result_factory: Callable[[], EnergyResults]
+    actual_positive_grid_loss: EnergyResults,
 ) -> None:
-    result = call_calculate_grid_loss(agg_result_factory)
-
-    assert result.df.collect()[0][Colname.sum_quantity] == Decimal("0.00000")
+    assert actual_positive_grid_loss.df.collect()[0][Colname.sum_quantity] == Decimal(
+        "0.00000"
+    )
 
 
 def test_grid_area_grid_loss_positive_values_will_not_change(
-    agg_result_factory: Callable[[], EnergyResults]
+    actual_positive_grid_loss: EnergyResults,
 ) -> None:
-    result = call_calculate_grid_loss(agg_result_factory)
-
-    assert result.df.collect()[1][Colname.sum_quantity] == Decimal("34.32000")
+    assert actual_positive_grid_loss.df.collect()[1][Colname.sum_quantity] == Decimal(
+        "34.32000"
+    )
 
 
 def test_grid_area_grid_loss_values_that_are_zero_stay_zero(
-    agg_result_factory: Callable[[], EnergyResults]
+    actual_positive_grid_loss: EnergyResults,
 ) -> None:
-    result = call_calculate_grid_loss(agg_result_factory)
-
-    assert result.df.collect()[2][Colname.sum_quantity] == Decimal("0.00000")
+    assert actual_positive_grid_loss.df.collect()[2][Colname.sum_quantity] == Decimal(
+        "0.00000"
+    )

--- a/source/databricks/calculation_engine/tests/calculation/energy/energy_results_factories.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/energy_results_factories.py
@@ -25,7 +25,7 @@ from package.codelists import MeteringPointType, QuantityQuality, SettlementMeth
 from package.constants import Colname
 
 DEFAULT_GRID_AREA = "100"
-DEFAULT_FROM_GRID_AREA = "200"
+DEFAULT_FROM_GRID_AREA = "200"  # TODO BJM: Should this be None?
 DEFAULT_TO_GRID_AREA = "300"
 DEFAULT_OBSERVATION_TIME = datetime.datetime.now()
 DEFAULT_SUM_QUANTITY = Decimal("999.123456")
@@ -40,7 +40,7 @@ def create_row(
     grid_area: str = DEFAULT_GRID_AREA,
     from_grid_area: str | None = DEFAULT_FROM_GRID_AREA,
     to_grid_area: str | None = DEFAULT_TO_GRID_AREA,
-    observation_time: datetime = DEFAULT_OBSERVATION_TIME,
+    observation_time: datetime.datetime = DEFAULT_OBSERVATION_TIME,
     sum_quantity: int | Decimal = DEFAULT_SUM_QUANTITY,
     qualities: None | QuantityQuality | list[QuantityQuality] = None,
     energy_supplier_id: str | None = DEFAULT_ENERGY_SUPPLIER_ID,

--- a/source/databricks/calculation_engine/tests/calculation/energy/energy_results_factories.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/energy_results_factories.py
@@ -51,6 +51,7 @@ def create_row(
     qualities: None | QuantityQuality | list[QuantityQuality] = None,
     energy_supplier_id: str | None = DEFAULT_ENERGY_SUPPLIER_ID,
     balance_responsible_id: str | None = DEFAULT_BALANCE_RESPONSIBLE_ID,
+    metering_point_id: str | None = None,
     metering_point_type: MeteringPointType = DEFAULT_METERING_POINT_TYPE,
     resolution: MeteringPointResolution = DEFAULT_RESOLUTION,
 ) -> Row:
@@ -75,6 +76,7 @@ def create_row(
         },
         Colname.sum_quantity: sum_quantity,
         Colname.qualities: qualities,
+        Colname.metering_point_id: metering_point_id,
         Colname.metering_point_type: metering_point_type.value,
         Colname.resolution: resolution.value,
     }

--- a/source/databricks/calculation_engine/tests/calculation/energy/energy_results_factories.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/energy_results_factories.py
@@ -21,16 +21,22 @@ from package.calculation.energy.energy_results import (
     EnergyResults,
     energy_results_schema,
 )
-from package.codelists import MeteringPointType, QuantityQuality, SettlementMethod
+from package.codelists import (
+    MeteringPointType,
+    QuantityQuality,
+    SettlementMethod,
+    MeteringPointResolution,
+)
 from package.constants import Colname
 
 DEFAULT_GRID_AREA = "100"
-DEFAULT_FROM_GRID_AREA = "200"  # TODO BJM: Should this be None?
-DEFAULT_TO_GRID_AREA = "300"
+DEFAULT_FROM_GRID_AREA = None
+DEFAULT_TO_GRID_AREA = None
 DEFAULT_OBSERVATION_TIME = datetime.datetime.now()
 DEFAULT_SUM_QUANTITY = Decimal("999.123456")
 DEFAULT_QUALITIES = [QuantityQuality.MEASURED]
 DEFAULT_METERING_POINT_TYPE = MeteringPointType.CONSUMPTION
+DEFAULT_RESOLUTION = MeteringPointResolution.QUARTER
 DEFAULT_SETTLEMENT_METHOD = SettlementMethod.NON_PROFILED
 DEFAULT_ENERGY_SUPPLIER_ID = "1234567890123"
 DEFAULT_BALANCE_RESPONSIBLE_ID = "9999999999999"
@@ -45,7 +51,8 @@ def create_row(
     qualities: None | QuantityQuality | list[QuantityQuality] = None,
     energy_supplier_id: str | None = DEFAULT_ENERGY_SUPPLIER_ID,
     balance_responsible_id: str | None = DEFAULT_BALANCE_RESPONSIBLE_ID,
-    metering_point_id: str | None = None,
+    metering_point_type: MeteringPointType = DEFAULT_METERING_POINT_TYPE,
+    resolution: MeteringPointResolution = DEFAULT_RESOLUTION,
 ) -> Row:
     if isinstance(sum_quantity, int):
         sum_quantity = Decimal(sum_quantity)
@@ -68,7 +75,8 @@ def create_row(
         },
         Colname.sum_quantity: sum_quantity,
         Colname.qualities: qualities,
-        Colname.metering_point_type: metering_point_id,
+        Colname.metering_point_type: metering_point_type.value,
+        Colname.resolution: resolution.value,
     }
 
     return Row(**row)

--- a/source/databricks/calculation_engine/tests/calculation/energy/quarterly_metering_point_time_series_factories.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/quarterly_metering_point_time_series_factories.py
@@ -42,7 +42,7 @@ def create_row(
     from_grid_area: str | None = None,
     metering_point_id: str = DEFAULT_METERING_POINT_ID,
     metering_point_type: MeteringPointType = DEFAULT_METERING_POINT_TYPE,
-    observation_time: datetime = DEFAULT_OBSERVATION_TIME,
+    observation_time: datetime.datetime = DEFAULT_OBSERVATION_TIME,
     quantity: int | Decimal = DEFAULT_QUANTITY,
     quality: QuantityQuality = DEFAULT_QUALITY,
     energy_supplier_id: str | None = DEFAULT_ENERGY_SUPPLIER_ID,

--- a/source/databricks/calculation_engine/tests/calculation/energy/test_transform_hour_to_quarter.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/test_transform_hour_to_quarter.py
@@ -11,59 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from decimal import Decimal
 
 import pytest
-from decimal import Decimal
-from datetime import datetime
 from pyspark.sql import SparkSession, Row
-from pyspark.sql.types import (
-    TimestampType,
-)
 
-from package.constants import Colname
-from package.codelists import MeteringPointResolution, QuantityQuality
+from calculation.basis_data_time_series_points_factories import (
+    basis_data_time_series_points_row,
+)
 from package.calculation.energy.hour_to_quarter import (
     transform_hour_to_quarter,
     metering_point_time_series_schema,
 )
-
-
-def basis_data_time_series_points_row(
-    grid_area: str = "805",
-    to_grid_area: str = "805",
-    from_grid_area: str = "806",
-    metering_point_id: str = "the_metering_point_id",
-    metering_point_type: str = "the_metering_point_type",
-    resolution: MeteringPointResolution = MeteringPointResolution.HOUR,
-    observation_time: TimestampType() = datetime(2020, 1, 1, 0, 0),
-    quantity: Decimal = Decimal("4.444444"),
-    quality: QuantityQuality = QuantityQuality.ESTIMATED,
-    energy_supplier_id: str = "the_energy_supplier_id",
-    balance_responsible_id: str = "the_balance_responsible_id",
-    settlement_method: str = "the_settlement_method",
-) -> Row:
-    row = {
-        Colname.grid_area: grid_area,
-        Colname.to_grid_area: to_grid_area,
-        Colname.from_grid_area: from_grid_area,
-        Colname.metering_point_id: metering_point_id,
-        Colname.metering_point_type: metering_point_type,
-        Colname.resolution: resolution.value,
-        Colname.observation_time: observation_time,
-        Colname.quantity: quantity,
-        Colname.quality: quality.value,
-        Colname.energy_supplier_id: energy_supplier_id,
-        Colname.balance_responsible_id: balance_responsible_id,
-        Colname.settlement_method: settlement_method,
-    }
-
-    return Row(**row)
+from package.codelists import MeteringPointResolution
+from package.constants import Colname
 
 
 def test__transform_hour_to_quarter__when_invalid_input_schema__raise_assertion_error(
     spark: SparkSession,
-):
+) -> None:
     # Arrange
     basis_data_time_series_points = spark.createDataFrame(
         data=[Row(**({"Hello": "World"}))]

--- a/source/databricks/calculation_engine/tests/calculation/output/test_energy_storage_model_factory.py
+++ b/source/databricks/calculation_engine/tests/calculation/output/test_energy_storage_model_factory.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from pyspark.sql.types import Row
 import uuid
 from copy import copy
 from datetime import datetime, timedelta
@@ -29,6 +29,7 @@ from package.calculation.energy.energy_results import (
     EnergyResults,
 )
 from package.calculation.output import energy_storage_model_factory as sut
+from package.codelists import MeteringPointType
 from package.constants import Colname, EnergyResultColumnNames
 from package.infrastructure.paths import OUTPUT_DATABASE_NAME, ENERGY_RESULT_TABLE_NAME
 from tests.contract_utils import (
@@ -95,8 +96,8 @@ def _create_result_row(
     quality: e.QuantityQuality = DEFAULT_QUALITY,
     time_window_start: datetime = DEFAULT_TIME_WINDOW_START,
     time_window_end: datetime = DEFAULT_TIME_WINDOW_END,
-    metering_point_id: str | None = None,
-) -> dict:
+    metering_point_type: MeteringPointType = DEFAULT_METERING_POINT_TYPE,
+) -> Row:
     row = {
         Colname.grid_area: grid_area,
         Colname.to_grid_area: to_grid_area,
@@ -110,14 +111,14 @@ def _create_result_row(
         Colname.sum_quantity: Decimal(quantity),
         Colname.qualities: [quality.value],
         Colname.settlement_method: [],
-        Colname.metering_point_id: metering_point_id,
+        Colname.metering_point_type: metering_point_type.value,
     }
 
-    return row
+    return Row(**row)
 
 
-def _create_energy_results(spark: SparkSession, row: List[dict]) -> EnergyResults:
-    df = spark.createDataFrame(data=row, schema=energy_results_schema)
+def _create_energy_results(spark: SparkSession, rows: List[Row]) -> EnergyResults:
+    df = spark.createDataFrame(data=rows, schema=energy_results_schema)
     return EnergyResults(df)
 
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

refac: `get_wholesale_metering_point_times_series` as module.

Add aggregated grid loss time series to basis data.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
