### PR TITLE
refac: Skip use of `Colname.sum_quantity` in pyspark

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/energy/aggregators/exchange_aggregators.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/aggregators/exchange_aggregators.py
@@ -51,13 +51,13 @@ def aggregate_net_exchange_per_neighbour_ga(
 
     exchange_to = (
         T.aggregate_quantity_and_quality(df, group_by)
-        .withColumnRenamed(Colname.sum_quantity, to_sum)
+        .withColumnRenamed(Colname.quantity, to_sum)
         .withColumnRenamed(Colname.to_grid_area, exchange_in_to_grid_area)
         .withColumnRenamed(Colname.from_grid_area, exchange_in_from_grid_area)
     )
     exchange_from = (
         T.aggregate_quantity_and_quality(df, group_by)
-        .withColumnRenamed(Colname.sum_quantity, from_sum)
+        .withColumnRenamed(Colname.quantity, from_sum)
         .withColumnRenamed(Colname.to_grid_area, exchange_out_to_grid_area)
         .withColumnRenamed(Colname.from_grid_area, exchange_out_from_grid_area)
     )
@@ -113,7 +113,7 @@ def aggregate_net_exchange_per_neighbour_ga(
             ),
         )
         # Calculate netto sum between neighboring grid areas
-        .withColumn(Colname.sum_quantity, F.col(to_sum) - F.col(from_sum))
+        .withColumn(Colname.quantity, F.col(to_sum) - F.col(from_sum))
         # Finally select the result columns
         .select(
             Colname.to_grid_area,
@@ -121,7 +121,7 @@ def aggregate_net_exchange_per_neighbour_ga(
             Colname.observation_time,
             # Include qualities from all to- and from- metering point time series
             F.array_union(Colname.qualities, from_qualities).alias(Colname.qualities),
-            Colname.sum_quantity,
+            Colname.quantity,
             F.col(Colname.to_grid_area).alias(Colname.grid_area),
         )
     )

--- a/source/databricks/calculation_engine/package/calculation/energy/aggregators/grid_loss_aggregators.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/aggregators/grid_loss_aggregators.py
@@ -45,22 +45,20 @@ def calculate_grid_loss(
     agg_non_profiled_consumption_result = t.aggregate_sum_quantity_and_qualities(
         non_profiled_consumption.df,
         [Colname.grid_area, Colname.observation_time],
-    ).withColumnRenamed(Colname.sum_quantity, hourly_result)
+    ).withColumnRenamed(Colname.quantity, hourly_result)
 
     agg_flex_consumption_result = t.aggregate_sum_quantity_and_qualities(
         flex_consumption.df,
         [Colname.grid_area, Colname.observation_time],
-    ).withColumnRenamed(Colname.sum_quantity, flex_result)
+    ).withColumnRenamed(Colname.quantity, flex_result)
 
     agg_production_result = t.aggregate_sum_quantity_and_qualities(
         production.df,
         [Colname.grid_area, Colname.observation_time],
-    ).withColumnRenamed(Colname.sum_quantity, prod_result)
+    ).withColumnRenamed(Colname.quantity, prod_result)
 
     result = (
-        net_exchange_per_ga.df.withColumnRenamed(
-            Colname.sum_quantity, net_exchange_result
-        )
+        net_exchange_per_ga.df.withColumnRenamed(Colname.quantity, net_exchange_result)
         .join(
             agg_production_result, [Colname.grid_area, Colname.observation_time], "left"
         )
@@ -86,7 +84,7 @@ def calculate_grid_loss(
     )
 
     result = result.withColumn(
-        Colname.sum_quantity,
+        Colname.quantity,
         result[net_exchange_result]
         + result[prod_result]
         - (result[hourly_result] + result[flex_result]),
@@ -95,7 +93,7 @@ def calculate_grid_loss(
     result = result.select(
         Colname.grid_area,
         Colname.observation_time,
-        Colname.sum_quantity,  # grid loss
+        Colname.quantity,  # grid loss
         f.lit(MeteringPointType.CONSUMPTION.value).alias(Colname.metering_point_type),
         # Quality of positive and negative grid loss must always be "calculated" as they become time series
         # that'll be sent to the metering points
@@ -139,9 +137,9 @@ def calculate_negative_grid_loss(
     ).select(
         Colname.grid_area,
         Colname.observation_time,
-        f.when(f.col(Colname.sum_quantity) < 0, -f.col(Colname.sum_quantity))
+        f.when(f.col(Colname.quantity) < 0, -f.col(Colname.quantity))
         .otherwise(0)
-        .alias(Colname.sum_quantity),
+        .alias(Colname.quantity),
         f.lit(MeteringPointType.PRODUCTION.value).alias(Colname.metering_point_type),
         Colname.qualities,
         only_grid_area_and_metering_point_id[Colname.grid_loss_metering_point_id],
@@ -172,9 +170,9 @@ def calculate_positive_grid_loss(
     ).select(
         Colname.grid_area,
         Colname.observation_time,
-        f.when(f.col(Colname.sum_quantity) > 0, f.col(Colname.sum_quantity))
+        f.when(f.col(Colname.quantity) > 0, f.col(Colname.quantity))
         .otherwise(0)
-        .alias(Colname.sum_quantity),
+        .alias(Colname.quantity),
         f.lit(MeteringPointType.CONSUMPTION.value).alias(Colname.metering_point_type),
         Colname.qualities,
         only_grid_area_and_metering_point_id[Colname.grid_loss_metering_point_id],
@@ -194,7 +192,7 @@ def calculate_total_consumption(
             production_per_ga.df,
             [Colname.grid_area, Colname.observation_time],
         )
-        .withColumnRenamed(Colname.sum_quantity, production_sum_quantity)
+        .withColumnRenamed(Colname.quantity, production_sum_quantity)
         .withColumnRenamed(Colname.qualities, aggregated_production_qualities)
     )
 
@@ -203,7 +201,7 @@ def calculate_total_consumption(
             net_exchange_per_ga.df,
             [Colname.grid_area, Colname.observation_time],
         )
-        .withColumnRenamed(Colname.sum_quantity, exchange_sum_quantity)
+        .withColumnRenamed(Colname.quantity, exchange_sum_quantity)
         .withColumnRenamed(Colname.qualities, aggregated_net_exchange_qualities)
     )
 
@@ -212,7 +210,7 @@ def calculate_total_consumption(
             result_net_exchange, [Colname.grid_area, Colname.observation_time], "inner"
         )
         .withColumn(
-            Colname.sum_quantity,
+            Colname.quantity,
             f.col(production_sum_quantity) + f.col(exchange_sum_quantity),
         )
         .withColumn(
@@ -227,7 +225,7 @@ def calculate_total_consumption(
         Colname.grid_area,
         Colname.observation_time,
         Colname.qualities,
-        Colname.sum_quantity,
+        Colname.quantity,
         f.lit(MeteringPointType.CONSUMPTION.value).alias(Colname.metering_point_type),
     )
 
@@ -275,7 +273,7 @@ def apply_grid_loss_adjustment(
         Colname.grid_area,
         Colname.energy_supplier_id,
         Colname.observation_time,
-        Colname.sum_quantity,
+        Colname.quantity,
         Colname.qualities,
     )
 
@@ -288,7 +286,7 @@ def apply_grid_loss_adjustment(
         result_df[Colname.balance_responsible_id],
         Colname.energy_supplier_id,
         Colname.observation_time,
-        result_df[Colname.sum_quantity],
+        result_df[Colname.quantity],
         f.when(
             result_df[Colname.qualities].isNull(),
             joined_grid_loss_result_and_responsible[Colname.qualities],
@@ -303,15 +301,15 @@ def apply_grid_loss_adjustment(
             )
         )
         .alias(Colname.qualities),
-        joined_grid_loss_result_and_responsible[Colname.sum_quantity].alias(
+        joined_grid_loss_result_and_responsible[Colname.quantity].alias(
             "grid_loss_sum_quantity"
         ),
     )
-    df = df.na.fill(0, subset=["grid_loss_sum_quantity", Colname.sum_quantity])
+    df = df.na.fill(0, subset=["grid_loss_sum_quantity", Colname.quantity])
 
     result_df = df.withColumn(
         adjusted_sum_quantity,
-        f.col(Colname.sum_quantity) + f.col("grid_loss_sum_quantity"),
+        f.col(Colname.quantity) + f.col("grid_loss_sum_quantity"),
     )
 
     result = result_df.select(
@@ -319,7 +317,7 @@ def apply_grid_loss_adjustment(
         Colname.balance_responsible_id,
         Colname.energy_supplier_id,
         Colname.observation_time,
-        f.col(adjusted_sum_quantity).alias(Colname.sum_quantity),
+        f.col(adjusted_sum_quantity).alias(Colname.quantity),
         Colname.qualities,
     ).orderBy(
         Colname.grid_area,

--- a/source/databricks/calculation_engine/package/calculation/energy/aggregators/transformations/aggregate_sum_and_quality.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/aggregators/transformations/aggregate_sum_and_quality.py
@@ -24,7 +24,7 @@ def aggregate_quantity_and_quality(result: DataFrame, group_by: list[str]) -> Da
     Sums quantity and collects distinct quality from the metering point time-series.
     """
     return result.groupBy(group_by).agg(
-        f.sum(Colname.quantity).alias(Colname.sum_quantity),
+        f.sum(Colname.quantity).alias(Colname.quantity),
         f.collect_set(Colname.quality).alias(Colname.qualities),
     )
 
@@ -39,7 +39,7 @@ def aggregate_sum_quantity_and_qualities(
     Sums sum_quantity and collects distinct qualities from the aggregated time-series.
     """
     return result.groupBy(group_by).agg(
-        f.sum(Colname.sum_quantity).alias(Colname.sum_quantity),
+        f.sum(Colname.quantity).alias(Colname.quantity),
         f.array_distinct(f.flatten(f.collect_set(Colname.qualities))).alias(
             Colname.qualities
         ),

--- a/source/databricks/calculation_engine/package/calculation/energy/data_structures/energy_results.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/data_structures/energy_results.py
@@ -53,7 +53,7 @@ energy_results_schema = t.StructType(
         t.StructField(Colname.balance_responsible_id, t.StringType(), True),
         t.StructField(Colname.energy_supplier_id, t.StringType(), True),
         t.StructField(Colname.observation_time, t.TimestampType(), False),
-        t.StructField(Colname.sum_quantity, t.DecimalType(18, 6), False),
+        t.StructField(Colname.quantity, t.DecimalType(18, 6), False),
         t.StructField(Colname.qualities, t.ArrayType(t.StringType(), False), False),
         t.StructField(Colname.metering_point_id, t.StringType(), True),
     ]

--- a/source/databricks/calculation_engine/package/calculation/output/energy_storage_model_factory.py
+++ b/source/databricks/calculation_engine/package/calculation/output/energy_storage_model_factory.py
@@ -114,7 +114,7 @@ def _map_to_storage_dataframe(results: DataFrame) -> DataFrame:
             EnergyResultColumnNames.balance_responsible_id
         ),
         # TODO JVM: This is a temporary fix for the fact that the sum_quantity column is not nullable
-        f.coalesce(f.col(Colname.sum_quantity), f.lit(0))
+        f.coalesce(f.col(Colname.quantity), f.lit(0))
         .alias(EnergyResultColumnNames.quantity)
         .cast(DecimalType(18, 3)),
         f.col(Colname.qualities).alias(EnergyResultColumnNames.quantity_qualities),

--- a/source/databricks/calculation_engine/package/calculation/preparation/data_structures/prepared_tariffs.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/data_structures/prepared_tariffs.py
@@ -56,7 +56,7 @@ prepared_tariffs_schema = t.StructType(
         t.StructField(Colname.metering_point_type, t.StringType(), False),
         t.StructField(Colname.settlement_method, t.StringType(), True),
         t.StructField(Colname.grid_area, t.StringType(), False),
-        t.StructField(Colname.sum_quantity, t.DecimalType(18, 3), True),
+        t.StructField(Colname.quantity, t.DecimalType(18, 3), True),
         t.StructField(Colname.qualities, t.ArrayType(t.StringType()), False),
     ]
 )

--- a/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/tariffs.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/tariffs.py
@@ -170,7 +170,7 @@ def _group_by_time_series_on_metering_point_id_and_resolution_and_sum_quantity(
             ],
         )
         .select(
-            Colname.sum_quantity,
+            Colname.quantity,
             Colname.qualities,
             Colname.metering_point_id,
             f.col("time_window.start").alias(Colname.observation_time),
@@ -184,7 +184,7 @@ def _group_by_time_series_on_metering_point_id_and_resolution_and_sum_quantity(
     # The sum operator creates by default a column as a double type (28,6).
     # It must be cast to a decimal type (18,3) to conform to the tariff schema.
     grouped_time_series = grouped_time_series.withColumn(
-        Colname.sum_quantity, f.col(Colname.sum_quantity).cast(DecimalType(18, 3))
+        Colname.quantity, f.col(Colname.quantity).cast(DecimalType(18, 3))
     )
 
     grouped_time_series = grouped_time_series.withColumn(
@@ -230,7 +230,7 @@ def _join_with_grouped_time_series(
         df[Colname.metering_point_type],
         df[Colname.settlement_method],
         df[Colname.grid_area],
-        grouped_time_series[Colname.sum_quantity],
+        grouped_time_series[Colname.quantity],
         grouped_time_series[Colname.qualities],
     )
     return df

--- a/source/databricks/calculation_engine/package/calculation/wholesale/get_wholesale_metering_point_time_series.py
+++ b/source/databricks/calculation_engine/package/calculation/wholesale/get_wholesale_metering_point_time_series.py
@@ -58,7 +58,7 @@ def get_wholesale_metering_point_times_series(
                 Colname.resolution
             ),  # This will change when we must support HOURLY for calculations before 1st of May 2023
             f.col(Colname.observation_time),
-            f.col(Colname.sum_quantity).alias(Colname.quantity),
+            f.col(Colname.quantity).alias(Colname.quantity),
             f.lit(QuantityQuality.CALCULATED.value).alias(Colname.quality),
             f.col(Colname.energy_supplier_id),
             f.col(Colname.balance_responsible_id),

--- a/source/databricks/calculation_engine/package/calculation/wholesale/tariff_calculators.py
+++ b/source/databricks/calculation_engine/package/calculation/wholesale/tariff_calculators.py
@@ -81,7 +81,7 @@ def _sum_quantity_and_count_charges(prepared_tariffs: PreparedTariffs) -> DataFr
         Colname.resolution,
         Colname.charge_price,
     ).agg(
-        f.sum(Colname.sum_quantity).alias(Colname.total_quantity),
+        f.sum(Colname.quantity).alias(Colname.total_quantity),
         f.flatten(f.collect_set(Colname.qualities)).alias(Colname.qualities),
     )
 

--- a/source/databricks/calculation_engine/tests/calculation/dataframe_defaults.py
+++ b/source/databricks/calculation_engine/tests/calculation/dataframe_defaults.py
@@ -61,7 +61,6 @@ class DataframeDefaults:
     default_quantity: Decimal = Decimal("1.123")
     default_metering_point_resolution: str = MeteringPointResolution.HOUR.value
     default_settlement_method: str = SettlementMethod.FLEX.value
-    default_sum_quantity: Decimal = Decimal("1.234")
     default_to_grid_area: str = "1"
     default_to_date: datetime = datetime(2020, 1, 2, 0, 0)
     default_unit: str = "chargea"

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_ga_v8.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_ga_v8.py
@@ -172,13 +172,13 @@ def test_exchange_aggregator_returns_correct_aggregations(
 
 
 def check_aggregation_row(
-    df: EnergyResults, grid_area: str, sum_quantity: Decimal, time: datetime
+    df: EnergyResults, grid_area: str, quantity: Decimal, time: datetime
 ) -> None:
     """Helper function that checks column values for the given row"""
     gridfiltered = df.df.where(df.df[Colname.grid_area] == grid_area).select(
         col(Colname.grid_area),
-        col(Colname.sum_quantity),
+        col(Colname.quantity),
         col(Colname.observation_time),
     )
     res = gridfiltered.filter(gridfiltered[Colname.observation_time] == time).collect()
-    assert res[0][Colname.sum_quantity] == sum_quantity
+    assert res[0][Colname.quantity] == quantity

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga_v8.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga_v8.py
@@ -93,10 +93,10 @@ def test_aggregate_net_exchange_per_neighbour_ga_single_hour(single_quarter_test
     assert values[0][Colname.to_grid_area] == "A"
     assert values[1][Colname.from_grid_area] == "C"
     assert values[2][Colname.to_grid_area] == "B"
-    assert values[0][Colname.sum_quantity] == Decimal("10")
-    assert values[1][Colname.sum_quantity] == Decimal("5")
-    assert values[2][Colname.sum_quantity] == Decimal("-10")
-    assert values[3][Colname.sum_quantity] == Decimal("-5")
+    assert values[0][Colname.quantity] == Decimal("10")
+    assert values[1][Colname.quantity] == Decimal("5")
+    assert values[2][Colname.quantity] == Decimal("-10")
+    assert values[3][Colname.quantity] == Decimal("-5")
 
 
 def test_aggregate_net_exchange_per_neighbour_ga_multi_hour(multi_quarter_test_data):
@@ -111,11 +111,11 @@ def test_aggregate_net_exchange_per_neighbour_ga_multi_hour(multi_quarter_test_d
         values[0][Colname.observation_time].strftime(date_time_formatting_string)
         == "2020-01-01T00:00:00"
     )
-    assert values[0][Colname.sum_quantity] == Decimal("10")
+    assert values[0][Colname.quantity] == Decimal("10")
     assert values[19][Colname.to_grid_area] == "A"
     assert values[19][Colname.from_grid_area] == "B"
     assert (
         values[19][Colname.observation_time].strftime(date_time_formatting_string)
         == "2020-01-01T04:45:00"
     )
-    assert values[19][Colname.sum_quantity] == Decimal("10")
+    assert values[19][Colname.quantity] == Decimal("10")

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_apply_grid_loss_adjustment.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_apply_grid_loss_adjustment.py
@@ -104,13 +104,13 @@ class TestWhenValidInput:
         result_row = energy_results_factories.create_row(
             observation_time=DEFAULT_OBSERVATION_TIME,
             energy_supplier_id="energy_supplier_id",
-            sum_quantity=20,
+            quantity=20,
         )
         result = energy_results_factories.create(spark, [result_row])
 
         grid_loss_row = energy_results_factories.create_row(
             observation_time=DEFAULT_OBSERVATION_TIME,
-            sum_quantity=10,
+            quantity=10,
         )
         grid_loss = energy_results_factories.create(spark, [grid_loss_row])
 
@@ -132,8 +132,8 @@ class TestWhenValidInput:
 
         # Assert
         actual_row = actual.df.collect()[0]
-        actual_sum_quantity = actual_row[Colname.sum_quantity]
-        assert actual_sum_quantity == 30
+        actual_quantity = actual_row[Colname.quantity]
+        assert actual_quantity == 30
 
 
 class TestWhenEnergySupplierIdIsNotGridLossResponsible:
@@ -155,7 +155,7 @@ class TestWhenEnergySupplierIdIsNotGridLossResponsible:
                 grid_area="1",
                 energy_supplier_id="not_grid_loss_responsible",
                 observation_time=DEFAULT_OBSERVATION_TIME,
-                sum_quantity=10,
+                quantity=10,
             )
         ]
         result = energy_results_factories.create(spark, result_rows)
@@ -168,7 +168,7 @@ class TestWhenEnergySupplierIdIsNotGridLossResponsible:
                 balance_responsible_id=None,
                 energy_supplier_id=None,
                 observation_time=DEFAULT_OBSERVATION_TIME,
-                sum_quantity=20,
+                quantity=20,
                 qualities=[QuantityQuality.MEASURED],
             )
         ]
@@ -197,8 +197,8 @@ class TestWhenEnergySupplierIdIsNotGridLossResponsible:
 
         # Assert
         assert actual.df.count() == 2
-        assert actual.df.collect()[0][Colname.sum_quantity] == 20
-        assert actual.df.collect()[1][Colname.sum_quantity] == 10
+        assert actual.df.collect()[0][Colname.quantity] == 20
+        assert actual.df.collect()[1][Colname.quantity] == 10
 
 
 class TestWhenGridLossResponsibleIsChangedWithinPeriod:
@@ -225,7 +225,7 @@ class TestWhenGridLossResponsibleIsChangedWithinPeriod:
                 grid_area="1",
                 energy_supplier_id="grid_loss_responsible_2",
                 observation_time=DEFAULT_OBSERVATION_TIME,
-                sum_quantity=10,
+                quantity=10,
             )
         ]
         result = energy_results_factories.create(spark, result_rows)
@@ -238,7 +238,7 @@ class TestWhenGridLossResponsibleIsChangedWithinPeriod:
                 balance_responsible_id=None,
                 energy_supplier_id=None,
                 observation_time=DEFAULT_OBSERVATION_TIME,
-                sum_quantity=20,
+                quantity=20,
                 qualities=[QuantityQuality.MEASURED],
             ),
             energy_results_factories.create_row(
@@ -248,7 +248,7 @@ class TestWhenGridLossResponsibleIsChangedWithinPeriod:
                 balance_responsible_id=None,
                 energy_supplier_id=None,
                 observation_time=from_date_2,
-                sum_quantity=30,
+                quantity=30,
                 qualities=[QuantityQuality.MEASURED],
             ),
         ]
@@ -284,17 +284,17 @@ class TestWhenGridLossResponsibleIsChangedWithinPeriod:
 
         # Assert
         assert actual.df.count() == 3
-        assert actual.df.collect()[0][Colname.sum_quantity] == 20
+        assert actual.df.collect()[0][Colname.quantity] == 20
         assert (
             actual.df.collect()[0][Colname.energy_supplier_id]
             == "grid_loss_responsible_1"
         )
-        assert actual.df.collect()[1][Colname.sum_quantity] == 30
+        assert actual.df.collect()[1][Colname.quantity] == 30
         assert (
             actual.df.collect()[1][Colname.energy_supplier_id]
             == "grid_loss_responsible_2"
         )
-        assert actual.df.collect()[2][Colname.sum_quantity] == 10
+        assert actual.df.collect()[2][Colname.quantity] == 10
         assert (
             actual.df.collect()[2][Colname.energy_supplier_id]
             == "grid_loss_responsible_2"

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_calculate_total_consumption.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_calculate_total_consumption.py
@@ -89,12 +89,12 @@ class TestWhenValidInput:
     ):
         # Arrange
         production = [
-            energy_results.create_row(sum_quantity=1),
-            energy_results.create_row(sum_quantity=2),
+            energy_results.create_row(quantity=1),
+            energy_results.create_row(quantity=2),
         ]
         net_exchange = [
-            energy_results.create_row(sum_quantity=4),
-            energy_results.create_row(sum_quantity=8, grid_area="some-other-grid-area"),
+            energy_results.create_row(quantity=4),
+            energy_results.create_row(quantity=8, grid_area="some-other-grid-area"),
         ]
         production_per_ga = energy_results.create(spark, production)
         net_exchange_per_ga = energy_results.create(spark, net_exchange)
@@ -106,19 +106,19 @@ class TestWhenValidInput:
 
         # Assert
         actual_row = actual.df.collect()[0]
-        assert actual_row[Colname.sum_quantity] == expected_sum_quantity
+        assert actual_row[Colname.quantity] == expected_sum_quantity
 
     def test__does_not_include_quantity_from_non_neighbour_ga_in_return(
         self, spark: SparkSession
     ):
         # Arrange
         production = [
-            energy_results.create_row(sum_quantity=1),
-            energy_results.create_row(sum_quantity=2),
+            energy_results.create_row(quantity=1),
+            energy_results.create_row(quantity=2),
         ]
         net_exchange_other_ga = [
-            energy_results.create_row(sum_quantity=4),
-            energy_results.create_row(sum_quantity=8, grid_area="some-other-grid-area"),
+            energy_results.create_row(quantity=4),
+            energy_results.create_row(quantity=8, grid_area="some-other-grid-area"),
         ]
         production_per_ga = energy_results.create(spark, production)
         net_exchange_per_ga = energy_results.create(spark, net_exchange_other_ga)
@@ -130,4 +130,4 @@ class TestWhenValidInput:
 
         # Assert
         actual_row = actual.df.collect()[0]
-        assert actual_row[Colname.sum_quantity] == expected_sum_quantity
+        assert actual_row[Colname.quantity] == expected_sum_quantity

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_negative_grid_loss.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_negative_grid_loss.py
@@ -36,15 +36,15 @@ def actual_negative_grid_loss(spark: SparkSession) -> EnergyResults:
     rows = [
         energy_results_factories.create_row(
             grid_area="001",
-            sum_quantity=Decimal(-12.567),
+            quantity=Decimal(-12.567),
         ),
         energy_results_factories.create_row(
             grid_area="002",
-            sum_quantity=Decimal(34.32),
+            quantity=Decimal(34.32),
         ),
         energy_results_factories.create_row(
             grid_area="003",
-            sum_quantity=Decimal(0.0),
+            quantity=Decimal(0.0),
         ),
     ]
 
@@ -63,15 +63,13 @@ def actual_negative_grid_loss(spark: SparkSession) -> EnergyResults:
 def test_negative_grid_loss_has_no_values_below_zero(
     actual_negative_grid_loss: EnergyResults,
 ) -> None:
-    assert (
-        actual_negative_grid_loss.df.where(col(Colname.sum_quantity) < 0).count() == 0
-    )
+    assert actual_negative_grid_loss.df.where(col(Colname.quantity) < 0).count() == 0
 
 
 def test_negative_grid_loss_change_negative_value_to_positive(
     actual_negative_grid_loss: EnergyResults,
 ) -> None:
-    assert actual_negative_grid_loss.df.collect()[0][Colname.sum_quantity] == Decimal(
+    assert actual_negative_grid_loss.df.collect()[0][Colname.quantity] == Decimal(
         "12.56700"
     )
 
@@ -79,7 +77,7 @@ def test_negative_grid_loss_change_negative_value_to_positive(
 def test_negative_grid_loss_change_positive_value_to_zero(
     actual_negative_grid_loss: EnergyResults,
 ) -> None:
-    assert actual_negative_grid_loss.df.collect()[1][Colname.sum_quantity] == Decimal(
+    assert actual_negative_grid_loss.df.collect()[1][Colname.quantity] == Decimal(
         "0.00000"
     )
 
@@ -87,6 +85,6 @@ def test_negative_grid_loss_change_positive_value_to_zero(
 def test_negative_grid_loss_values_that_are_zero_stay_zero(
     actual_negative_grid_loss: EnergyResults,
 ) -> None:
-    assert actual_negative_grid_loss.df.collect()[2][Colname.sum_quantity] == Decimal(
+    assert actual_negative_grid_loss.df.collect()[2][Colname.quantity] == Decimal(
         "0.00000"
     )

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_positive_grid_loss.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grid_loss_aggregators/test_positive_grid_loss.py
@@ -36,15 +36,15 @@ def actual_positive_grid_loss(spark: SparkSession) -> EnergyResults:
     rows = [
         energy_results_factories.create_row(
             grid_area="001",
-            sum_quantity=Decimal(-12.567),
+            quantity=Decimal(-12.567),
         ),
         energy_results_factories.create_row(
             grid_area="002",
-            sum_quantity=Decimal(34.32),
+            quantity=Decimal(34.32),
         ),
         energy_results_factories.create_row(
             grid_area="003",
-            sum_quantity=Decimal(0.0),
+            quantity=Decimal(0.0),
         ),
     ]
 
@@ -63,15 +63,13 @@ def actual_positive_grid_loss(spark: SparkSession) -> EnergyResults:
 def test_grid_area_grid_loss_has_no_values_below_zero(
     actual_positive_grid_loss: EnergyResults,
 ) -> None:
-    assert (
-        actual_positive_grid_loss.df.where(col(Colname.sum_quantity) < 0).count() == 0
-    )
+    assert actual_positive_grid_loss.df.where(col(Colname.quantity) < 0).count() == 0
 
 
 def test_grid_area_grid_loss_changes_negative_values_to_zero(
     actual_positive_grid_loss: EnergyResults,
 ) -> None:
-    assert actual_positive_grid_loss.df.collect()[0][Colname.sum_quantity] == Decimal(
+    assert actual_positive_grid_loss.df.collect()[0][Colname.quantity] == Decimal(
         "0.00000"
     )
 
@@ -79,7 +77,7 @@ def test_grid_area_grid_loss_changes_negative_values_to_zero(
 def test_grid_area_grid_loss_positive_values_will_not_change(
     actual_positive_grid_loss: EnergyResults,
 ) -> None:
-    assert actual_positive_grid_loss.df.collect()[1][Colname.sum_quantity] == Decimal(
+    assert actual_positive_grid_loss.df.collect()[1][Colname.quantity] == Decimal(
         "34.32000"
     )
 
@@ -87,6 +85,6 @@ def test_grid_area_grid_loss_positive_values_will_not_change(
 def test_grid_area_grid_loss_values_that_are_zero_stay_zero(
     actual_positive_grid_loss: EnergyResults,
 ) -> None:
-    assert actual_positive_grid_loss.df.collect()[2][Colname.sum_quantity] == Decimal(
+    assert actual_positive_grid_loss.df.collect()[2][Colname.quantity] == Decimal(
         "0.00000"
     )

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grouping_aggregators/test_aggregate_per_ga.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grouping_aggregators/test_aggregate_per_ga.py
@@ -43,7 +43,7 @@ class TestWhenValidInput:
         assert len(actual_rows) == 1
         actual_row = actual_rows[0]
         assert actual_row[Colname.grid_area] == factories.DEFAULT_GRID_AREA
-        assert actual_row[Colname.sum_quantity] == 2 * factories.DEFAULT_SUM_QUANTITY
+        assert actual_row[Colname.quantity] == 2 * factories.DEFAULT_QUANTITY
         assert actual_row[Colname.qualities] == [
             q.value for q in factories.DEFAULT_QUALITIES
         ]

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grouping_aggregators/test_aggregate_per_ga_and_brp.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grouping_aggregators/test_aggregate_per_ga_and_brp.py
@@ -43,7 +43,7 @@ class TestWhenValidInput:
         assert len(actual_rows) == 1
         actual_row = actual_rows[0]
         assert actual_row[Colname.grid_area] == factories.DEFAULT_GRID_AREA
-        assert actual_row[Colname.sum_quantity] == 2 * factories.DEFAULT_SUM_QUANTITY
+        assert actual_row[Colname.quantity] == 2 * factories.DEFAULT_QUANTITY
         assert actual_row[Colname.qualities] == [
             q.value for q in factories.DEFAULT_QUALITIES
         ]

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grouping_aggregators/test_aggregate_per_ga_and_es.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/grouping_aggregators/test_aggregate_per_ga_and_es.py
@@ -43,7 +43,7 @@ class TestWhenValidInput:
         assert len(actual_rows) == 1
         actual_row = actual_rows[0]
         assert actual_row[Colname.grid_area] == factories.DEFAULT_GRID_AREA
-        assert actual_row[Colname.sum_quantity] == 2 * factories.DEFAULT_SUM_QUANTITY
+        assert actual_row[Colname.quantity] == 2 * factories.DEFAULT_QUANTITY
         assert actual_row[Colname.qualities] == [
             q.value for q in factories.DEFAULT_QUALITIES
         ]

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/metering_point_time_series_aggregators/test_aggregate_per_ga_and_brp_and_es.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/metering_point_time_series_aggregators/test_aggregate_per_ga_and_brp_and_es.py
@@ -62,7 +62,7 @@ class TestWhenValidInput:
         assert (
             actual_row[Colname.observation_time] == factories.DEFAULT_OBSERVATION_TIME
         )
-        assert actual_row[Colname.sum_quantity] == 2 * factories.DEFAULT_QUANTITY
+        assert actual_row[Colname.quantity] == 2 * factories.DEFAULT_QUANTITY
         assert actual_row[Colname.qualities] == [factories.DEFAULT_QUALITY.value]
 
     def test_returns_rows_for_each_ga(self, spark: SparkSession):

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/transformations/test_aggregate_quantity_and_quality.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/transformations/test_aggregate_quantity_and_quality.py
@@ -83,7 +83,7 @@ class TestWhenValidInput:
 
         # assert
         actual_row = actual.collect()[0]
-        assert actual_row[Colname.sum_quantity] == Decimal("3.333")
+        assert actual_row[Colname.quantity] == Decimal("3.333")
 
     def test_returns_sum_of_quantity_in_each_group(self, spark: SparkSession):
         # Arrange
@@ -124,8 +124,8 @@ class TestWhenValidInput:
 
         # assert
         actual_rows = actual.collect()
-        assert actual_rows[0][Colname.sum_quantity] == Decimal("3.3")
-        assert actual_rows[1][Colname.sum_quantity] == Decimal("7.0")
+        assert actual_rows[0][Colname.quantity] == Decimal("3.3")
+        assert actual_rows[1][Colname.quantity] == Decimal("7.0")
 
     def test_returns_distinct_qualities_in_group(self, spark: SparkSession):
         # Arrange

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/transformations/test_aggregate_sum_quantity_and_qualities.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/transformations/test_aggregate_sum_quantity_and_qualities.py
@@ -27,14 +27,14 @@ class TestWhenValidInput:
         rows = [
             Row(
                 **{
-                    Colname.sum_quantity: 1,
+                    Colname.quantity: 1,
                     Colname.qualities: ["foo"],
                     "group": "some-group",
                 }
             ),
             Row(
                 **{
-                    Colname.sum_quantity: 2,
+                    Colname.quantity: 2,
                     Colname.qualities: ["foo"],
                     "group": "some-group",
                 }
@@ -54,14 +54,14 @@ class TestWhenValidInput:
         rows = [
             Row(
                 **{
-                    Colname.sum_quantity: 1,
+                    Colname.quantity: 1,
                     Colname.qualities: ["foo"],
                     "group": "some-group",
                 }
             ),
             Row(
                 **{
-                    Colname.sum_quantity: 2,
+                    Colname.quantity: 2,
                     Colname.qualities: ["foo"],
                     "group": "another-group",
                 }
@@ -81,14 +81,14 @@ class TestWhenValidInput:
         rows = [
             Row(
                 **{
-                    Colname.sum_quantity: Decimal("1.111"),
+                    Colname.quantity: Decimal("1.111"),
                     Colname.qualities: ["foo"],
                     "group": "some-group",
                 }
             ),
             Row(
                 **{
-                    Colname.sum_quantity: Decimal("2.222"),
+                    Colname.quantity: Decimal("2.222"),
                     Colname.qualities: ["foo"],
                     "group": "some-group",
                 }
@@ -101,35 +101,35 @@ class TestWhenValidInput:
 
         # assert
         actual_row = actual.collect()[0]
-        assert actual_row[Colname.sum_quantity] == Decimal("3.333")
+        assert actual_row[Colname.quantity] == Decimal("3.333")
 
     def test_returns_sum_of_quantity_in_each_group(self, spark: SparkSession):
         # Arrange
         rows = [
             Row(
                 **{
-                    Colname.sum_quantity: Decimal("1.1"),
+                    Colname.quantity: Decimal("1.1"),
                     Colname.qualities: ["foo"],
                     "group": "some-group",
                 }
             ),
             Row(
                 **{
-                    Colname.sum_quantity: Decimal("2.2"),
+                    Colname.quantity: Decimal("2.2"),
                     Colname.qualities: ["foo"],
                     "group": "some-group",
                 }
             ),
             Row(
                 **{
-                    Colname.sum_quantity: Decimal("3.0"),
+                    Colname.quantity: Decimal("3.0"),
                     Colname.qualities: ["foo"],
                     "group": "another-group",
                 }
             ),
             Row(
                 **{
-                    Colname.sum_quantity: Decimal("4.0"),
+                    Colname.quantity: Decimal("4.0"),
                     Colname.qualities: ["foo"],
                     "group": "another-group",
                 }
@@ -142,8 +142,8 @@ class TestWhenValidInput:
 
         # assert
         actual_rows = actual.collect()
-        assert actual_rows[0][Colname.sum_quantity] == Decimal("3.3")
-        assert actual_rows[1][Colname.sum_quantity] == Decimal("7.0")
+        assert actual_rows[0][Colname.quantity] == Decimal("3.3")
+        assert actual_rows[1][Colname.quantity] == Decimal("7.0")
 
     def test_returns_distinct_qualities_in_group(self, spark: SparkSession):
         # Arrange
@@ -151,31 +151,29 @@ class TestWhenValidInput:
         rows = [
             Row(
                 **{
-                    Colname.sum_quantity: 1,
+                    Colname.quantity: 1,
                     Colname.qualities: ["foo", "bar"],
                     group: "the-group",
                 }
             ),
             Row(
                 **{
-                    Colname.sum_quantity: 2,
+                    Colname.quantity: 2,
                     Colname.qualities: ["baz"],
                     group: "the-group",
                 }
             ),
             Row(
                 **{
-                    Colname.sum_quantity: 3,
+                    Colname.quantity: 3,
                     Colname.qualities: [],
                     group: "the-group",
                 }
             ),
-            Row(
-                **{Colname.sum_quantity: 4, Colname.qualities: None, group: "the-group"}
-            ),
+            Row(**{Colname.quantity: 4, Colname.qualities: None, group: "the-group"}),
             Row(
                 **{
-                    Colname.sum_quantity: 5,
+                    Colname.quantity: 5,
                     Colname.qualities: None,
                     group: "other-group",
                 }

--- a/source/databricks/calculation_engine/tests/calculation/energy/energy_results_factories.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/energy_results_factories.py
@@ -26,7 +26,7 @@ from package.constants import Colname
 
 DEFAULT_GRID_AREA = "100"
 DEFAULT_OBSERVATION_TIME = datetime.datetime.now()
-DEFAULT_SUM_QUANTITY = Decimal("999.123456")
+DEFAULT_QUANTITY = Decimal("999.123456")
 DEFAULT_QUALITIES = [QuantityQuality.MEASURED]
 DEFAULT_METERING_POINT_TYPE = MeteringPointType.CONSUMPTION
 DEFAULT_SETTLEMENT_METHOD = SettlementMethod.NON_PROFILED
@@ -38,15 +38,15 @@ def create_row(
     grid_area: str = DEFAULT_GRID_AREA,
     from_grid_area: str | None = None,
     to_grid_area: str | None = None,
-    observation_time: datetime = DEFAULT_OBSERVATION_TIME,
-    sum_quantity: int | Decimal = DEFAULT_SUM_QUANTITY,
+    observation_time: datetime.datetime = DEFAULT_OBSERVATION_TIME,
+    quantity: int | Decimal = DEFAULT_QUANTITY,
     qualities: None | QuantityQuality | list[QuantityQuality] = None,
     energy_supplier_id: str | None = DEFAULT_ENERGY_SUPPLIER_ID,
     balance_responsible_id: str | None = DEFAULT_BALANCE_RESPONSIBLE_ID,
     metering_point_id: str | None = None,
 ) -> Row:
-    if isinstance(sum_quantity, int):
-        sum_quantity = Decimal(sum_quantity)
+    if isinstance(quantity, int):
+        quantity = Decimal(quantity)
 
     if qualities is None:
         qualities = DEFAULT_QUALITIES
@@ -61,7 +61,7 @@ def create_row(
         Colname.balance_responsible_id: balance_responsible_id,
         Colname.energy_supplier_id: energy_supplier_id,
         Colname.observation_time: observation_time,
-        Colname.sum_quantity: sum_quantity,
+        Colname.quantity: quantity,
         Colname.qualities: qualities,
         Colname.metering_point_type: metering_point_id,
     }

--- a/source/databricks/calculation_engine/tests/calculation/energy/test_energy_results.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/test_energy_results.py
@@ -53,14 +53,14 @@ class TestCtor:
         ) -> None:
             # Arrange
             df = factory.create(spark).df
-            df = df.withColumn(Colname.sum_quantity, lit(None).cast(DecimalType(18, 6)))
+            df = df.withColumn(Colname.quantity, lit(None).cast(DecimalType(18, 6)))
 
             # Act
             actual = EnergyResults(df)
 
             # Assert
-            assert energy_results_schema[Colname.sum_quantity].nullable is False
-            assert actual.df.schema[Colname.sum_quantity].nullable is True
+            assert energy_results_schema[Colname.quantity].nullable is False
+            assert actual.df.schema[Colname.quantity].nullable is True
 
     class TestWhenValidInput:
         def test_returns_expected_dataframe(self, spark: SparkSession) -> None:
@@ -98,7 +98,7 @@ class TestCtor:
             expected_scale = 8
             df = factory.create(spark).df
             df = df.withColumn(
-                Colname.sum_quantity,
+                Colname.quantity,
                 lit(Decimal("0.12345678")).cast(DecimalType(18, expected_scale)),
             )
 
@@ -106,6 +106,4 @@ class TestCtor:
             actual = EnergyResults(df)
 
             # Assert
-            assert (
-                actual.df.schema[Colname.sum_quantity].dataType.scale == expected_scale
-            )
+            assert actual.df.schema[Colname.quantity].dataType.scale == expected_scale

--- a/source/databricks/calculation_engine/tests/calculation/output/test_energy_storage_model_factory.py
+++ b/source/databricks/calculation_engine/tests/calculation/output/test_energy_storage_model_factory.py
@@ -101,7 +101,7 @@ def _create_result_row(
         Colname.balance_responsible_id: balance_responsible_id,
         Colname.energy_supplier_id: energy_supplier_id,
         Colname.observation_time: observation_time,
-        Colname.sum_quantity: Decimal(quantity),
+        Colname.quantity: Decimal(quantity),
         Colname.qualities: [quality.value],
         Colname.settlement_method: [],
         Colname.metering_point_id: metering_point_id,
@@ -321,7 +321,7 @@ def test__create__when_rows_belong_to_different_results__adds_different_calculat
 @pytest.mark.parametrize(
     "column_name, value, other_value",
     [
-        (Colname.sum_quantity, Decimal(DEFAULT_QUANTITY), Decimal(OTHER_QUANTITY)),
+        (Colname.quantity, Decimal(DEFAULT_QUANTITY), Decimal(OTHER_QUANTITY)),
         (
             Colname.quality,
             DEFAULT_QUALITY.value,

--- a/source/databricks/calculation_engine/tests/calculation/preparation/transformations/charge_types/test_tariffs.py
+++ b/source/databricks/calculation_engine/tests/calculation/preparation/transformations/charge_types/test_tariffs.py
@@ -320,8 +320,7 @@ def test__get_prepared_tariffs__when_same_metering_point_and_resolution__sums_qu
 
     # Assert
     assert (
-        actual.df.collect()[0][Colname.sum_quantity]
-        == 2 * factory.DefaultValues.QUANTITY
+        actual.df.collect()[0][Colname.quantity] == 2 * factory.DefaultValues.QUANTITY
     )
 
 
@@ -464,7 +463,7 @@ def test__get_prepared_tariffs__returns_expected_tariff_values(
 
 
 @pytest.mark.parametrize(
-    "charge_resolution, expected_rows, expected_sum_quantity",
+    "charge_resolution, expected_rows, expected_quantity",
     [
         (
             e.ChargeResolution.HOUR,
@@ -482,7 +481,7 @@ def test__get_prepared_tariffs__when_charges_with_specific_charge_resolution_and
     spark: SparkSession,
     charge_resolution: e.ChargeResolution,
     expected_rows: int,
-    expected_sum_quantity: int,
+    expected_quantity,
 ) -> None:
     """
     Only charges where charge time is greater than or equal to the metering point from
@@ -543,11 +542,11 @@ def test__get_prepared_tariffs__when_charges_with_specific_charge_resolution_and
 
     # Assert
     assert actual.df.count() == expected_rows
-    assert actual.df.collect()[0][Colname.sum_quantity] == expected_sum_quantity
+    assert actual.df.collect()[0][Colname.quantity] == expected_quantity
 
 
 @pytest.mark.parametrize(
-    "charge_resolution, expected_rows, expected_sum_quantity",
+    "charge_resolution, expected_rows, expected_quantity",
     [
         (
             e.ChargeResolution.HOUR,
@@ -565,7 +564,7 @@ def test__get_prepared_tariffs__when_specific_charge_resolution_and_time_series_
     spark: SparkSession,
     charge_resolution: e.ChargeResolution,
     expected_rows: int,
-    expected_sum_quantity: int,
+    expected_quantity: int,
 ) -> None:
     """
     Only charges where charge time is greater than or equal to the metering point from
@@ -627,7 +626,7 @@ def test__get_prepared_tariffs__when_specific_charge_resolution_and_time_series_
 
     # Assert
     assert actual.df.count() == expected_rows
-    assert actual.df.collect()[0][Colname.sum_quantity] == expected_sum_quantity
+    assert actual.df.collect()[0][Colname.quantity] == expected_quantity
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
