### PR TITLE
refac: Added expected files guard in logic test 

### DIFF
--- a/source/databricks/calculation_engine/tests/features/utils/scenario_fixture2.py
+++ b/source/databricks/calculation_engine/tests/features/utils/scenario_fixture2.py
@@ -114,7 +114,7 @@ class ScenarioFixture2:
         )
 
         if len(expected_result_file_paths) == 0:
-            raise Exception(f"Missing expected result files in output folder.")
+            raise Exception("Missing expected result files in output folder.")
 
         for result_file in expected_result_file_paths:
             raw_df = spark.read.csv(result_file[1], header=True, sep=";")

--- a/source/databricks/calculation_engine/tests/features/utils/scenario_fixture2.py
+++ b/source/databricks/calculation_engine/tests/features/utils/scenario_fixture2.py
@@ -109,8 +109,14 @@ class ScenarioFixture2:
 
     def _get_expected_results(self, spark: SparkSession) -> list[ExpectedResult]:
         expected_results = []
-        result_files = self._get_scenario_output_paths()
-        for result_file in result_files:
+        expected_result_file_paths = (
+            self._get_paths_to_expected_result_files_in_output_folder()
+        )
+
+        if len(expected_result_file_paths) == 0:
+            raise Exception(f"Missing expected result files in output folder.")
+
+        for result_file in expected_result_file_paths:
             raw_df = spark.read.csv(result_file[1], header=True, sep=";")
             if "energy_results" in result_file[1]:
                 df = create_energy_result_dataframe(
@@ -126,7 +132,9 @@ class ScenarioFixture2:
 
         return expected_results
 
-    def _get_scenario_output_paths(self) -> list[Tuple[str, str]]:
+    def _get_paths_to_expected_result_files_in_output_folder(
+        self,
+    ) -> list[Tuple[str, str]]:
         """Returns (file base name without extension, file full path)."""
 
         output_folder_path = Path(f"{self.scenario_path}/output")


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

If the number of expected files in a logic test is zero an exception is thrown. This ensures the test doesn't become green when the expected files folder is empty.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002` or `sandbox_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalogue](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
