### PR TITLE
refac: Make Mosaic co-codeowners of .NET source code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @Energinet-DataHub/Mandalorian
 /.github/actions @Energinet-DataHub/TheOutlaws
 /.github/workflows @Energinet-DataHub/TheOutlaws
-/source/dotnet/wholesale-api/Edi* @Energinet-DataHub/Mandalorian @Energinet-DataHub/Team-Mosaic
+/source/dotnet @Energinet-DataHub/Mandalorian @Energinet-DataHub/Team-Mosaic


### PR DESCRIPTION
# Description

Make Mosaic co-codeowners of .NET source code.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
