### PR TITLE
feat: Add validation rule for chargetypes in wholesale services requests

### DIFF
--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/ChargeTypeValidatorTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/ChargeTypeValidatorTests.cs
@@ -23,7 +23,7 @@ namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Validators.WholesaleServices
 
 public class ChargeTypeValidatorTests
 {
-    private static readonly ValidationError _chargeIdIsToLongError = new ValidationError(
+    private static readonly ValidationError _chargeTypeIdIsToLongError = new ValidationError(
         "Følgende chargeType er for lang: {PropertyName}. Den må højst indeholde 10 karaktere/"
         + "The following ChargeId is to long: {PropertyName} It must at most be 10 characters",
         "D14");
@@ -73,7 +73,7 @@ public class ChargeTypeValidatorTests
         // Assert
         validationErrors.Should().ContainSingle()
             .Subject.Should().Be(
-                _chargeIdIsToLongError.WithPropertyName(chargeTypeId));
+                _chargeTypeIdIsToLongError.WithPropertyName(chargeTypeId));
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class ChargeTypeValidatorTests
 
         for (var i = 0; i < chargeTypes.Count(); i++)
         {
-            expectedErrors.Add(_chargeIdIsToLongError.WithPropertyName(chargeTypes[i].ChargeType_));
+            expectedErrors.Add(_chargeTypeIdIsToLongError.WithPropertyName(chargeTypes[i].ChargeType_));
         }
 
         var message = new WholesaleServicesRequestBuilder()
@@ -123,6 +123,6 @@ public class ChargeTypeValidatorTests
         var validationErrors = await _sut.ValidateAsync(message);
 
         // Assert
-        validationErrors.Should().ContainSingle().Subject.Should().Be(_chargeIdIsToLongError.WithPropertyName(invalidCharTypeId));
+        validationErrors.Should().ContainSingle().Subject.Should().Be(_chargeTypeIdIsToLongError.WithPropertyName(invalidCharTypeId));
     }
 }

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/ChargeTypeValidatorTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/ChargeTypeValidatorTests.cs
@@ -1,0 +1,128 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Edi.Requests;
+using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
+using Energinet.DataHub.Wholesale.Edi.Validation;
+using Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Rules;
+using FluentAssertions;
+using Xunit;
+
+namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Validators.WholesaleServicesRequest;
+
+public class ChargeTypeValidatorTests
+{
+    private static readonly ValidationError _chargeIdIsToLongError = new ValidationError(
+        "Følgende chargeType er for lang: {PropertyName}. Den må højst indeholde 10 karaktere/"
+        + "The following ChargeId is to long: {PropertyName} It must at most be 10 characters",
+        "D14");
+
+    private readonly ChargeTypeValidationRule _sut = new();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("0")]
+    [InlineData("%/)(&)")]
+    [InlineData("0000000000")]
+    [InlineData("1234567890")]
+    [InlineData("-234567890")]
+    public async Task Validate_WhenChargeTypeContainsAValidType_returnsExpectedValidationError(string? chargeTypeId)
+    {
+        // Arrange
+        var chargeTypes = Array.Empty<ChargeType>();
+
+        if (chargeTypeId is not null)
+            chargeTypes = [new ChargeType() { ChargeType_ = chargeTypeId, ChargeCode = "D01" }];
+
+        var message = new WholesaleServicesRequestBuilder()
+            .WithChargeTypes(chargeTypes)
+            .Build();
+
+        // Act
+        var validationErrors = await _sut.ValidateAsync(message);
+
+        // Assert
+        validationErrors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("12345678901")] // 11 char long
+    public async Task Validate_WhenChargeTypeContainsAInvalidType_returnsExpectedValidationError(string chargeTypeId)
+    {
+        // Arrange
+        var chargeTypes = new ChargeType() { ChargeType_ = chargeTypeId, ChargeCode = "D01" };
+
+        var message = new WholesaleServicesRequestBuilder()
+            .WithChargeTypes(chargeTypes)
+            .Build();
+
+        // Act
+        var validationErrors = await _sut.ValidateAsync(message);
+
+        // Assert
+        validationErrors.Should().ContainSingle()
+            .Subject.Should().Be(
+                _chargeIdIsToLongError.WithPropertyName(chargeTypeId));
+    }
+
+    [Fact]
+    public async Task Validate_WhenChargeTypeContainsMultipleInvalidType_returnsExpectedValidationError()
+    {
+        // Arrange
+        var chargeTypes = new ChargeType[]
+            {
+                new ChargeType() { ChargeType_ = "12345678901", ChargeCode = "D01" },
+                new ChargeType() { ChargeType_ = "10987654321", ChargeCode = "D01" },
+            };
+        var expectedErrors = new List<ValidationError>();
+
+        for (var i = 0; i < chargeTypes.Count(); i++)
+        {
+            expectedErrors.Add(_chargeIdIsToLongError.WithPropertyName(chargeTypes[i].ChargeType_));
+        }
+
+        var message = new WholesaleServicesRequestBuilder()
+            .WithChargeTypes(chargeTypes)
+            .Build();
+
+        // Act
+        var validationErrors = await _sut.ValidateAsync(message);
+
+        // Assert
+        validationErrors.Should().Equal(expectedErrors);
+    }
+
+    [Fact]
+    public async Task Validate_WhenMultipleChargeTypeButOneHasInvalidType_returnsExpectedValidationError()
+    {
+        // Arrange
+        var invalidCharTypeId = "ThisIsMoreThan10Charlong";
+        var chargeTypes = new ChargeType[]
+            {
+                new ChargeType() { ChargeType_ = "valid1", ChargeCode = "D01" },
+                new ChargeType() { ChargeType_ = invalidCharTypeId, ChargeCode = "D01" },
+                new ChargeType() { ChargeType_ = "valid2", ChargeCode = "D01" },
+            };
+
+        var message = new WholesaleServicesRequestBuilder()
+            .WithChargeTypes(chargeTypes)
+            .Build();
+
+        // Act
+        var validationErrors = await _sut.ValidateAsync(message);
+
+        // Assert
+        validationErrors.Should().ContainSingle().Subject.Should().Be(_chargeIdIsToLongError.WithPropertyName(invalidCharTypeId));
+    }
+}

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/ChargeTypeValidatorTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/ChargeTypeValidatorTests.cs
@@ -107,11 +107,11 @@ public class ChargeTypeValidatorTests
     public async Task Validate_WhenMultipleChargeTypeButOneHasInvalidType_returnsExpectedValidationError()
     {
         // Arrange
-        var invalidCharTypeId = "ThisIsMoreThan10Charlong";
+        var invalidCharType = "ThisIsMoreThan10Charlong";
         var chargeTypes = new ChargeType[]
             {
                 new ChargeType() { ChargeType_ = "valid1", ChargeCode = "D01" },
-                new ChargeType() { ChargeType_ = invalidCharTypeId, ChargeCode = "D01" },
+                new ChargeType() { ChargeType_ = invalidCharType, ChargeCode = "D01" },
                 new ChargeType() { ChargeType_ = "valid2", ChargeCode = "D01" },
             };
 
@@ -123,6 +123,6 @@ public class ChargeTypeValidatorTests
         var validationErrors = await _sut.ValidateAsync(message);
 
         // Assert
-        validationErrors.Should().ContainSingle().Subject.Should().Be(_chargeTypeIdIsToLongError.WithPropertyName(invalidCharTypeId));
+        validationErrors.Should().ContainSingle().Subject.Should().Be(_chargeTypeIdIsToLongError.WithPropertyName(invalidCharType));
     }
 }

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/ChargeTypeValidatorTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/ChargeTypeValidatorTests.cs
@@ -24,8 +24,8 @@ namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Validators.WholesaleServices
 public class ChargeTypeValidatorTests
 {
     private static readonly ValidationError _chargeTypeIdIsToLongError = new ValidationError(
-        "Følgende chargeType er for lang: {PropertyName}. Den må højst indeholde 10 karaktere/"
-        + "The following ChargeId is to long: {PropertyName} It must at most be 10 characters",
+        "Følgende chargeType mRID er for lang: {PropertyName}. Den må højst indeholde 10 karaktere/"
+        + "The following chargeType mRID is to long: {PropertyName} It must at most be 10 characters",
         "D14");
 
     private readonly ChargeTypeValidationRule _sut = new();

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/WholesaleServicesRequestValidatorTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/WholesaleServicesRequestValidatorTests.cs
@@ -133,7 +133,7 @@ public sealed class WholesaleServicesRequestValidatorTests
     }
 
     [Fact]
-    public async Task Validate_WhenChargeIdIsToLong_ReturnsUnsuccessfulValidation()
+    public async Task Validate_WhenChargeTypeIsToLong_ReturnsUnsuccessfulValidation()
     {
         // Arrange
         var chargeTypeInRequest = new ChargeType() { ChargeCode = "123", ChargeType_ = "ThisIsMoreThan10CharsLong", };

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/WholesaleServicesRequestValidatorTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/WholesaleServicesRequestValidatorTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.Edi.Requests;
 using Energinet.DataHub.Wholesale.Calculations.Infrastructure.Persistence;
 using Energinet.DataHub.Wholesale.Calculations.Infrastructure.Persistence.GridArea;
 using Energinet.DataHub.Wholesale.Calculations.Interfaces.GridArea;
@@ -129,5 +130,23 @@ public sealed class WholesaleServicesRequestValidatorTests
         // Assert
         validationErrors.Should().ContainSingle()
             .Which.ErrorCode.Should().Be("D23");
+    }
+
+    [Fact]
+    public async Task Validate_WhenChargeIdIsToLong_ReturnsUnsuccessfulValidation()
+    {
+        // Arrange
+        var chargeTypeInRequest = new ChargeType() { ChargeCode = "123", ChargeType_ = "ThisIsMoreThan10CharsLong", };
+
+        var request = new WholesaleServicesRequestBuilder()
+            .WithChargeTypes(chargeTypeInRequest)
+            .Build();
+
+        // Act
+        var validationErrors = await _sut.ValidateAsync(request);
+
+        // Assert
+        validationErrors.Should().ContainSingle()
+            .Which.ErrorCode.Should().Be("D14");
     }
 }

--- a/source/dotnet/wholesale-api/Edi/Extensions/DependencyInjection/EdiExtensions.cs
+++ b/source/dotnet/wholesale-api/Edi/Extensions/DependencyInjection/EdiExtensions.cs
@@ -83,15 +83,18 @@ public static class EdiExtensions
     {
         services.AddScoped<IValidator<WholesaleServicesRequest>, WholesaleServicesRequestValidator>();
         services
-            .AddScoped<
-                IValidationRule<WholesaleServicesRequest>,
-                Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Rules.PeriodValidationRule>()
             .AddSingleton<
                 IValidationRule<WholesaleServicesRequest>,
                 Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Rules.ResolutionValidationRule>()
             .AddSingleton<
                 IValidationRule<WholesaleServicesRequest>,
                 Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Rules.EnergySupplierValidationRule>()
+            .AddSingleton<
+                IValidationRule<WholesaleServicesRequest>,
+                Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Rules.ChargeTypeValidationRule>()
+            .AddScoped<
+                IValidationRule<WholesaleServicesRequest>,
+                Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Rules.PeriodValidationRule>()
             .AddScoped<
                 IValidationRule<WholesaleServicesRequest>,
                 Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Rules.GridAreaValidationRule>();

--- a/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/ChargeTypeValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/ChargeTypeValidationRule.cs
@@ -16,7 +16,7 @@ namespace Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Ru
 
 public class ChargeTypeValidationRule : IValidationRule<DataHub.Edi.Requests.WholesaleServicesRequest>
 {
-    private static readonly ValidationError _chargeIdIsToLongError = new ValidationError(
+    private static readonly ValidationError _chargeTypeIdIsToLongError = new ValidationError(
         "Følgende chargeType er for lang: {PropertyName}. Den må højst indeholde 10 karaktere/"
         + "The following ChargeId is to long: {PropertyName} It must at most be 10 characters",
         "D14");
@@ -27,12 +27,12 @@ public class ChargeTypeValidationRule : IValidationRule<DataHub.Edi.Requests.Who
 
         if (chargeTypesWithToLongType.Any())
         {
-            var errors = chargeTypesWithToLongType.Select(chargeType => _chargeIdIsToLongError.WithPropertyName(chargeType.ChargeType_)).ToList();
+            var errors = chargeTypesWithToLongType.Select(chargeType => _chargeTypeIdIsToLongError.WithPropertyName(chargeType.ChargeType_)).ToList();
             return Task.FromResult<IList<ValidationError>>(errors);
         }
 
         if (subject.ChargeTypes.Any(chargeType => chargeType.ChargeType_.Length > 10))
-            return Task.FromResult<IList<ValidationError>>(new List<ValidationError> { _chargeIdIsToLongError });
+            return Task.FromResult<IList<ValidationError>>(new List<ValidationError> { _chargeTypeIdIsToLongError });
 
         return Task.FromResult(NoError);
     }

--- a/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/ChargeTypeValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/ChargeTypeValidationRule.cs
@@ -31,9 +31,6 @@ public class ChargeTypeValidationRule : IValidationRule<DataHub.Edi.Requests.Who
             return Task.FromResult<IList<ValidationError>>(errors);
         }
 
-        if (subject.ChargeTypes.Any(chargeType => chargeType.ChargeType_.Length > 10))
-            return Task.FromResult<IList<ValidationError>>(new List<ValidationError> { _chargeTypeIdIsToLongError });
-
         return Task.FromResult(NoError);
     }
 

--- a/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/ChargeTypeValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/ChargeTypeValidationRule.cs
@@ -17,8 +17,8 @@ namespace Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Ru
 public class ChargeTypeValidationRule : IValidationRule<DataHub.Edi.Requests.WholesaleServicesRequest>
 {
     private static readonly ValidationError _chargeTypeIdIsToLongError = new ValidationError(
-        "Følgende chargeType er for lang: {PropertyName}. Den må højst indeholde 10 karaktere/"
-        + "The following ChargeId is to long: {PropertyName} It must at most be 10 characters",
+        "Følgende chargeType mRID er for lang: {PropertyName}. Den må højst indeholde 10 karaktere/"
+        + "The following chargeType mRID is to long: {PropertyName} It must at most be 10 characters",
         "D14");
 
     public Task<IList<ValidationError>> ValidateAsync(DataHub.Edi.Requests.WholesaleServicesRequest subject)

--- a/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/ChargeTypeValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/ChargeTypeValidationRule.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Rules;
+
+public class ChargeTypeValidationRule : IValidationRule<DataHub.Edi.Requests.WholesaleServicesRequest>
+{
+    private static readonly ValidationError _chargeIdIsToLongError = new ValidationError(
+        "Følgende chargeType er for lang: {PropertyName}. Den må højst indeholde 10 karaktere/"
+        + "The following ChargeId is to long: {PropertyName} It must at most be 10 characters",
+        "D14");
+
+    public Task<IList<ValidationError>> ValidateAsync(DataHub.Edi.Requests.WholesaleServicesRequest subject)
+    {
+        var chargeTypesWithToLongType = subject.ChargeTypes.Where(chargeType => chargeType.ChargeType_.Length > 10).ToList();
+
+        if (chargeTypesWithToLongType.Any())
+        {
+            var errors = chargeTypesWithToLongType.Select(chargeType => _chargeIdIsToLongError.WithPropertyName(chargeType.ChargeType_)).ToList();
+            return Task.FromResult<IList<ValidationError>>(errors);
+        }
+
+        if (subject.ChargeTypes.Any(chargeType => chargeType.ChargeType_.Length > 10))
+            return Task.FromResult<IList<ValidationError>>(new List<ValidationError> { _chargeIdIsToLongError });
+
+        return Task.FromResult(NoError);
+    }
+
+    private static IList<ValidationError> NoError => new List<ValidationError>();
+}


### PR DESCRIPTION
Validation of chargeType. Since their type must at most be 10 characters long. Return error message with faulted type

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
