### PR TITLE
fix: Total monthly amount issue when multiple energy suppliers

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/wholesale/total_monthly_amount_calculator.py
+++ b/source/databricks/calculation_engine/package/calculation/wholesale/total_monthly_amount_calculator.py
@@ -41,17 +41,15 @@ def calculate_per_ga_co_es(
 
     amount_without_tax = "amount_without_tax"
     amount_with_tax = "amount_with_tax"
+    tax_charge_owner = "tax_charge_owner"
+
+    total_amount_with_tax = total_amount_with_tax.withColumnRenamed(
+        Colname.charge_owner, tax_charge_owner
+    )
 
     total_monthly_amount = total_amount_without_tax.join(
         total_amount_with_tax,
-        (
-            total_amount_without_tax[Colname.grid_area]
-            == total_amount_with_tax[Colname.grid_area]
-        )
-        & (
-            total_amount_without_tax[Colname.charge_owner]
-            != total_amount_with_tax[Colname.charge_owner]
-        ),
+        [Colname.grid_area, Colname.energy_supplier_id],
         "left",
     ).select(
         total_amount_without_tax[Colname.grid_area],
@@ -60,21 +58,24 @@ def calculate_per_ga_co_es(
         total_amount_without_tax[Colname.charge_time],
         total_amount_without_tax[Colname.total_amount].alias(amount_without_tax),
         total_amount_with_tax[Colname.total_amount].alias(amount_with_tax),
+        total_amount_with_tax[tax_charge_owner],
     )
 
-    # Add tax amount to non-tax amount (if it is not null)
     total_monthly_amount = total_monthly_amount.withColumn(
         Colname.total_amount,
         f.when(
-            (f.col(amount_without_tax).isNotNull())
-            & (f.col(amount_with_tax).isNotNull()),
-            f.col(amount_with_tax) + f.col(amount_without_tax),
-        )
-        .when(
-            (f.col(amount_with_tax).isNotNull()) & (f.col(amount_without_tax).isNull()),
-            f.col(amount_with_tax),
-        )
-        .otherwise(f.col(amount_without_tax)),
+            f.col(Colname.charge_owner) == f.col(tax_charge_owner),
+            f.col(amount_without_tax),
+        ).otherwise(
+            f.when(
+                (f.col(amount_with_tax).isNull())
+                & (f.col(amount_without_tax).isNull()),
+                None,
+            ).otherwise(
+                f.coalesce(f.col(amount_with_tax), f.lit(0))
+                + f.coalesce(f.col(amount_without_tax), f.lit(0))
+            )
+        ),
     )
 
     return TotalMonthlyAmount(total_monthly_amount)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

The left join operation in the total monthly amount calculator gave to many rows. This is fixed in this PR

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
