### PR TITLE
refac: Use python paths in docker in CI

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -29,7 +29,7 @@ export PYSPARK_DRIVER_PYTHON=/opt/conda/bin/python
 set -e
 
 cd source/databricks/calculation_engine/tests/
-coverage run --branch -m pytest -k "$1" --junitxml=pytest-results.xml .
+coverage run --branch -m pytest "$1" --junitxml=pytest-results.xml .
 
 # Create data for threshold evaluation
 coverage json


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

An [unintentional break](https://github.com/pytest-dev/pytest/issues/4048) was introduced in pytest between 3.6 and 3.8. To circumvent this problem the CI now uses paths to python tests instead of the -k expressions.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
