### PR TITLE
fix: return no data if calculation does not exist for requested period

### DIFF
--- a/source/dotnet/wholesale-api/Edi.UnitTests/Calculations/CompletedCalculationRetrieverTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Calculations/CompletedCalculationRetrieverTest.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.Wholesale.Edi.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NodaTime;
 using Xunit;
@@ -35,6 +36,7 @@ public class CompletedCalculationRetrieverTest
     [InlineAutoMoqData]
     public async Task GetLatestCompletedCalculationForRequestAsync_WithLatestCorrectionWhenCalculationIsThirdCorrectionSettlement_ReturnsCalculationsAsync(
         [Frozen] Mock<LatestCalculationsForPeriod> latestCalculationsForPeriod,
+        [Frozen] Mock<ILogger<CompletedCalculationRetriever>> logger,
         [Frozen] Mock<ICalculationsClient> calculationsClient)
     {
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -58,7 +60,7 @@ public class CompletedCalculationRetrieverTest
 
         var request = CreateRequestParameters(startOfPeriodFilter, endOfPeriodFilter);
 
-        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object);
+        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object, logger.Object);
 
         // Act
         var actual = await sut.GetLatestCompletedCalculationsForPeriodAsync(request.GridArea, request.Period, request.RequestedCalculationType);
@@ -71,6 +73,7 @@ public class CompletedCalculationRetrieverTest
     [InlineAutoMoqData]
     public async Task GetLatestCorrectionAsync_WithLatestCorrectionWhenCalculationIsSecondCorrectionSettlement_ReturnsCalculationsAsync(
         [Frozen] Mock<LatestCalculationsForPeriod> latestCalculationsForPeriod,
+        [Frozen] Mock<ILogger<CompletedCalculationRetriever>> logger,
         [Frozen] Mock<ICalculationsClient> calculationsClient)
     {
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -94,7 +97,7 @@ public class CompletedCalculationRetrieverTest
 
         var request = CreateRequestParameters(startOfPeriodFilter, endOfPeriodFilter);
 
-        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object);
+        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object, logger.Object);
 
         // Act
         var actual = await sut.GetLatestCompletedCalculationsForPeriodAsync(request.GridArea, request.Period, request.RequestedCalculationType);
@@ -107,6 +110,7 @@ public class CompletedCalculationRetrieverTest
     [InlineAutoMoqData]
     public async Task GetLatestCorrectionAsync_WithLatestCorrectionWhenCalculationIsFirstCorrectionSettlement_ReturnsCalculationsAsync(
         [Frozen] Mock<LatestCalculationsForPeriod> latestCalculationsForPeriod,
+        [Frozen] Mock<ILogger<CompletedCalculationRetriever>> logger,
         [Frozen] Mock<ICalculationsClient> calculationsClient)
     {
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -130,7 +134,7 @@ public class CompletedCalculationRetrieverTest
 
         var request = CreateRequestParameters(startOfPeriodFilter, endOfPeriodFilter);
 
-        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object);
+        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object, logger.Object);
 
         // Act
         var actual = await sut.GetLatestCompletedCalculationsForPeriodAsync(request.GridArea, request.Period, request.RequestedCalculationType);
@@ -143,6 +147,7 @@ public class CompletedCalculationRetrieverTest
     [InlineAutoMoqData]
     public async Task GetLatestCompletedCalculationForRequestAsync_WhenNoCorrectionsExists_ReturnsNoResultAsync(
         [Frozen] Mock<LatestCalculationsForPeriod> latestCalculationsForPeriod,
+        [Frozen] Mock<ILogger<CompletedCalculationRetriever>> logger,
         [Frozen] Mock<ICalculationsClient> calculationsClient)
     {
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -150,7 +155,7 @@ public class CompletedCalculationRetrieverTest
 
         var request = CreateRequestParameters(startOfPeriodFilter, endOfPeriodFilter);
 
-        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object);
+        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object, logger.Object);
 
         // Act
         var actual = await sut.GetLatestCompletedCalculationsForPeriodAsync(request.GridArea, request.Period, request.RequestedCalculationType);
@@ -163,6 +168,7 @@ public class CompletedCalculationRetrieverTest
     [InlineAutoMoqData]
     public async Task GetLatestCorrectionAsync_WithLatestCorrectionWhenFirstCorrectionSettlementCalculationAndSecondCorrectionSettlementCalculation_ReturnsCalculationsForSecondCorrectionAsync(
         [Frozen] Mock<LatestCalculationsForPeriod> latestCalculationsForPeriod,
+        [Frozen] Mock<ILogger<CompletedCalculationRetriever>> logger,
         [Frozen] Mock<ICalculationsClient> calculationsClient)
     {
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -204,7 +210,7 @@ public class CompletedCalculationRetrieverTest
 
         var request = CreateRequestParameters(startOfPeriodFilter, endOfPeriodFilter);
 
-        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object);
+        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object, logger.Object);
 
         // Act
         var actual = await sut.GetLatestCompletedCalculationsForPeriodAsync(request.GridArea, request.Period, request.RequestedCalculationType);
@@ -219,6 +225,7 @@ public class CompletedCalculationRetrieverTest
     [InlineAutoMoqData]
     public async Task GetLatestCorrectionAsync_WithSecondCorrectionWhenSecondCorrectionSettlementCalculationAndThirdCorrectionSettlementCalculation_ReturnsCalculationsForSecondCorrectionAsync(
         [Frozen] Mock<LatestCalculationsForPeriod> latestCalculationsForPeriod,
+        [Frozen] Mock<ILogger<CompletedCalculationRetriever>> logger,
         [Frozen] Mock<ICalculationsClient> calculationsClient)
     {
         var startOfPeriodFilter = Instant.FromUtc(2022, 1, 1, 0, 0);
@@ -260,7 +267,7 @@ public class CompletedCalculationRetrieverTest
 
         var request = CreateRequestParameters(startOfPeriodFilter, endOfPeriodFilter, RequestedCalculationType.SecondCorrection);
 
-        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object);
+        var sut = new CompletedCalculationRetriever(latestCalculationsForPeriod.Object, calculationsClient.Object, logger.Object);
 
         // Act
         var actual = await sut.GetLatestCompletedCalculationsForPeriodAsync(request.GridArea, request.Period, request.RequestedCalculationType);

--- a/source/dotnet/wholesale-api/Edi.UnitTests/WholesaleServicesRequestHandlerTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/WholesaleServicesRequestHandlerTests.cs
@@ -18,11 +18,13 @@ using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
 using Energinet.DataHub.Edi.Responses;
 using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults;
 using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults.Model;
+using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults.Model.EnergyResults;
 using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults.Model.WholesaleResults;
 using Energinet.DataHub.Wholesale.Common.Interfaces.Models;
 using Energinet.DataHub.Wholesale.Edi.Calculations;
 using Energinet.DataHub.Wholesale.Edi.Client;
 using Energinet.DataHub.Wholesale.Edi.Factories;
+using Energinet.DataHub.Wholesale.Edi.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Extensions;
 using Energinet.DataHub.Wholesale.Edi.Validation;
@@ -65,6 +67,15 @@ public class WholesaleServicesRequestHandlerTests
             {
                 wholesaleServices,
             }.ToAsyncEnumerable());
+
+        completedCalculationRetriever.Setup(c => c.GetLatestCompletedCalculationsForPeriodAsync(
+            It.IsAny<string>(),
+            It.IsAny<Energinet.DataHub.Wholesale.Edi.Models.Period>(),
+            It.IsAny<RequestedCalculationType>()))
+            .ReturnsAsync(new List<CalculationForPeriod>
+            {
+                new(new Period(wholesaleServices.Period.Start, wholesaleServices.Period.End), Guid.NewGuid(), 1),
+            }.AsReadOnly());
 
         var sut = new WholesaleServicesRequestHandler(
             ediClient.Object,

--- a/source/dotnet/wholesale-api/Edi/AggregatedTimeSeriesRequestHandler.cs
+++ b/source/dotnet/wholesale-api/Edi/AggregatedTimeSeriesRequestHandler.cs
@@ -114,7 +114,6 @@ public class AggregatedTimeSeriesRequestHandler : IWholesaleInboxRequestHandler
             error = [_noDataForRequestedGridArea];
         }
 
-        _logger.LogInformation("No data available for AggregatedTimeSeriesRequest message with reference id {reference_id}", referenceId);
         await SendRejectedMessageAsync(error, referenceId, cancellationToken).ConfigureAwait(false);
     }
 

--- a/source/dotnet/wholesale-api/Edi/AggregatedTimeSeriesRequestHandler.cs
+++ b/source/dotnet/wholesale-api/Edi/AggregatedTimeSeriesRequestHandler.cs
@@ -73,35 +73,49 @@ public class AggregatedTimeSeriesRequestHandler : IWholesaleInboxRequestHandler
         }
 
         var aggregatedTimeSeriesRequestMessage = AggregatedTimeSeriesRequestFactory.Parse(aggregatedTimeSeriesRequest);
-        var results = await GetAggregatedTimeSeriesAsync(
-            aggregatedTimeSeriesRequestMessage,
-            cancellationToken).ConfigureAwait(false);
-
-        if (!results.Any())
+        var queryParameters = await CreateAggregatedTimeSeriesQueryParametersWithoutCalculationTypeAsync(aggregatedTimeSeriesRequestMessage).ConfigureAwait(false);
+        if (!queryParameters.LatestCalculationForPeriod.Any())
         {
-            var error = new List<ValidationError> { _noDataAvailable };
-            if (await EnergySupplierOrBalanceResponsibleHaveAggregatedTimeSeriesForAnotherGridAreasAsync(aggregatedTimeSeriesRequest, aggregatedTimeSeriesRequestMessage).ConfigureAwait(false))
-            {
-                error = [_noDataForRequestedGridArea];
-            }
+            await SendNoDateRejectMessageAsync(
+                    referenceId,
+                    cancellationToken,
+                    aggregatedTimeSeriesRequest,
+                    aggregatedTimeSeriesRequestMessage)
+                .ConfigureAwait(false);
+            return;
+        }
 
-            _logger.LogInformation("No data available for AggregatedTimeSeriesRequest message with reference id {reference_id}", referenceId);
-            await SendRejectedMessageAsync(error, referenceId, cancellationToken).ConfigureAwait(false);
+        var calculationResults = await _aggregatedTimeSeriesQueries.GetAsync(
+            queryParameters).ToListAsync(cancellationToken).ConfigureAwait(false);
+        if (!calculationResults.Any())
+        {
+            await SendNoDateRejectMessageAsync(
+                referenceId,
+                cancellationToken,
+                aggregatedTimeSeriesRequest,
+                aggregatedTimeSeriesRequestMessage)
+                .ConfigureAwait(false);
             return;
         }
 
         _logger.LogInformation("Sending AggregatedTimeSeriesRequest accepted message with reference id {reference_id}", referenceId);
-        await SendAcceptedMessageAsync(results, referenceId, cancellationToken).ConfigureAwait(false);
+        await SendAcceptedMessageAsync(calculationResults, referenceId, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<IReadOnlyCollection<AggregatedTimeSeries>> GetAggregatedTimeSeriesAsync(
-        AggregatedTimeSeriesRequest request,
-        CancellationToken cancellationToken)
+    private async Task SendNoDateRejectMessageAsync(
+        string referenceId,
+        CancellationToken cancellationToken,
+        DataHub.Edi.Requests.AggregatedTimeSeriesRequest aggregatedTimeSeriesRequest,
+        AggregatedTimeSeriesRequest aggregatedTimeSeriesRequestMessage)
     {
-        var parameters = await CreateAggregatedTimeSeriesQueryParametersWithoutCalculationTypeAsync(request).ConfigureAwait(false);
+        var error = new List<ValidationError> { _noDataAvailable };
+        if (await EnergySupplierOrBalanceResponsibleHaveAggregatedTimeSeriesForAnotherGridAreasAsync(aggregatedTimeSeriesRequest, aggregatedTimeSeriesRequestMessage).ConfigureAwait(false))
+        {
+            error = [_noDataForRequestedGridArea];
+        }
 
-        return await _aggregatedTimeSeriesQueries.GetAsync(
-            parameters).ToListAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation("No data available for AggregatedTimeSeriesRequest message with reference id {reference_id}", referenceId);
+        await SendRejectedMessageAsync(error, referenceId, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<bool> EnergySupplierOrBalanceResponsibleHaveAggregatedTimeSeriesForAnotherGridAreasAsync(

--- a/source/dotnet/wholesale-api/Edi/Calculations/CompletedCalculationRetriever.cs
+++ b/source/dotnet/wholesale-api/Edi/Calculations/CompletedCalculationRetriever.cs
@@ -41,7 +41,7 @@ public class CompletedCalculationRetriever
         _calculationsClient = calculationsClient;
     }
 
-    public async Task<IReadOnlyCollection<CalculationForPeriod>> GetLatestCompletedCalculationsForPeriodAsync(
+    public virtual async Task<IReadOnlyCollection<CalculationForPeriod>> GetLatestCompletedCalculationsForPeriodAsync(
         string? gridAreaCode, Period period, RequestedCalculationType requestedCalculationType)
     {
         IReadOnlyCollection<CalculationDto> completedCalculationsForPeriod = Array.Empty<CalculationDto>();

--- a/source/dotnet/wholesale-api/Edi/Calculations/CompletedCalculationRetriever.cs
+++ b/source/dotnet/wholesale-api/Edi/Calculations/CompletedCalculationRetriever.cs
@@ -15,8 +15,10 @@
 using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults.Model.EnergyResults;
 using Energinet.DataHub.Wholesale.Calculations.Interfaces;
 using Energinet.DataHub.Wholesale.Calculations.Interfaces.Models;
+using Energinet.DataHub.Wholesale.Edi.Exceptions;
 using Energinet.DataHub.Wholesale.Edi.Mappers;
 using Energinet.DataHub.Wholesale.Edi.Models;
+using Microsoft.Extensions.Logging;
 using Period = Energinet.DataHub.Wholesale.Edi.Models.Period;
 
 namespace Energinet.DataHub.Wholesale.Edi.Calculations;
@@ -32,13 +34,16 @@ public class CompletedCalculationRetriever
 
     private readonly LatestCalculationsForPeriod _latestCalculationsForPeriod;
     private readonly ICalculationsClient _calculationsClient;
+    private readonly ILogger<CompletedCalculationRetriever> _logger;
 
     public CompletedCalculationRetriever(
         LatestCalculationsForPeriod latestCalculationsForPeriod,
-        ICalculationsClient calculationsClient)
+        ICalculationsClient calculationsClient,
+        ILogger<CompletedCalculationRetriever> logger)
     {
         _latestCalculationsForPeriod = latestCalculationsForPeriod;
         _calculationsClient = calculationsClient;
+        _logger = logger;
     }
 
     public virtual async Task<IReadOnlyCollection<CalculationForPeriod>> GetLatestCompletedCalculationsForPeriodAsync(
@@ -70,10 +75,24 @@ public class CompletedCalculationRetriever
                 .ConfigureAwait(true);
         }
 
-        return _latestCalculationsForPeriod.FindLatestCalculationsForPeriod(
-            period.Start,
-            period.End,
-            completedCalculationsForPeriod);
+        try
+        {
+            return _latestCalculationsForPeriod.FindLatestCalculationsForPeriod(
+                period.Start,
+                period.End,
+                completedCalculationsForPeriod);
+        }
+        catch (MissingCalculationException e)
+        {
+            _logger.LogError(
+                e,
+                "Failed to find latest calculations for calculation type {RequestedCalculationType}, grid area code: {GridAreaCode}, within period: {Start}  - {End}",
+                requestedCalculationType,
+                gridAreaCode,
+                period.Start,
+                period.End);
+            throw;
+        }
     }
 
     private async Task<IReadOnlyCollection<CalculationDto>> GetCompletedCalculationsForPeriodAsync(string? gridAreaCode, Period period, RequestedCalculationType requestedCalculationType)

--- a/source/dotnet/wholesale-api/Edi/Calculations/LatestCalculationsForPeriod.cs
+++ b/source/dotnet/wholesale-api/Edi/Calculations/LatestCalculationsForPeriod.cs
@@ -70,9 +70,9 @@ public class LatestCalculationsForPeriod
     /// <summary>
     /// Ensure that all days in the period have a calculation or none have a calculation.
     /// </summary>
-    private static bool DaysInPeriodWithNoCalculations(List<Instant> remainingDaysInPeriod, List<CalculationForPeriod> latestCalculationsForPeriod)
+    private static bool DaysInPeriodWithNoCalculations(List<Instant> daysWithoutCalculation, List<CalculationForPeriod> latestCalculationsForPeriod)
     {
-        return remainingDaysInPeriod.Any() && latestCalculationsForPeriod.Any();
+        return daysWithoutCalculation.Any() && latestCalculationsForPeriod.Any();
     }
 
     private static IReadOnlyCollection<CalculationForPeriod> GetPeriodsWhereCalculationIsLatest(

--- a/source/dotnet/wholesale-api/Edi/Calculations/LatestCalculationsForPeriod.cs
+++ b/source/dotnet/wholesale-api/Edi/Calculations/LatestCalculationsForPeriod.cs
@@ -58,9 +58,21 @@ public class LatestCalculationsForPeriod
                 return latestCalculationsForPeriod.OrderBy(x => x.Period.Start).ToList();
         }
 
-        return latestCalculationsForPeriod.Count == 0
-            ? (IReadOnlyCollection<CalculationForPeriod>)latestCalculationsForPeriod.OrderBy(x => x.Period.Start).ToList()
-            : throw new MissingCalculationException($"No calculation found for dates: {string.Join(", ", remainingDaysInPeriod)}");
+        if (DaysInPeriodWithNoCalculations(remainingDaysInPeriod, latestCalculationsForPeriod))
+        {
+            throw new MissingCalculationException($"No calculation found for dates: {string.Join(", ", remainingDaysInPeriod)}");
+        }
+
+        return latestCalculationsForPeriod.OrderBy(x => x.Period.Start)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Ensure that all days in the period have a calculation or none have a calculation.
+    /// </summary>
+    private static bool DaysInPeriodWithNoCalculations(List<Instant> remainingDaysInPeriod, List<CalculationForPeriod> latestCalculationsForPeriod)
+    {
+        return remainingDaysInPeriod.Any() && latestCalculationsForPeriod.Any();
     }
 
     private static IReadOnlyCollection<CalculationForPeriod> GetPeriodsWhereCalculationIsLatest(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->
If we can't find any calculation for the request periode and calculation type we now return "No Data" instead of throwing missing calculation exception. 

However, if we finds calculation for part of the requested period, we throw exception with missing calculation. 


## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
