### PR TITLE
chore: Update to latest docker base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,12 +41,6 @@
 	"containerEnv": {
 		"GRANT_SUDO": "yes"
 	},
-	"forwardPorts": [
-		5567
-	],
-	"appPort": [
-		"5567:5050"
-	],
 	"overrideCommand": false,
 	"containerUser": "root"
 }

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -14,7 +14,7 @@
 
 # The spark version should follow the spark version in databricks.
 # The databricks version of spark is controlled from dh3-infrastructure and uses latest LTS (ATTOW - Spark v3.5.0)
-FROM ghcr.io/energinet-datahub/pyspark-slim:3.5.0
+FROM ghcr.io/energinet-datahub/pyspark-slim:3.5.1-2
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/.docker/mamba_requirements.txt
+++ b/.docker/mamba_requirements.txt
@@ -1,10 +1,8 @@
 # Dependencies must be listed using the format:
 # <package>=<version>
 # But notice wildcards are supported, like described here: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-file-manually
-rope=1.6.*
 pytest=7.2.*
 configargparse=1.5.3
 coverage=7.0.*
-azure-storage-blob=12.14.*
 pytest-mock=3.10.*
 virtualenv=20.*

--- a/.docker/requirements.txt
+++ b/.docker/requirements.txt
@@ -9,7 +9,6 @@ build
 coverage-threshold
 flake8
 mypy
-ptvsd
 pyspelling
 pytest-asyncio
 pytest-xdist
@@ -22,12 +21,10 @@ databricks-cli==0.18
 dataclasses-json==0.6.4
 delta-spark==3.1.0
 dependency_injector==4.41.0
-azure-eventhub==5.11.6
 azure-identity==1.12.0
 azure-keyvault-secrets==4.7.0
 azure-monitor-opentelemetry==1.2.0
 azure-monitor-query==1.2.0
-azure-servicebus==7.11.4
 azure-storage-file-datalake==12.11.0
 opengeh-spark-sql-migrations @ git+https://git@github.com/Energinet-DataHub/opengeh-python-packages@1.5.0#subdirectory=source/spark_sql_migrations
 python-dateutil==2.8.2

--- a/.docker/spark-defaults.conf
+++ b/.docker/spark-defaults.conf
@@ -9,7 +9,7 @@
 # spark.driver.memory               16g
 # spark.executor.extraJavaOptions  -XX:+PrintGCDetails -Dkey=value -Dnumbers="one two three"
 
-spark.jars.packages com.microsoft.azure:azure-eventhubs-spark_2.12:2.3.17,org.apache.hadoop:hadoop-azure:3.3.2,org.apache.hadoop:hadoop-common:3.3.2,io.delta:delta-core_2.12:2.2.0
+spark.jars.packages io.delta:delta-core_2.12:2.2.0
 
 # spark.hadoop.fs.AbstractFileSystem.abfss.impl org.apache.hadoop.fs.azurebfs.Abfss
 # spark.hadoop.fs.abfss.impl org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem

--- a/source/databricks/README.md
+++ b/source/databricks/README.md
@@ -64,39 +64,6 @@
 
 Use the [Python Test Explorer for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=LittleFoxTeam.vscode-python-test-adapter) extension in VSCode. It is automatically installed in the container (see [`.devcontainer/devcontainer.json`](https://github.com/Energinet-DataHub/opengeh-wholesale/blob/main/.devcontainer/devcontainer.json)).
 
-### Alternative Debug Approach
-
-This is a less simple and intuitive way of debugging,
-but may serve as an alternative in case of problems with the recommended way of debugging.
-
-* To debug tests you need to execute the following command
-
-    Using debugz.sh with the following command
-
-    ````text
-    sh debugz.sh
-    ````
-
-    Or using command inside debugz.sh
-
-    ```text
-    python -m ptvsd --host 0.0.0.0 --port 3000 --wait -m pytest -v
-    ```
-
-* Create a ***launch.json*** file in the ***Run and Debug*** panel and add the following
-
-    ```json
-    {
-        "name": "Python: Attach container",
-        "type": "python",
-        "request": "attach",
-        "port": 3000,
-        "host": "localhost"
-    }
-    ```
-
-* Start debugging on the ***Python: Attach container*** in the ***Run and Debug*** panel
-
 ## Styling and Formatting
 
 We try to follow [PEP8](https://peps.python.org/pep-0008/) as much as possible, we do this by using [Flake8](https://flake8.pycqa.org/en/latest/) and [Black](https://black.readthedocs.io/en/stable/)

--- a/source/databricks/calculation_engine/setup.py
+++ b/source/databricks/calculation_engine/setup.py
@@ -34,7 +34,6 @@ setup(
         "pyspark==3.5.1",
         "azure-identity==1.12.0",
         "azure-storage-file-datalake==12.11.0",
-        "databricks-cli==0.18",
         "dependency_injector==4.41.0",
         "urllib3==2.2.*",
         "delta-spark==3.1.0",

--- a/source/databricks/debugz.sh
+++ b/source/databricks/debugz.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-clear
-echo "Starting pytest with remote debugger attachment on port 3000"
-echo "Please attach your debugger now"
-python -m ptvsd --host 0.0.0.0 --port 3000 --wait -m pytest -v "$1"


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Update to Docker base image `ghcr.io/energinet-datahub/pyspark-slim:3.5.1-2`, which is significantly smaller than the previous versions.

In addition, some obsolete stuff has been removed. This is primarily to reduce the image size further.

The resulting wholesale image is 3.74 GB.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] _Some_ tests are ~written and~ executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
