### PR TITLE
refac: Dont write energy in migration_executed fixture

### DIFF
--- a/source/databricks/calculation_engine/tests/conftest.py
+++ b/source/databricks/calculation_engine/tests/conftest.py
@@ -400,6 +400,7 @@ def energy_input_data_written_to_delta(
     spark: SparkSession,
     test_files_folder_path: str,
     calculation_input_path: str,
+    migrations_executed: None,
     test_session_configuration: TestSessionConfiguration,
 ) -> None:
     _write_input_test_data_to_table(

--- a/source/databricks/calculation_engine/tests/conftest.py
+++ b/source/databricks/calculation_engine/tests/conftest.py
@@ -229,7 +229,6 @@ def calculation_output_path(data_lake_path: str) -> str:
 def migrations_executed(
     spark: SparkSession,
     calculation_output_path: str,
-    energy_input_data_written_to_delta: None,
     test_session_configuration: TestSessionConfiguration,
 ) -> None:
     # Execute all migrations


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
