### PR TITLE
Revert "refac: Use python paths in docker in CI"

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -29,7 +29,7 @@ export PYSPARK_DRIVER_PYTHON=/opt/conda/bin/python
 set -e
 
 cd source/databricks/calculation_engine/tests/
-coverage run --branch -m pytest "$1" --junitxml=pytest-results.xml .
+coverage run --branch -m pytest -k "$1" --junitxml=pytest-results.xml .
 
 # Create data for threshold evaluation
 coverage json


### PR DESCRIPTION
Reverts Energinet-DataHub/opengeh-wholesale#2057

#2057 broke the pipeline in an unexpected way and I have no other quick fixes than reverting.