### PR TITLE
chore: Split pyspark logic tests for better CI performance

### DIFF
--- a/.github/workflows/ci-databricks.yml
+++ b/.github/workflows/ci-databricks.yml
@@ -123,8 +123,10 @@ jobs:
             paths: calculator_job/test_energy_calculation.py
           - name: Wholesale (calculator_job)
             paths: calculator_job/test_wholesale_calculation.py
-          - name: Logic
-            paths: calculation_logic/
+          - name: Energy logic
+            paths: calculation_logic/features/energy_calculations
+          - name: Wholesale logic
+            paths: calculation_logic/features/wholesale_calculations
           - name: Unit tests
             paths: calculation/ codelists/ common/ infrastructure/
           - name: Entry point tests


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Logic tests consist of both energy calculation and wholesale calculation tests. They use almost 10 minutes in the CI. This PR splits the two in to separate job runs to reduce the total time.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
