### PR TITLE
fix: Fix `test_public_data_model_views.py`

### DIFF
--- a/source/databricks/calculation_engine/tests/features/public_data_models/test_public_data_model_views.py
+++ b/source/databricks/calculation_engine/tests/features/public_data_models/test_public_data_model_views.py
@@ -55,8 +55,11 @@ def test__public_data_model_views_have_correct_schemas(
     """Verify that all schemas from all views in all public view models match the respective expected schema."""
 
     # Arrange
-    databases = get_public_data_model_databases(spark)
     expected_schemas = get_expected_public_data_model_schemas()
+    if not expected_schemas:
+        raise ValueError("No expected schemas found.")
+
+    databases = get_public_data_model_databases(spark)
     errors = []
 
     # Act & Assert
@@ -66,7 +69,7 @@ def test__public_data_model_views_have_correct_schemas(
 
         for view in views:
             try:
-                if not view.name in expected_schemas:
+                if view.name not in expected_schemas:
                     raise ValueError(
                         f"Expected schema for {database.name}.{view.name} not found."
                     )

--- a/source/databricks/calculation_engine/tests/features/public_data_models/test_public_data_model_views.py
+++ b/source/databricks/calculation_engine/tests/features/public_data_models/test_public_data_model_views.py
@@ -66,6 +66,11 @@ def test__public_data_model_views_have_correct_schemas(
 
         for view in views:
             try:
+                if not view.name in expected_schemas:
+                    raise ValueError(
+                        f"Expected schema for {database.name}.{view.name} not found."
+                    )
+
                 actual_df = spark.table(f"{database.name}.{view.name}")
                 expected_df = spark.createDataFrame([], expected_schemas[view.name])
 

--- a/source/databricks/calculation_engine/tests/features/utils/views/public_data_models_databases_and_schemas.py
+++ b/source/databricks/calculation_engine/tests/features/utils/views/public_data_models_databases_and_schemas.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import importlib.util
 import os
+from pathlib import Path
 from typing import List
 
 from pyspark.sql import SparkSession
@@ -42,8 +43,8 @@ def get_public_data_model_databases(spark: SparkSession) -> List[Database]:
 
 def get_expected_public_data_model_schemas() -> dict:
     schemas = {}
-    current_directory = os.getcwd()
-    schemas_folder = current_directory + "/features/utils/views/expected_schemas"
+    current_directory = Path(__file__).parent
+    schemas_folder = current_directory / "expected_schemas"
 
     for root, _, files in os.walk(schemas_folder):
         for file_name in files:


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Replace non-useful error output, when expected schemas are not found. New output:

![image](https://github.com/Energinet-DataHub/opengeh-wholesale/assets/11583438/a98dafea-7979-4d3c-bf69-16abb2c77c12)

Fix the path to expected schemas so the test works regardless of how the pytest session was started.


## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
