### PR TITLE
fix: Handle start and stop of subscription/fee on the same day

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/explode_charge_price_information_within_periods.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/explode_charge_price_information_within_periods.py
@@ -31,14 +31,11 @@ def explode_charge_price_information_within_periods(
     if resolution != ChargeResolution.HOUR and resolution != ChargeResolution.DAY:
         raise ValueError(f"Unsupported resolution {resolution}")
 
-    charge_price_information_df = charge_price_information.df.filter(
-        f.col(Colname.resolution) == resolution.value
-    )
     explode_with_charge_time = {
         ChargeResolution.DAY: lambda df: _explode_with_daily_charge_time(df, time_zone),
         ChargeResolution.HOUR: lambda df: _explode_with_hourly_charge_time(df),
     }
-    return explode_with_charge_time[resolution](charge_price_information_df)
+    return explode_with_charge_time[resolution](charge_price_information.df)
 
 
 def _explode_with_daily_charge_time(

--- a/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/subscriptions_and_fees.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/subscriptions_and_fees.py
@@ -104,9 +104,6 @@ def _join_with_prices(
     """
     charge_prices = charge_prices.df
 
-    # charge_price_information_with_charge_time = _explode_with_daily_charge_time(
-    #     charge_price_information, time_zone
-    # )
     charge_price_information_with_charge_time = (
         explode_charge_price_information_within_periods(
             charge_price_information, ChargeResolution.DAY, time_zone

--- a/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/subscriptions_and_fees.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/subscriptions_and_fees.py
@@ -114,7 +114,7 @@ def _join_with_prices(
         Colname.charge_time
     )
 
-    master_data_with_prices = (
+    charge_price_information_with_prices = (
         charge_price_information_with_charge_time.join(
             charge_prices, [Colname.charge_key, Colname.charge_time], "left"
         )
@@ -135,36 +135,7 @@ def _join_with_prices(
             Colname.charge_price,
         )
     )
-    return master_data_with_prices
-
-
-def _explode_with_daily_charge_time(
-    charge_price_information: DataFrame, time_zone: str
-) -> DataFrame:
-    """
-    Add charge_time column to charge_periods DataFrame.
-    The charge_time column is created by exploding charge_periods using from_date and to_date with a resolution of 1 day.
-    """
-
-    charge_periods_with_charge_time = (
-        charge_price_information.withColumn(
-            Colname.charge_time,
-            f.explode(
-                f.sequence(
-                    f.from_utc_timestamp(Colname.from_date, time_zone),
-                    f.from_utc_timestamp(Colname.to_date, time_zone),
-                    f.expr("interval 1 day"),
-                )
-            ),
-        )
-        .withColumn(
-            Colname.charge_time,
-            f.to_utc_timestamp(Colname.charge_time, time_zone),
-        )
-        .where(f.col(Colname.charge_time) < f.col(Colname.to_date))
-    )
-
-    return charge_periods_with_charge_time
+    return charge_price_information_with_prices
 
 
 def _join_with_links(

--- a/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/subscriptions_and_fees.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/subscriptions_and_fees.py
@@ -17,7 +17,10 @@ from pyspark.sql import Window
 from pyspark.sql.dataframe import DataFrame
 
 import package.calculation.preparation.data_structures as d
-from package.codelists import ChargeType, WholesaleResultResolution
+from package.calculation.preparation.transformations.charge_types.explode_charge_price_information_within_periods import (
+    explode_charge_price_information_within_periods,
+)
+from package.codelists import ChargeType, WholesaleResultResolution, ChargeResolution
 from package.constants import Colname
 
 
@@ -100,10 +103,14 @@ def _join_with_prices(
     - The charge price is the last known charge price for the charge key.
     """
     charge_prices = charge_prices.df
-    charge_price_information = charge_price_information.df
 
-    charge_price_information_with_charge_time = _explode_with_daily_charge_time(
-        charge_price_information, time_zone
+    # charge_price_information_with_charge_time = _explode_with_daily_charge_time(
+    #     charge_price_information, time_zone
+    # )
+    charge_price_information_with_charge_time = (
+        explode_charge_price_information_within_periods(
+            charge_price_information, ChargeResolution.DAY, time_zone
+        )
     )
 
     w = Window.partitionBy(Colname.charge_key, Colname.from_date).orderBy(
@@ -142,18 +149,22 @@ def _explode_with_daily_charge_time(
     The charge_time column is created by exploding charge_periods using from_date and to_date with a resolution of 1 day.
     """
 
-    charge_periods_with_charge_time = charge_price_information.withColumn(
-        Colname.charge_time,
-        f.explode(
-            f.sequence(
-                f.from_utc_timestamp(Colname.from_date, time_zone),
-                f.from_utc_timestamp(Colname.to_date, time_zone),
-                f.expr("interval 1 day"),
-            )
-        ),
-    ).withColumn(
-        Colname.charge_time,
-        f.to_utc_timestamp(Colname.charge_time, time_zone),
+    charge_periods_with_charge_time = (
+        charge_price_information.withColumn(
+            Colname.charge_time,
+            f.explode(
+                f.sequence(
+                    f.from_utc_timestamp(Colname.from_date, time_zone),
+                    f.from_utc_timestamp(Colname.to_date, time_zone),
+                    f.expr("interval 1 day"),
+                )
+            ),
+        )
+        .withColumn(
+            Colname.charge_time,
+            f.to_utc_timestamp(Colname.charge_time, time_zone),
+        )
+        .where(f.col(Colname.charge_time) < f.col(Colname.to_date))
     )
 
     return charge_periods_with_charge_time

--- a/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/tariffs.py
+++ b/source/databricks/calculation_engine/package/calculation/preparation/transformations/charge_types/tariffs.py
@@ -76,65 +76,37 @@ def _join_price_information_periods_and_prices_add_missing_prices(
     time_zone: str,
 ) -> DataFrame:
     charge_prices = charge_prices.df
-    charge_price_information_filtered = charge_price_information.df.filter(
-        f.col(Colname.resolution) == resolution.value
+
+    charge_price_information = ChargePriceInformation(
+        charge_price_information.df.filter(
+            f.col(Colname.resolution) == resolution.value
+        )
     )
 
-    charges_with_no_prices = get_charges_with_no_prices(
-        charge_price_information_filtered, resolution, time_zone
+    charge_price_information_with_charge_time = (
+        explode_charge_price_information_within_periods(
+            charge_price_information, resolution, time_zone
+        )
     )
 
-    charges_with_prices_and_missing_prices = charges_with_no_prices.join(
-        charge_prices, [Colname.charge_key, Colname.charge_time], "left"
-    ).select(
-        charges_with_no_prices[Colname.charge_key],
-        charges_with_no_prices[Colname.charge_code],
-        charges_with_no_prices[Colname.charge_type],
-        charges_with_no_prices[Colname.charge_owner],
-        charges_with_no_prices[Colname.charge_tax],
-        charges_with_no_prices[Colname.resolution],
-        charges_with_no_prices[Colname.charge_time],
-        charges_with_no_prices[Colname.from_date],
-        charges_with_no_prices[Colname.to_date],
-        Colname.charge_price,
+    charges_with_prices_and_missing_prices = (
+        charge_price_information_with_charge_time.join(
+            charge_prices, [Colname.charge_key, Colname.charge_time], "left"
+        ).select(
+            charge_price_information_with_charge_time[Colname.charge_key],
+            charge_price_information_with_charge_time[Colname.charge_code],
+            charge_price_information_with_charge_time[Colname.charge_type],
+            charge_price_information_with_charge_time[Colname.charge_owner],
+            charge_price_information_with_charge_time[Colname.charge_tax],
+            charge_price_information_with_charge_time[Colname.resolution],
+            charge_price_information_with_charge_time[Colname.charge_time],
+            charge_price_information_with_charge_time[Colname.from_date],
+            charge_price_information_with_charge_time[Colname.to_date],
+            Colname.charge_price,
+        )
     )
 
     return charges_with_prices_and_missing_prices
-
-
-def get_charges_with_no_prices(
-    charge_price_information_filtered: DataFrame,
-    resolution: ChargeResolution,
-    time_zone: str,
-) -> DataFrame:
-    if resolution == ChargeResolution.HOUR:
-        return charge_price_information_filtered.withColumn(
-            Colname.charge_time,
-            f.explode(
-                f.sequence(
-                    Colname.from_date,
-                    Colname.to_date,
-                    f.expr("interval 1 hour"),
-                )
-            ),
-        )
-    elif resolution == ChargeResolution.DAY:
-        # When resolution is DAY we need to deal with local time to get the correct start time of each day
-        return charge_price_information_filtered.withColumn(
-            Colname.charge_time,
-            f.explode(
-                # Create a sequence of the start of each day in the period. The times are local time
-                f.sequence(
-                    f.from_utc_timestamp(Colname.from_date, time_zone),
-                    f.from_utc_timestamp(Colname.to_date, time_zone),
-                    f.expr("interval 1 day"),
-                )
-            ),
-            # Convert local day start times back to UTC
-        ).withColumn(
-            Colname.charge_time,
-            f.to_utc_timestamp(Colname.charge_time, time_zone),
-        )
 
 
 def _join_with_charge_link_metering_points(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Fees and subscriptions now uses the same method as tariffs to explode charge_price_information based on charge_resolution. By doing this we fix an issue with duplicate charge_times in the explode method.
## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
