### PR TITLE
refac: Configure Calculation orchestration

### DIFF
--- a/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Fixtures/OrchestrationsAppFixture.cs
+++ b/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Fixtures/OrchestrationsAppFixture.cs
@@ -26,6 +26,7 @@ using Energinet.DataHub.Core.TestCommon.Diagnostics;
 using Energinet.DataHub.Wholesale.Calculations.Infrastructure.Persistence;
 using Energinet.DataHub.Wholesale.Common.Infrastructure.Extensions.Options;
 using Energinet.DataHub.Wholesale.Common.Infrastructure.Options;
+using Energinet.DataHub.Wholesale.Orchestrations.Extensions.Options;
 using Energinet.DataHub.Wholesale.Orchestrations.IntegrationTests.DurableTask;
 using Energinet.DataHub.Wholesale.Test.Core.Fixture.Database;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
@@ -187,7 +188,7 @@ public class OrchestrationsAppFixture : IAsyncLifetime
 
         // Database
         appHostSettings.ProcessEnvironmentVariables.Add(
-            $"{nameof(ConnectionStringsOptions.ConnectionStrings)}__{nameof(ConnectionStringsOptions.DB_CONNECTION_STRING)}",
+            $"{ConnectionStringsOptions.ConnectionStrings}__{nameof(ConnectionStringsOptions.DB_CONNECTION_STRING)}",
             DatabaseManager.ConnectionString);
 
         // Databricks
@@ -214,6 +215,14 @@ public class OrchestrationsAppFixture : IAsyncLifetime
         appHostSettings.ProcessEnvironmentVariables.Add(
             $"{ServiceBusNamespaceOptions.SectionName}__{nameof(ServiceBusNamespaceOptions.ConnectionString)}",
             ServiceBusResourceProvider.ConnectionString);
+
+        // Override default CalculationJob status monitor configuration
+        appHostSettings.ProcessEnvironmentVariables.Add(
+            $"{CalculationJobStatusMonitorOptions.SectionName}__{nameof(CalculationJobStatusMonitorOptions.PollingIntervalInSeconds)}",
+            "3");
+        appHostSettings.ProcessEnvironmentVariables.Add(
+            $"{CalculationJobStatusMonitorOptions.SectionName}__{nameof(CalculationJobStatusMonitorOptions.ExpiryTimeInSeconds)}",
+            "20");
 
         return appHostSettings;
     }

--- a/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/Calculation/CalculationOrchestrationTests.cs
+++ b/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/Calculation/CalculationOrchestrationTests.cs
@@ -27,7 +27,6 @@ using FluentAssertions.Execution;
 using Newtonsoft.Json;
 using NodaTime;
 using Xunit.Abstractions;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Energinet.DataHub.Wholesale.Orchestrations.IntegrationTests.Functions.Calculation;
 
@@ -244,7 +243,7 @@ public class CalculationOrchestrationTests : IAsyncLifetime
         // => Wait for completion
         var completeOrchestrationStatus = await Fixture.DurableClient.WaitForInstanceCompletedAsync(
             orchestrationStatus.InstanceId,
-            TimeSpan.FromMinutes(6)); // We will loop at least twice to get job status
+            TimeSpan.FromMinutes(1)); // We will loop at least twice to get job status
 
         // => Expect history
         using var assertionScope = new AssertionScope();

--- a/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/Calculation/CalculationOrchestrationTests.cs
+++ b/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/Calculation/CalculationOrchestrationTests.cs
@@ -273,7 +273,7 @@ public class CalculationOrchestrationTests : IAsyncLifetime
     /// Verify the job status monitor (loop) breaks if we reach expiry time.
     /// </summary>
     [Fact]
-    public async Task MockJobsRunsGetAsRunning_WhenCallingStartCalculationEndPoint_OrchestrationCompletesWithExpectedGetJobStatusActivity()
+    public async Task MockJobsRunsGetAsRunning_WhenCallingStartCalculationEndpointAndCalculationTimeoutIsExceeded_OrchestrationCompletesWithExpectedGetJobStatusActivity()
     {
         // Arrange
         // => Databricks Jobs API

--- a/source/dotnet/wholesale-api/Orchestrations/Extensions/Options/CalculationJobStatusMonitorOptions.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Extensions/Options/CalculationJobStatusMonitorOptions.cs
@@ -32,5 +32,5 @@ public class CalculationJobStatusMonitorOptions
     /// <summary>
     /// Expiry time of the job status monitor (loop).
     /// </summary>
-    public int ExpiryTimeInSeconds { get; set; } = 1800;
+    public int ExpiryTimeInSeconds { get; set; } = 3600;
 }

--- a/source/dotnet/wholesale-api/Orchestrations/Extensions/Options/CalculationJobStatusMonitorOptions.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Extensions/Options/CalculationJobStatusMonitorOptions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Wholesale.Orchestrations.Functions.Calculation;
+
+namespace Energinet.DataHub.Wholesale.Orchestrations.Extensions.Options;
+
+/// <summary>
+/// Options for the CalculationJob status monitor implemented as part of the
+/// <see cref="CalculationOrchestration.Calculation"/>.
+/// </summary>
+public class CalculationJobStatusMonitorOptions
+{
+    public const string SectionName = "CalculationJobStatusMonitor";
+
+    /// <summary>
+    /// Time between each call to get the job status.
+    /// </summary>
+    public int PollingIntervalInSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Expiry time of the job status monitor (loop).
+    /// </summary>
+    public int ExpiryTimeInSeconds { get; set; } = 1800;
+}

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationOrchestration.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationOrchestration.cs
@@ -50,9 +50,8 @@ internal class CalculationOrchestration
 
         // TODO: Adjust polling and expiry
         var pollingIntervalInSeconds = 60;
-        var expiryTime = context.CurrentUtcDateTime.AddMinutes(30);
+        var expiryTime = context.CurrentUtcDateTime.AddSeconds(30 * 60);
 
-        // While may be redundant, since we start all over, when a function starts
         while (context.CurrentUtcDateTime < expiryTime)
         {
             // Monitor calculation (Databricks)

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationOrchestration.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationOrchestration.cs
@@ -48,10 +48,7 @@ internal class CalculationOrchestration
         calculationMetadata.OrchestrationProgress = "CalculationJobQueued";
         context.SetCustomStatus(calculationMetadata);
 
-        // TODO: Adjust polling and expiry
-        var pollingIntervalInSeconds = 60;
-        var expiryTime = context.CurrentUtcDateTime.AddSeconds(30 * 60);
-
+        var expiryTime = context.CurrentUtcDateTime.AddSeconds(input.JobStatusMonitorOptions.ExpiryTimeInSeconds);
         while (context.CurrentUtcDateTime < expiryTime)
         {
             // Monitor calculation (Databricks)
@@ -69,7 +66,7 @@ internal class CalculationOrchestration
                     calculationMetadata);
 
                 // Wait for the next checkpoint
-                var nextCheckpoint = context.CurrentUtcDateTime.AddSeconds(pollingIntervalInSeconds);
+                var nextCheckpoint = context.CurrentUtcDateTime.AddSeconds(input.JobStatusMonitorOptions.PollingIntervalInSeconds);
                 await context.CreateTimer(nextCheckpoint, CancellationToken.None);
             }
             else

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
@@ -34,6 +34,7 @@ internal class CalculationTrigger
 
         var orchestrationInput = new CalculationOrchestrationInput(
             startCalculationRequestDto,
+            // TODO: Retrieve user id from token sent as part of http request
             Guid.Parse("3A3A90B7-C624-4844-B990-3221DEE54F04"));
 
         var instanceId = await client.ScheduleNewOrchestrationInstanceAsync(nameof(CalculationOrchestration.Calculation), orchestrationInput).ConfigureAwait(false);

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Net;
+using Energinet.DataHub.Wholesale.Orchestrations.Extensions.Options;
 using Energinet.DataHub.Wholesale.Orchestrations.Functions.Calculation.Model;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -33,6 +34,7 @@ internal class CalculationTrigger
         var logger = executionContext.GetLogger<CalculationOrchestration>();
 
         var orchestrationInput = new CalculationOrchestrationInput(
+            new CalculationJobStatusMonitorOptions(),
             startCalculationRequestDto,
             // TODO: Retrieve user id from token sent as part of http request
             Guid.Parse("3A3A90B7-C624-4844-B990-3221DEE54F04"));

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
@@ -18,12 +18,21 @@ using Energinet.DataHub.Wholesale.Orchestrations.Functions.Calculation.Model;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Energinet.DataHub.Wholesale.Orchestrations.Functions.Calculation;
 
 internal class CalculationTrigger
 {
+    private readonly CalculationJobStatusMonitorOptions _jobStatusMonitorOptions;
+
+    public CalculationTrigger(IOptions<CalculationJobStatusMonitorOptions> jobStatusMonitorOptions)
+    {
+        _jobStatusMonitorOptions = jobStatusMonitorOptions.Value;
+    }
+
     [Function(nameof(StartCalculation))]
     public async Task<HttpResponseData> StartCalculation(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req,
@@ -34,7 +43,7 @@ internal class CalculationTrigger
         var logger = executionContext.GetLogger<CalculationOrchestration>();
 
         var orchestrationInput = new CalculationOrchestrationInput(
-            new CalculationJobStatusMonitorOptions(),
+            _jobStatusMonitorOptions,
             startCalculationRequestDto,
             // TODO: Retrieve user id from token sent as part of http request
             Guid.Parse("3A3A90B7-C624-4844-B990-3221DEE54F04"));

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/Model/CalculationOrchestrationInput.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/Model/CalculationOrchestrationInput.cs
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Wholesale.Orchestrations.Extensions.Options;
+
 namespace Energinet.DataHub.Wholesale.Orchestrations.Functions.Calculation.Model;
 
 /// <summary>
 /// An immutable input to start the calculation orchestration.
 /// </summary>
 public sealed record CalculationOrchestrationInput(
+    CalculationJobStatusMonitorOptions JobStatusMonitorOptions,
     StartCalculationRequestDto StartCalculationRequestDto,
     Guid RequestedByUserId);

--- a/source/dotnet/wholesale-api/Orchestrations/Program.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Program.cs
@@ -20,6 +20,8 @@ using Energinet.DataHub.Wholesale.Calculations.Infrastructure.Extensions.Depende
 using Energinet.DataHub.Wholesale.Common.Infrastructure.Extensions.DependencyInjection;
 using Energinet.DataHub.Wholesale.Common.Infrastructure.Telemetry;
 using Energinet.DataHub.Wholesale.Events.Infrastructure.Extensions.DependencyInjection;
+using Energinet.DataHub.Wholesale.Orchestrations.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 var host = new HostBuilder()
@@ -33,6 +35,9 @@ var host = new HostBuilder()
         // Shared by modules
         services.AddNodaTimeForApplication();
         services.AddDatabricksJobsForApplication(context.Configuration);
+        services
+            .AddOptions<CalculationJobStatusMonitorOptions>()
+            .BindConfiguration(CalculationJobStatusMonitorOptions.SectionName);
 
         // Modules
         services.AddCalculationsModule(context.Configuration);


### PR DESCRIPTION
# Description

- [x] Be able to configure Calculation orchestration so we can control the Job status monitor polling interval and expiry time from tests.
- [x] Implement a test of the job status monitor for a scenario where the job runs forever

Part of:
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/182

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
