### PR TITLE
refac: Remove redundant pytest fixture

### DIFF
--- a/source/databricks/calculation_engine/tests/calculation/energy/energy_results_factories.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/energy_results_factories.py
@@ -75,6 +75,7 @@ def create_row(
 
 
 def create(spark: SparkSession, data: None | Row | list[Row] = None) -> EnergyResults:
+    """If data is None, a single row with default values is created."""
     if data is None:
         data = [create_row()]
     elif isinstance(data, Row):

--- a/source/databricks/calculation_engine/tests/calculation/energy/test_energy_results.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/test_energy_results.py
@@ -11,70 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 from decimal import Decimal
-from datetime import datetime
-from typing import Callable
-import pytest
-from pyspark.sql import DataFrame, Row, SparkSession
+
+from pyspark.sql import SparkSession
 from pyspark.sql.functions import lit
 from pyspark.sql.types import DecimalType
 
+import tests.calculation.energy.energy_results_factories as factory
 from package.calculation.energy.energy_results import (
     EnergyResults,
     energy_results_schema,
 )
-
 from package.constants import Colname
-
-from tests.calculation.dataframe_defaults import DataframeDefaults
-
-
-@pytest.fixture(scope="module")
-def dataframe_with_energy_result_schema_factory(
-    spark: SparkSession,
-) -> Callable[..., DataFrame]:
-    def factory(
-        grid_area: str = DataframeDefaults.default_grid_area,
-        to_grid_area: str | None = None,
-        from_grid_area: str | None = None,
-        balance_responsible_id: str | None = None,
-        energy_supplier_id: str | None = None,
-        time_window_start: datetime = DataframeDefaults.default_time_window_start,
-        time_window_end: datetime = DataframeDefaults.default_time_window_end,
-        sum_quantity: Decimal = DataframeDefaults.default_sum_quantity,
-        quality: str = DataframeDefaults.default_quality,
-        metering_point_id: str | None = None,
-    ) -> DataFrame:
-        row = {
-            Colname.grid_area: grid_area,
-            Colname.to_grid_area: to_grid_area,
-            Colname.from_grid_area: from_grid_area,
-            Colname.balance_responsible_id: balance_responsible_id,
-            Colname.energy_supplier_id: energy_supplier_id,
-            Colname.time_window: {
-                Colname.start: time_window_start,
-                Colname.end: time_window_end,
-            },
-            Colname.sum_quantity: sum_quantity,
-            Colname.qualities: [quality],
-            Colname.metering_point_id: metering_point_id,
-        }
-
-        return spark.createDataFrame([Row(**row)], schema=energy_results_schema)
-
-    return factory
 
 
 class TestCtor:
     class TestWhenNullableColumnsAreMissingInInputDataframe:
         def test_returns_dataframe_that_includes_missing_column(
-            self,
-            dataframe_with_energy_result_schema_factory,
+            self, spark: SparkSession
         ) -> None:
             # Arrange
-            df = dataframe_with_energy_result_schema_factory()
+            df = factory.create(spark).df
             nullable_columns = [
                 Colname.to_grid_area,
                 Colname.from_grid_area,
@@ -91,12 +48,11 @@ class TestCtor:
             assert set(nullable_columns).issubset(set(actual.df.schema.fieldNames()))
 
     class TestWhenMismatchInNullability:
-        def test_respects_nullability_of_input_dataframe(
-            self,
-            dataframe_with_energy_result_schema_factory,
+        def test_accepts_nullability_of_input_dataframe(
+            self, spark: SparkSession
         ) -> None:
             # Arrange
-            df = dataframe_with_energy_result_schema_factory()
+            df = factory.create(spark).df
             df = df.withColumn(Colname.sum_quantity, lit(None).cast(DecimalType(18, 6)))
 
             # Act
@@ -107,28 +63,21 @@ class TestCtor:
             assert actual.df.schema[Colname.sum_quantity].nullable is True
 
     class TestWhenValidInput:
-        def test_returns_expected_dataframe(
-            self,
-            dataframe_with_energy_result_schema_factory: Callable[..., DataFrame],
-        ) -> None:
-            # Arrange
-            df = dataframe_with_energy_result_schema_factory()
+        def test_returns_expected_dataframe(self, spark: SparkSession) -> None:
+            df = factory.create(spark).df
 
-            # Act
             actual = EnergyResults(df)
 
-            # Assert
             assert actual.df.collect() == df.collect()
 
     class TestWhenInputContainsIrrelevantColumn:
         def test_returns_schema_without_irrelevant_column(
-            self,
-            dataframe_with_energy_result_schema_factory,
+            self, spark: SparkSession
         ) -> None:
             # Arrange
-            df = dataframe_with_energy_result_schema_factory()
+            df = factory.create(spark).df
             irrelevant_column = "irrelevant_column"
-            df.withColumn(irrelevant_column, lit("test"))
+            df = df.withColumn(irrelevant_column, lit("test"))
 
             # Act
             actual = EnergyResults(df)
@@ -137,10 +86,7 @@ class TestCtor:
             assert irrelevant_column not in actual.df.schema.fieldNames()
 
     class TestWhenInputDecimalScaleIsHigherThanSix:
-        def test_respects_input_scale(
-            self,
-            dataframe_with_energy_result_schema_factory,
-        ):
+        def test_respects_input_scale(self, spark: SparkSession) -> None:
             """
             In practice the sum_quantity column in EnergyResult can be represented by 5 decimals, because time
             series has 3 decimals and is divided by four (quarters). The end result should be stored with 6 decimals.
@@ -150,7 +96,7 @@ class TestCtor:
 
             # Arrange
             expected_scale = 8
-            df = dataframe_with_energy_result_schema_factory()
+            df = factory.create(spark).df
             df = df.withColumn(
                 Colname.sum_quantity,
                 lit(Decimal("0.12345678")).cast(DecimalType(18, expected_scale)),


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

One less implementation of code generating EnergyResults data.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
