### PR TITLE
feat: Add FAS check to download

### DIFF
--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Application/SettlementReports_v2/SettlementReportDownloadHandler.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Application/SettlementReports_v2/SettlementReportDownloadHandler.cs
@@ -30,13 +30,13 @@ public sealed class SettlementReportDownloadHandler : ISettlementReportDownloadH
         _repository = repository;
     }
 
-    public async Task DownloadReportAsync(SettlementReportRequestId requestId, Stream downloadStream, Guid userId, Guid actorId)
+    public async Task DownloadReportAsync(SettlementReportRequestId requestId, Stream downloadStream, Guid userId, Guid actorId, bool isMultitenancy)
     {
         var report = await _repository
             .GetAsync(requestId.Id)
             .ConfigureAwait(false) ?? throw new InvalidOperationException("Report not found.");
 
-        if (report.UserId != userId || report.ActorId != actorId)
+        if (!isMultitenancy && (report.UserId != userId || report.ActorId != actorId))
             throw new InvalidOperationException("User does not have access to the report.");
 
         if (string.IsNullOrEmpty(report.BlobFileName))

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Application/SettlementReports/SettlementReportDownloadHandlerIntegrationTests.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Application/SettlementReports/SettlementReportDownloadHandlerIntegrationTests.cs
@@ -75,7 +75,63 @@ public sealed class SettlementReportDownloadHandlerIntegrationTests : TestBase<S
 
         // Act
         await using var downloadStream = new MemoryStream();
-        await Sut.DownloadReportAsync(requestId, downloadStream, userId, actorId);
+        await Sut.DownloadReportAsync(requestId, downloadStream, userId, actorId, false);
+
+        // Assert
+        Assert.NotNull(downloadStream);
+        Assert.NotEqual(0, downloadStream.Length);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_NoAccess_ThrowsException()
+    {
+        var requestId = new SettlementReportRequestId(Guid.NewGuid().ToString());
+        await MakeTestFileAsync(requestId);
+
+        var generatedSettlementReport = new GeneratedSettlementReportDto(
+            requestId,
+            new GeneratedSettlementReportFileDto(requestId, "Report.zip"),
+            []);
+
+        var userId = Guid.NewGuid();
+        var actorId = Guid.NewGuid();
+        var settlementReport =
+            new SettlementReport(SystemClock.Instance, userId, actorId, requestId, _mockedSettlementReportRequest);
+        settlementReport.MarkAsCompleted(generatedSettlementReport);
+
+        await using var dbContext = _wholesaleDatabaseFixture.DatabaseManager.CreateDbContext();
+        await dbContext.SettlementReports.AddAsync(settlementReport);
+        await dbContext.SaveChangesAsync();
+
+        // Act + Assert
+        await using var downloadStream = new MemoryStream();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Sut.DownloadReportAsync(requestId, downloadStream, Guid.NewGuid(), Guid.NewGuid(), false));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_AsFAS_ReturnsStream()
+    {
+        var requestId = new SettlementReportRequestId(Guid.NewGuid().ToString());
+        await MakeTestFileAsync(requestId);
+
+        var generatedSettlementReport = new GeneratedSettlementReportDto(
+            requestId,
+            new GeneratedSettlementReportFileDto(requestId, "Report.zip"),
+            []);
+
+        var userId = Guid.NewGuid();
+        var actorId = Guid.NewGuid();
+        var settlementReport =
+            new SettlementReport(SystemClock.Instance, userId, actorId, requestId, _mockedSettlementReportRequest);
+        settlementReport.MarkAsCompleted(generatedSettlementReport);
+
+        await using var dbContext = _wholesaleDatabaseFixture.DatabaseManager.CreateDbContext();
+        await dbContext.SettlementReports.AddAsync(settlementReport);
+        await dbContext.SaveChangesAsync();
+
+        // Act
+        await using var downloadStream = new MemoryStream();
+        await Sut.DownloadReportAsync(requestId, downloadStream, Guid.NewGuid(), Guid.NewGuid(), true);
 
         // Assert
         Assert.NotNull(downloadStream);

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/SettlementReports_v2/ISettlementReportDownloadHandler.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/SettlementReports_v2/ISettlementReportDownloadHandler.cs
@@ -18,5 +18,5 @@ namespace Energinet.DataHub.Wholesale.CalculationResults.Interfaces.SettlementRe
 
 public interface ISettlementReportDownloadHandler
 {
-    Task DownloadReportAsync(SettlementReportRequestId requestId, Stream downloadStream, Guid userId, Guid actorId);
+    Task DownloadReportAsync(SettlementReportRequestId requestId, Stream downloadStream, Guid userId, Guid actorId, bool isMultitenancy);
 }

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/SettlementReports/SettlementReportDownloadTrigger.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/SettlementReports/SettlementReportDownloadTrigger.cs
@@ -46,8 +46,9 @@ internal sealed class SettlementReportDownloadTrigger
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Content-Type", "application/octet-stream");
             await _settlementReportDownloadHandler
-                .DownloadReportAsync(settlementReportRequestId, response.Body, _userContext.CurrentUser.UserId, _userContext.CurrentUser.ActorId)
+                .DownloadReportAsync(settlementReportRequestId, response.Body, _userContext.CurrentUser.UserId, _userContext.CurrentUser.ActorId, _userContext.CurrentUser.MultiTenancy)
                 .ConfigureAwait(false);
+
             return response;
         }
         catch (Exception ex) when (ex is InvalidOperationException or RequestFailedException)


### PR DESCRIPTION
# Description

Adds a check to the download settlement report function, to see if a user is FAS and therefore is allowed to download all reports.

## Pull-request quality

- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
