### PR TITLE
refac: Use paths to control python test execution in CI

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -16,7 +16,7 @@
 
 # $1: (Optional) Can be set to specify a filter for running python tests by using 'keyword expressions'.
 # See use of '-k' and 'keyword expressions' here: https://docs.pytest.org/en/7.4.x/how-to/usage.html#specifying-which-tests-to-run
-echo "Filter (keyword expression): $1"
+echo "Filter (paths): '$1'"
 
 # Configure Azure CLI to use token cache which must be mapped as volume from host machine
 export AZURE_CONFIG_DIR=/home/joyvan/.azure
@@ -29,7 +29,7 @@ export PYSPARK_DRIVER_PYTHON=/opt/conda/bin/python
 set -e
 
 cd source/databricks/calculation_engine/tests/
-coverage run --branch -m pytest -k "$1" --junitxml=pytest-results.xml .
+coverage run --branch -m pytest --junitxml=pytest-results.xml $1
 
 # Create data for threshold evaluation
 coverage json


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
