### PR TITLE
fix: vscode devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,6 +41,11 @@
 	"containerEnv": {
 		"GRANT_SUDO": "yes"
 	},
-	"overrideCommand": false,
+	"forwardPorts": [
+		5567
+	],
+	"appPort": [
+		"5567:5050"
+	],
 	"containerUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,37 +4,41 @@
 		"dockerfile": "../.docker/Dockerfile",
 		"args": {}
 	},
-	"extensions": [
-		"mypy",
-		"flake8",
-		"ms-dotnettools.dotnet-interactive-vscode",
-		"ms-python.python",
-		"ms-python.black-formatter",
-		"littlefoxteam.vscode-python-test-adapter",
-		"hbenl.vscode-test-explorer",
-		"eamodio.gitlens",
-		"ms-python.vscode-pylance",
-		"HashiCorp.terraform",
-		"christian-kohler.path-intellisense",
-		"Gruntfuggly.todo-tree",
-		"DavidAnson.vscode-markdownlint",
-		"kevinglasson.cornflakes-linter",
-		"KevinRose.vsc-python-indent",
-		"sonarsource.sonarlint-vscode"
-	],
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash",
-		"editor.formatOnSave": false,
-		"[python]": {
-			"editor.formatOnSave": true
-		},
-		"python.formatting.provider": "black",
-		"python.defaultInterpreterPath": "/opt/conda/bin/python",
-		"python.languageServer": "Pylance",
-		"markdownlint.config": {
-			"MD007": {
-				"indent": 4
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"matangover.mypy",
+				"ms-python.flake8",
+				"ms-dotnettools.dotnet-interactive-vscode",
+				"ms-python.python",
+				"ms-python.black-formatter",
+				"littlefoxteam.vscode-python-test-adapter",
+				"hbenl.vscode-test-explorer",
+				"eamodio.gitlens",
+				"ms-python.vscode-pylance",
+				"HashiCorp.terraform",
+				"christian-kohler.path-intellisense",
+				"Gruntfuggly.todo-tree",
+				"DavidAnson.vscode-markdownlint",
+				"kevinglasson.cornflakes-linter",
+				"KevinRose.vsc-python-indent",
+				"sonarsource.sonarlint-vscode"
+			],
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"terminal.integrated.shell.linux": "/bin/bash",
+				"editor.formatOnSave": false,
+				"[python]": {
+					"editor.formatOnSave": true
+				},
+				"python.formatting.provider": "black",
+				"python.defaultInterpreterPath": "/opt/conda/bin/python",
+				"python.languageServer": "Pylance",
+				"markdownlint.config": {
+					"MD007": {
+						"indent": 4
+					}
+				}
 			}
 		}
 	},


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Enable vscode dev container functionality with newest pyspark-slim image version

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
