### PR TITLE
fix: missing reference to TotalMonthlyAmountResultProducedV1.cs

### DIFF
--- a/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Wholesale Contracts Release notes
 
+## Version 9.3.1
+
+Added `TotalMonthlyAmountResultProducedV1.cs` as partial class to the TotalMonthlyAmountResultProducedV1 event.
+
 ## Version 9.3.0
 
 Added `CalculationResultVersion` property to `TotalMonthlyAmountResultProducedV1`

--- a/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
@@ -21,7 +21,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Wholesale.Contracts</PackageId>
-    <PackageVersion>9.3.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>9.3.1$(VersionSuffix)</PackageVersion>
     <Title>Wholesale Contracts</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
@@ -96,7 +96,7 @@ limitations under the License.
     <Compile Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\MonthlyAmountPerChargeResultProducedV1\MonthlyAmountPerChargeResultProducedV1.cs">
       <Link>Contracts\IntegrationEvents\MonthlyAmountPerChargeResultProducedV1.cs</Link>
     </Compile>
-    <Compile Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\TotalMonthlyAmountResultProducedV1\TotalMonthlyAmountResultProducedV1">
+    <Compile Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\TotalMonthlyAmountResultProducedV1\TotalMonthlyAmountResultProducedV1.cs">
       <Link>Contracts\IntegrationEvents\TotalMonthlyAmountResultProducedV1.cs</Link>
     </Compile>
   </ItemGroup>

--- a/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
@@ -96,6 +96,9 @@ limitations under the License.
     <Compile Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\MonthlyAmountPerChargeResultProducedV1\MonthlyAmountPerChargeResultProducedV1.cs">
       <Link>Contracts\IntegrationEvents\MonthlyAmountPerChargeResultProducedV1.cs</Link>
     </Compile>
+    <Compile Include="..\..\wholesale-api\Events\Events.Infrastructure\IntegrationEvents\TotalMonthlyAmountResultProducedV1\TotalMonthlyAmountResultProducedV1">
+      <Link>Contracts\IntegrationEvents\TotalMonthlyAmountResultProducedV1.cs</Link>
+    </Compile>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description
Ensure TotalMonthlyAmountResultProducedV1 partial class is added in the nuget package by adding a missing reference to TotalMonthlyAmountResultProducedV1 partial class. 

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
- [ ] Documentation has been updated
- [ ] The integration [event catalog](https://energinet.atlassian.net/wiki/spaces/D3/pages/555581556/Event+catalog) has been updated
- [ ] C4 diagrams have been updated and Team Outlaws has been informed about relevant changes
