### PR TITLE
refac: no more quarterly_metering_point_time_series

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/energy/aggregators/exchange_aggregators.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/aggregators/exchange_aggregators.py
@@ -16,8 +16,8 @@ import pyspark.sql.functions as F
 
 import package.calculation.energy.aggregators.transformations as T
 from package.calculation.energy.data_structures.energy_results import EnergyResults
-from package.calculation.preparation.data_structures.quarterly_metering_point_time_series import (
-    QuarterlyMeteringPointTimeSeries,
+from package.calculation.preparation.data_structures.metering_point_time_series import (
+    MeteringPointTimeSeries,
 )
 from package.calculation.preparation.transformations.rounding import (
     round_quantity,
@@ -34,7 +34,7 @@ exchange_out_from_grid_area = "ExOut_FromGridArea"
 
 
 def aggregate_net_exchange_per_neighbour_ga(
-    quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
+    metering_point_time_series: MeteringPointTimeSeries,
     calculation_grid_areas: list[str],
 ) -> EnergyResults:
     """
@@ -42,7 +42,7 @@ def aggregate_net_exchange_per_neighbour_ga(
     The result will only include exchange to/from grid areas specified in `calculation_grid_areas`.
     """
 
-    df = quarterly_metering_point_time_series.df.where(
+    df = metering_point_time_series.df.where(
         F.col(Colname.metering_point_type) == MeteringPointType.EXCHANGE.value
     )
 

--- a/source/databricks/calculation_engine/package/calculation/energy/aggregators/metering_point_time_series_aggregators.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/aggregators/metering_point_time_series_aggregators.py
@@ -18,8 +18,8 @@ from package.calculation.energy.data_structures.energy_results import EnergyResu
 from package.calculation.energy.aggregators.transformations.aggregate_sum_and_quality import (
     aggregate_quantity_and_quality,
 )
-from package.calculation.preparation.data_structures.quarterly_metering_point_time_series import (
-    QuarterlyMeteringPointTimeSeries,
+from package.calculation.preparation.data_structures.metering_point_time_series import (
+    MeteringPointTimeSeries,
 )
 from package.calculation.preparation.transformations.rounding import (
     round_quantity,
@@ -32,7 +32,7 @@ from package.constants import Colname
 
 
 def aggregate_per_ga_and_brp_and_es(
-    quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
+    metering_point_time_series: MeteringPointTimeSeries,
     metering_point_type: MeteringPointType,
     settlement_method: SettlementMethod | None,
 ) -> EnergyResults:
@@ -49,7 +49,7 @@ def aggregate_per_ga_and_brp_and_es(
     Each row in the output dataframe corresponds to a unique combination of: ga, brp, es, and quarter_time
     """
 
-    result = quarterly_metering_point_time_series.df.where(
+    result = metering_point_time_series.df.where(
         f.col(Colname.metering_point_type) == metering_point_type.value
     )
 
@@ -70,28 +70,28 @@ def aggregate_per_ga_and_brp_and_es(
 
 
 def aggregate_non_profiled_consumption_ga_brp_es(
-    quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
+    metering_point_time_series: MeteringPointTimeSeries,
 ) -> EnergyResults:
     return aggregate_per_ga_and_brp_and_es(
-        quarterly_metering_point_time_series,
+        metering_point_time_series,
         MeteringPointType.CONSUMPTION,
         SettlementMethod.NON_PROFILED,
     )
 
 
 def aggregate_flex_consumption_ga_brp_es(
-    quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
+    metering_point_time_series: MeteringPointTimeSeries,
 ) -> EnergyResults:
     return aggregate_per_ga_and_brp_and_es(
-        quarterly_metering_point_time_series,
+        metering_point_time_series,
         MeteringPointType.CONSUMPTION,
         SettlementMethod.FLEX,
     )
 
 
 def aggregate_production_ga_brp_es(
-    quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
+    metering_point_time_series: MeteringPointTimeSeries,
 ) -> EnergyResults:
     return aggregate_per_ga_and_brp_and_es(
-        quarterly_metering_point_time_series, MeteringPointType.PRODUCTION, None
+        metering_point_time_series, MeteringPointType.PRODUCTION, None
     )

--- a/source/databricks/calculation_engine/package/calculation/energy/energy_calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/energy_calculation.py
@@ -28,8 +28,8 @@ from package.calculation.preparation.data_structures.grid_loss_responsible impor
 from package.calculation.preparation.data_structures.prepared_metering_point_time_series import (
     PreparedMeteringPointTimeSeries,
 )
-from package.calculation.preparation.data_structures.quarterly_metering_point_time_series import (
-    QuarterlyMeteringPointTimeSeries,
+from package.calculation.preparation.data_structures.metering_point_time_series import (
+    MeteringPointTimeSeries,
 )
 from package.codelists import (
     CalculationType,
@@ -43,25 +43,25 @@ from package.infrastructure import logging_configuration
 @logging_configuration.use_span("calculation.execute.energy")
 def execute(
     args: CalculatorArgs,
-    metering_point_time_series: PreparedMeteringPointTimeSeries,
+    prepared_metering_point_time_series: PreparedMeteringPointTimeSeries,
     grid_loss_responsible_df: GridLossResponsible,
 ) -> Tuple[EnergyResultsContainer, EnergyResults, EnergyResults]:
-    with logging_configuration.start_span("quarterly_metering_point_time_series"):
-        quarterly_metering_point_time_series = transform_hour_to_quarter(
-            metering_point_time_series
+    with logging_configuration.start_span("metering_point_time_series"):
+        metering_point_time_series = transform_hour_to_quarter(
+            prepared_metering_point_time_series
         )
-        quarterly_metering_point_time_series.cache_internal()
+        metering_point_time_series.cache_internal()
 
     return _calculate(
         args,
-        quarterly_metering_point_time_series,
+        metering_point_time_series,
         grid_loss_responsible_df,
     )
 
 
 def _calculate(
     args: CalculatorArgs,
-    quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
+    metering_point_time_series: MeteringPointTimeSeries,
     grid_loss_responsible_df: GridLossResponsible,
 ) -> Tuple[EnergyResultsContainer, EnergyResults, EnergyResults]:
     results = EnergyResultsContainer()
@@ -69,25 +69,25 @@ def _calculate(
     # cache of net exchange per grid area did not improve performance (01/12/2023)
     net_exchange_per_ga = _calculate_net_exchange(
         args,
-        quarterly_metering_point_time_series,
+        metering_point_time_series,
         results,
     )
 
     temporary_production_per_ga_and_brp_and_es = (
         _calculate_temporary_production_per_per_ga_and_brp_and_es(
-            args, quarterly_metering_point_time_series, results
+            args, metering_point_time_series, results
         )
     )
 
     temporary_flex_consumption_per_ga_and_brp_and_es = (
         _calculate_temporary_flex_consumption_per_per_ga_and_brp_and_es(
-            args, quarterly_metering_point_time_series, results
+            args, metering_point_time_series, results
         )
     )
 
     non_profiled_consumption_per_ga_and_brp_and_es = (
         _calculate_non_profiled_consumption_per_ga_and_brp_and_es(
-            quarterly_metering_point_time_series
+            metering_point_time_series
         )
     )
     non_profiled_consumption_per_ga_and_brp_and_es.cache_internal()
@@ -142,16 +142,16 @@ def _calculate(
 @logging_configuration.use_span("calculate_net_exchange")
 def _calculate_net_exchange(
     args: CalculatorArgs,
-    quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
+    metering_point_time_series: MeteringPointTimeSeries,
     results: EnergyResultsContainer,
 ) -> EnergyResults:
     exchange_per_neighbour_ga = exchange_aggr.aggregate_net_exchange_per_neighbour_ga(
-        quarterly_metering_point_time_series, args.calculation_grid_areas
+        metering_point_time_series, args.calculation_grid_areas
     )
     if _is_aggregation_or_balance_fixing(args.calculation_type):
         exchange_per_neighbour_ga = (
             exchange_aggr.aggregate_net_exchange_per_neighbour_ga(
-                quarterly_metering_point_time_series, args.calculation_grid_areas
+                metering_point_time_series, args.calculation_grid_areas
             )
         )
 
@@ -180,13 +180,11 @@ def _calculate_net_exchange(
     "calculate_non_profiled_consumption_per_ga_and_brp_and_es"
 )
 def _calculate_non_profiled_consumption_per_ga_and_brp_and_es(
-    quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
+    metering_point_time_series: MeteringPointTimeSeries,
 ) -> EnergyResults:
     # Non-profiled consumption per balance responsible party and energy supplier
     non_profiled_consumption_per_ga_and_brp_and_es = (
-        mp_aggr.aggregate_non_profiled_consumption_ga_brp_es(
-            quarterly_metering_point_time_series
-        )
+        mp_aggr.aggregate_non_profiled_consumption_ga_brp_es(metering_point_time_series)
     )
 
     return non_profiled_consumption_per_ga_and_brp_and_es
@@ -197,11 +195,11 @@ def _calculate_non_profiled_consumption_per_ga_and_brp_and_es(
 )
 def _calculate_temporary_production_per_per_ga_and_brp_and_es(
     args: CalculatorArgs,
-    quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
+    metering_point_time_series: MeteringPointTimeSeries,
     results: EnergyResultsContainer,
 ) -> EnergyResults:
     temporary_production_per_ga_and_brp_and_es = mp_aggr.aggregate_production_ga_brp_es(
-        quarterly_metering_point_time_series
+        metering_point_time_series
     )
     temporary_production_per_ga_and_brp_and_es.cache_internal()
     # temp production per grid area - used as control result for grid loss
@@ -224,13 +222,11 @@ def _calculate_temporary_production_per_per_ga_and_brp_and_es(
 )
 def _calculate_temporary_flex_consumption_per_per_ga_and_brp_and_es(
     args: CalculatorArgs,
-    quarterly_metering_point_time_series: QuarterlyMeteringPointTimeSeries,
+    metering_point_time_series: MeteringPointTimeSeries,
     results: EnergyResultsContainer,
 ) -> EnergyResults:
     temporary_flex_consumption_per_ga_and_brp_and_es = (
-        mp_aggr.aggregate_flex_consumption_ga_brp_es(
-            quarterly_metering_point_time_series
-        )
+        mp_aggr.aggregate_flex_consumption_ga_brp_es(metering_point_time_series)
     )
     temporary_flex_consumption_per_ga_and_brp_and_es.cache_internal()
     # temp flex consumption per grid area - used as control result for grid loss

--- a/source/databricks/calculation_engine/package/calculation/energy/hour_to_quarter.py
+++ b/source/databricks/calculation_engine/package/calculation/energy/hour_to_quarter.py
@@ -17,8 +17,8 @@ import pyspark.sql.functions as f
 from package.calculation.preparation.data_structures.prepared_metering_point_time_series import (
     PreparedMeteringPointTimeSeries,
 )
-from package.calculation.preparation.data_structures.quarterly_metering_point_time_series import (
-    QuarterlyMeteringPointTimeSeries,
+from package.calculation.preparation.data_structures.metering_point_time_series import (
+    MeteringPointTimeSeries,
 )
 from package.codelists import MeteringPointResolution
 from package.constants import Colname
@@ -26,7 +26,7 @@ from package.constants import Colname
 
 def transform_hour_to_quarter(
     metering_point_time_series: PreparedMeteringPointTimeSeries,
-) -> QuarterlyMeteringPointTimeSeries:
+) -> MeteringPointTimeSeries:
     result = metering_point_time_series.df.withColumn(
         "quarter_times",
         f.when(
@@ -63,4 +63,4 @@ def transform_hour_to_quarter(
         ),
     )
 
-    return QuarterlyMeteringPointTimeSeries(result)
+    return MeteringPointTimeSeries(result)

--- a/source/databricks/calculation_engine/package/calculation/preparation/data_structures/metering_point_time_series.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/data_structures/metering_point_time_series.py
@@ -19,7 +19,7 @@ from package.common import DataFrameWrapper
 from package.constants import Colname
 
 
-class QuarterlyMeteringPointTimeSeries(DataFrameWrapper):
+class MeteringPointTimeSeries(DataFrameWrapper):
     """
     Time series points of metering points with resolution quarterly.
 
@@ -34,7 +34,7 @@ class QuarterlyMeteringPointTimeSeries(DataFrameWrapper):
     def __init__(self, df: DataFrame):
         super().__init__(
             df,
-            _quarterly_metering_point_time_series_schema,
+            metering_point_time_series_schema,
             # Setting these too False would cause errors, and there is no nice and easy fix for this.
             # Should they eventually be set to False?
             ignore_decimal_scale=True,
@@ -42,7 +42,7 @@ class QuarterlyMeteringPointTimeSeries(DataFrameWrapper):
         )
 
 
-_quarterly_metering_point_time_series_schema = t.StructType(
+metering_point_time_series_schema = t.StructType(
     [
         t.StructField(Colname.grid_area, t.StringType(), False),
         t.StructField(Colname.to_grid_area, t.StringType(), True),

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_ga.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_ga.py
@@ -19,7 +19,7 @@ from package.calculation.energy.aggregators.exchange_aggregators import (
     aggregate_net_exchange_per_ga,
     aggregate_net_exchange_per_neighbour_ga,
 )
-import tests.calculation.energy.quarterly_metering_point_time_series_factories as factories
+import tests.calculation.energy.metering_point_time_series_factories as factories
 from package.codelists import QuantityQuality, MeteringPointType
 from package.constants import Colname
 

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_ga_v8.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_ga_v8.py
@@ -26,14 +26,14 @@ from package.calculation.energy.aggregators.exchange_aggregators import (
 from package.calculation.energy.data_structures.energy_results import (
     EnergyResults,
 )
-from package.calculation.preparation.data_structures.quarterly_metering_point_time_series import (
-    QuarterlyMeteringPointTimeSeries,
-    _quarterly_metering_point_time_series_schema,
+from package.calculation.preparation.data_structures.metering_point_time_series import (
+    MeteringPointTimeSeries,
+    metering_point_time_series_schema,
 )
 from package.codelists import MeteringPointType
 from package.constants import Colname
 from tests.calculation.energy import (
-    quarterly_metering_point_time_series_factories as factories,
+    metering_point_time_series_factories as factories,
 )
 
 date_time_formatting_string = "%Y-%m-%dT%H:%M:%S%z"
@@ -46,9 +46,9 @@ ALL_GRID_AREAS = ["A", "B", "C", "D", "E", "F", "X", "Y"]
 
 
 @pytest.fixture(scope="module")
-def quarterly_metering_point_time_series(
+def metering_point_time_series(
     spark: SparkSession,
-) -> QuarterlyMeteringPointTimeSeries:
+) -> MeteringPointTimeSeries:
     rows = []
 
     # add 24 hours of exchange with different examples of exchange between grid areas. See readme.md for more info
@@ -72,10 +72,8 @@ def quarterly_metering_point_time_series(
         rows.append(_create_row("X", "Y", Decimal("42") * quarter_number, obs_time))
         rows.append(_create_row("Y", "X", Decimal("12") * quarter_number, obs_time))
 
-    df = spark.createDataFrame(
-        data=rows, schema=_quarterly_metering_point_time_series_schema
-    )
-    return QuarterlyMeteringPointTimeSeries(df)
+    df = spark.createDataFrame(data=rows, schema=metering_point_time_series_schema)
+    return MeteringPointTimeSeries(df)
 
 
 def _create_row(
@@ -94,17 +92,17 @@ def _create_row(
 
 
 @pytest.fixture(scope="module")
-def aggregated_data_frame(quarterly_metering_point_time_series):
+def aggregated_data_frame(metering_point_time_series):
     """Perform aggregation"""
     exchange_per_neighbour_ga = aggregate_net_exchange_per_neighbour_ga(
-        quarterly_metering_point_time_series, ALL_GRID_AREAS
+        metering_point_time_series, ALL_GRID_AREAS
     )
     return aggregate_net_exchange_per_ga(exchange_per_neighbour_ga)
 
 
-def test_test_data_has_correct_row_count(quarterly_metering_point_time_series):
+def test_test_data_has_correct_row_count(metering_point_time_series):
     """Check sample data row count"""
-    assert quarterly_metering_point_time_series.df.count() == (13 * numberOfQuarters)
+    assert metering_point_time_series.df.count() == (13 * numberOfQuarters)
 
 
 def test_exchange_has_correct_sign(aggregated_data_frame) -> None:

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga.py
@@ -17,7 +17,7 @@ from pyspark.sql import SparkSession
 from package.calculation.energy.aggregators.exchange_aggregators import (
     aggregate_net_exchange_per_neighbour_ga,
 )
-import tests.calculation.energy.quarterly_metering_point_time_series_factories as factories
+import tests.calculation.energy.metering_point_time_series_factories as factories
 from package.codelists import QuantityQuality
 from package.constants import Colname
 

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga_v8.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/exchange_aggregators/test_aggregate_net_exchange_per_neighbour_ga_v8.py
@@ -18,12 +18,12 @@ import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql.types import Row
 
-from calculation.energy import quarterly_metering_point_time_series_factories
+from calculation.energy import metering_point_time_series_factories
 from package.calculation.energy.aggregators.exchange_aggregators import (
     aggregate_net_exchange_per_neighbour_ga,
 )
-from package.calculation.preparation.data_structures.quarterly_metering_point_time_series import (
-    QuarterlyMeteringPointTimeSeries,
+from package.calculation.preparation.data_structures.metering_point_time_series import (
+    MeteringPointTimeSeries,
 )
 from package.codelists import (
     MeteringPointType,
@@ -40,7 +40,7 @@ ALL_GRID_AREAS = ["A", "B", "C"]
 
 
 @pytest.fixture(scope="module")
-def single_quarter_test_data(spark: SparkSession) -> QuarterlyMeteringPointTimeSeries:
+def single_quarter_test_data(spark: SparkSession) -> MeteringPointTimeSeries:
     rows = [
         _create_row("A", "A", "B", default_obs_time, Decimal("10")),
         _create_row("A", "A", "B", default_obs_time, Decimal("15")),
@@ -50,11 +50,11 @@ def single_quarter_test_data(spark: SparkSession) -> QuarterlyMeteringPointTimeS
         _create_row("C", "C", "A", default_obs_time, Decimal("10")),
         _create_row("C", "C", "A", default_obs_time, Decimal("5")),
     ]
-    return quarterly_metering_point_time_series_factories.create(spark, rows)
+    return metering_point_time_series_factories.create(spark, rows)
 
 
 @pytest.fixture(scope="module")
-def multi_quarter_test_data(spark: SparkSession) -> QuarterlyMeteringPointTimeSeries:
+def multi_quarter_test_data(spark: SparkSession) -> MeteringPointTimeSeries:
     rows = []
 
     for i in range(numberOfTestQuarters):
@@ -68,13 +68,13 @@ def multi_quarter_test_data(spark: SparkSession) -> QuarterlyMeteringPointTimeSe
         rows.append(_create_row("C", "C", "A", obs_time, Decimal("10")))
         rows.append(_create_row("C", "C", "A", obs_time, Decimal("5")))
 
-    return quarterly_metering_point_time_series_factories.create(spark, rows)
+    return metering_point_time_series_factories.create(spark, rows)
 
 
 def _create_row(
     domain: str, in_domain: str, out_domain: str, timestamp: datetime, quantity: Decimal
 ) -> Row:
-    return quarterly_metering_point_time_series_factories.create_row(
+    return metering_point_time_series_factories.create_row(
         grid_area=domain,
         to_grid_area=in_domain,
         from_grid_area=out_domain,

--- a/source/databricks/calculation_engine/tests/calculation/energy/aggregations/metering_point_time_series_aggregators/test_aggregate_per_ga_and_brp_and_es.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/aggregations/metering_point_time_series_aggregators/test_aggregate_per_ga_and_brp_and_es.py
@@ -16,7 +16,7 @@ import datetime
 
 from pyspark.sql import SparkSession
 
-import tests.calculation.energy.quarterly_metering_point_time_series_factories as factories
+import tests.calculation.energy.metering_point_time_series_factories as factories
 from package.calculation.energy.aggregators.metering_point_time_series_aggregators import (
     aggregate_per_ga_and_brp_and_es,
 )
@@ -33,11 +33,11 @@ class TestWhenValidInput:
     def test_returns_values_aggregated_for_ga(self, spark: SparkSession):
         # Arrange
         row = factories.create_row()
-        quarterly_metering_point_time_series = factories.create(spark, [row, row])
+        metering_point_time_series = factories.create(spark, [row, row])
 
         # Act
         actual = aggregate_per_ga_and_brp_and_es(
-            quarterly_metering_point_time_series,
+            metering_point_time_series,
             factories.DEFAULT_METERING_POINT_TYPE,
             None,
         )

--- a/source/databricks/calculation_engine/tests/calculation/energy/metering_point_time_series_factories.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/metering_point_time_series_factories.py
@@ -17,9 +17,9 @@ from decimal import Decimal
 
 from pyspark.sql import Row, SparkSession
 
-from package.calculation.preparation.data_structures.quarterly_metering_point_time_series import (
-    QuarterlyMeteringPointTimeSeries,
-    _quarterly_metering_point_time_series_schema,
+from package.calculation.preparation.data_structures.metering_point_time_series import (
+    MeteringPointTimeSeries,
+    metering_point_time_series_schema,
 )
 from package.codelists import MeteringPointType, QuantityQuality, SettlementMethod
 from package.constants import Colname
@@ -134,12 +134,10 @@ def create_to_row(
 
 def create(
     spark: SparkSession, data: None | Row | list[Row] = None
-) -> QuarterlyMeteringPointTimeSeries:
+) -> MeteringPointTimeSeries:
     if data is None:
         data = [create_row()]
     elif isinstance(data, Row):
         data = [data]
-    df = spark.createDataFrame(
-        data, schema=_quarterly_metering_point_time_series_schema
-    )
-    return QuarterlyMeteringPointTimeSeries(df)
+    df = spark.createDataFrame(data, schema=metering_point_time_series_schema)
+    return MeteringPointTimeSeries(df)


### PR DESCRIPTION
Rename quarterly_metering_point_time_series to metering_point_time_series since it is not just quarterly in the upcoming PRs