### PR TITLE
fix: settlement_report_metering_point_time_series_v1_view

### DIFF
--- a/source/databricks/calculation_engine/package/datamigration/migration_scripts/202405081100_Modify_settlement_report_metering_point_time_series_v1_view.sql
+++ b/source/databricks/calculation_engine/package/datamigration/migration_scripts/202405081100_Modify_settlement_report_metering_point_time_series_v1_view.sql
@@ -1,0 +1,23 @@
+DROP VIEW IF EXISTS {SETTLEMENT_REPORT_DATABASE_NAME}.metering_point_time_series
+GO
+
+DROP VIEW IF EXISTS {SETTLEMENT_REPORT_DATABASE_NAME}.metering_point_time_series_v1
+GO
+
+CREATE VIEW IF NOT EXISTS {SETTLEMENT_REPORT_DATABASE_NAME}.metering_point_time_series_v1 as
+SELECT m.calculation_id,
+       m.metering_point_id,
+       m.metering_point_type,
+       m.resolution,
+       m.grid_area_code,
+       m.energy_supplier_id,
+       DATE_TRUNC('day', FROM_UTC_TIMESTAMP(t.observation_time, 'Europe/Copenhagen')) AS observation_day,
+       ARRAY_SORT(ARRAY_AGG(struct(t.observation_time, t.quantity)))                  AS quantities
+FROM {BASIS_DATA_DATABASE_NAME}.metering_point_periods AS m
+         JOIN (SELECT * FROM {BASIS_DATA_DATABASE_NAME}.time_series_points order by observation_time) AS t ON m.metering_point_id = t.metering_point_id AND m
+             .calculation_id = t.calculation_id
+WHERE t.observation_time >= m.from_date
+AND (m.to_date IS NULL OR t.observation_time < m.to_date)
+GROUP BY m.calculation_id, m.metering_point_id, m.metering_point_type, observation_day, m.resolution, m.grid_area_code, m.energy_supplier_id
+ORDER BY observation_day
+GO


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Added the create settlement_report_metering_point_time_series_v1_view script (with rename of view).
Currently, the settlement_report_metering_point_time_series_v1_view is missing in several environments. 
Might be due to a missing GO in the script.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
