### PR TITLE
fix: Re-add Azure CLI to Docker image

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -19,21 +19,21 @@ FROM ghcr.io/energinet-datahub/pyspark-slim:3.5.0
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
+
+# - Install git as it is needed by spark
+# - Install Azure CLI, see https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
+#   as it is needed by integration tests
+#   - Curl is temporarily installed in order to download the Azure CLI (consider multi stage build instead)
+# - Cleanup apt cache to reduce image size
+RUN apt-get update; \
+    apt-get install --no-install-recommends -y git; \
+    apt-get install --no-install-recommends -y curl; \
+    curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash; \
+    apt-get remove -y curl; \
+    rm -rf /var/lib/apt/lists/*
+
 # This replaces the default spark configuration in the docker image with the ones defined in the sibling file
 COPY spark-defaults.conf $SPARK_HOME/conf/spark-defaults.conf
-
-# Install git as it is needed by spark
-RUN apt-get update; \
-    apt-get install -y git
-
-# Install Azure CLI, see https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
-#   Install curl to be able to download Azure CLI install script
-RUN apt-get install -y curl
-#   Download and execute install script
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
-# Cleanup apt cache to reduce image size
-RUN rm -rf /var/lib/apt/lists/*
 
 # Install spark packages with mamba (packages has to be updated according to spark version)
 COPY mamba_requirements.txt mamba_requirements.txt

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -26,6 +26,12 @@ COPY spark-defaults.conf $SPARK_HOME/conf/spark-defaults.conf
 RUN apt-get update; \
     apt-get install -y git
 
+# Install Azure CLI, see https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
+#   Install curl to be able to download Azure CLI install script
+RUN apt-get install -y curl
+#   Download and execute install script
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
 # Cleanup apt cache to reduce image size
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

I was mistaken. Azure CLI should not have been removed as it is used by the `pyspark` integration tests.

This PR re-adds the Azure CLI to the docker image. A few optimizations has been used as well:
- Reduce the number of layers by gathering several RUN commands into a single
- Move COPY of spark defaults to after more reusable layers

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
