### PR TITLE
refac: Update NuGet package dependencies

### DIFF
--- a/source/dotnet/subsystem-tests/SubsystemTests.csproj
+++ b/source/dotnet/subsystem-tests/SubsystemTests.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.4" />
-    <PackageReference Include="Azure.Monitor.Query" Version="1.2.0" />
+    <PackageReference Include="Azure.Monitor.Query" Version="1.3.0" />
     <PackageReference Include="Microsoft.Azure.Databricks.Client" Version="2.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Application/Calculations.Application.csproj
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Application/Calculations.Application.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="9.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="4.0.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.26.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="11.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="5.0.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
     <PackageReference Include="Grpc.Tools" Version="2.62.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Calculations.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Calculations.Infrastructure.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.3" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="8.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.Databricks.Jobs" Version="10.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.Databricks.Jobs" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
     <PackageReference Include="NodaTime" Version="3.1.11" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28">

--- a/source/dotnet/wholesale-api/Common.Infrastructure/Common.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Common.Infrastructure/Common.Infrastructure.csproj
@@ -22,9 +22,9 @@ limitations under the License.
     <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="8.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.17.1" />
-    <PackageReference Include="Energinet.DataHub.Core.Databricks.SqlStatementExecution" Version="10.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.Databricks.Jobs" Version="10.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.App.Common.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.Databricks.SqlStatementExecution" Version="10.0.1" />
+    <PackageReference Include="Energinet.DataHub.Core.Databricks.Jobs" Version="10.0.1" />
+    <PackageReference Include="Energinet.DataHub.Core.App.Common.Abstractions" Version="11.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />

--- a/source/dotnet/wholesale-api/Edi/Edi.csproj
+++ b/source/dotnet/wholesale-api/Edi/Edi.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.4" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="NodaTime.Serialization.Protobuf" Version="2.0.1" />
-    <PackageReference Include="Google.Protobuf" Version="3.26.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
     <PackageReference Include="Grpc.Tools" Version="2.62.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/source/dotnet/wholesale-api/Events/Events.Application/Events.Application.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.Application/Events.Application.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.Logging" Version="3.1.3" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="4.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/Events.Infrastructure.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
     <PackageReference Include="NodaTime.Serialization.Protobuf" Version="2.0.1" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="8.0.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.26.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
     <PackageReference Include="Grpc.Tools" Version="2.62.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/source/dotnet/wholesale-api/Orchestration/Orchestration.csproj
+++ b/source/dotnet/wholesale-api/Orchestration/Orchestration.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="9.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="11.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />

--- a/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
+++ b/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
@@ -19,7 +19,7 @@ limitations under the License.
     <RootNamespace>Energinet.DataHub.Wholesale.Test.Core</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="5.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="5.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="5.0.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/source/dotnet/wholesale-api/WebApi/WebApi.csproj
+++ b/source/dotnet/wholesale-api/WebApi/WebApi.csproj
@@ -25,10 +25,9 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Asp.Versioning.Mvc" Version="8.0.0" />
-    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.App.Common.Security" Version="8.3.2" />
-    <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="9.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="11.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />


### PR DESCRIPTION
# Description

Update NuGet package dependencies to ensure we use the newly released App package that uses .NET 8.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
