### PR TITLE
chore: Docker image optimizations

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -14,7 +14,7 @@
 
 # The spark version should follow the spark version in databricks.
 # The databricks version of spark is controlled from dh3-infrastructure and uses latest LTS (ATTOW - Spark v3.5.0)
-FROM ghcr.io/energinet-datahub/pyspark-slim:3.5.1-2
+FROM ghcr.io/energinet-datahub/pyspark-slim:3.5.1-3
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -44,9 +44,6 @@ RUN mamba install --quiet --yes --satisfied-skip-solve --file mamba_requirements
 # example (delta 2.2.x = spark 3.3.x)
 COPY requirements.txt requirements.txt
 RUN pip --no-cache-dir install -r requirements.txt
-
-# Below will make everything in the directory owned by the group ${NB_GID}
-RUN fix-permissions "${CONDA_DIR}"
 
 # Set misc environment variables required for properly run spark
 # note the amount of memory used on the driver is adjusted here


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

1. Update to base image `ghcr.io/energinet-datahub/pyspark-slim:3.5.1-3`, which fixes broken devcontainer
2. Reduce image size by approximately 1GB by removing the layer `RUN fix-permissions "${CONDA_DIR}"`

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are ~written and~ executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
