### PR TITLE
refac: Cache hourly tariff before calculating monthly amounts

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/wholesale/wholesale_calculation.py
+++ b/source/databricks/calculation_engine/package/calculation/wholesale/wholesale_calculation.py
@@ -137,6 +137,7 @@ def _calculate_hourly_tariffs(
     hourly_tariff_per_ga_co_es = tariff_calculator.calculate_tariff_price_per_ga_co_es(
         prepared_hourly_tariffs
     )
+    hourly_tariff_per_ga_co_es.cache_internal()
 
     results.hourly_tariff_per_ga_co_es = factory.create(
         args,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description
Cache hourly tariff before calculating/materializing monthly amount and total monthly amount. This will hopefully increase the performance for monthly and total monthly (see current times below):
![image](https://github.com/Energinet-DataHub/opengeh-wholesale/assets/112619721/ca51563d-0431-4e65-82e3-8a2862b10114)

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
