### PR TITLE
chore: Add padding to filegenerators for gridarea fields

### DIFF
--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/SettlementReports_v2/Generators/EnergyResultFileGenerator.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/SettlementReports_v2/Generators/EnergyResultFileGenerator.cs
@@ -47,7 +47,7 @@ public sealed class EnergyResultFileGenerator : CsvFileGeneratorBase<SettlementR
             Map(r => r.GridAreaCode)
                 .Name("METERINGGRIDAREAID")
                 .Index(0)
-                .Convert(row => row.Value.GridAreaCode);
+                .Convert(row => row.Value.GridAreaCode.PadLeft(3, '0'));
 
             Map(r => r.EnergyBusinessProcess)
                 .Name("ENERGYBUSINESSPROCESS")

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/SettlementReports_v2/Generators/MeteringPointMasterDataFileGenerator.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/SettlementReports_v2/Generators/MeteringPointMasterDataFileGenerator.cs
@@ -57,15 +57,18 @@ public sealed class MeteringPointMasterDataFileGenerator : CsvFileGeneratorBase<
 
             Map(r => r.GridAreaId)
                 .Name("GRIDAREAID")
-                .Index(3);
+                .Index(3)
+                .Convert(row => row.Value.GridAreaId.PadLeft(3, '0'));
 
             Map(r => r.GridAreaToId)
                 .Name("TOGRIDAREAID")
-                .Index(4);
+                .Index(4)
+                .Convert(row => row.Value.GridAreaToId?.PadLeft(3, '0'));
 
             Map(r => r.GridAreaFromId)
                 .Name("FROMGRIDAREAID")
-                .Index(5);
+                .Index(5)
+                .Convert(row => row.Value.GridAreaFromId?.PadLeft(3, '0'));
 
             Map(r => r.MeteringPointType)
                 .Name("TYPEOFMP")

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/SettlementReports_v2/Generators/MonthlyAmountFileGenerator.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/SettlementReports_v2/Generators/MonthlyAmountFileGenerator.cs
@@ -54,7 +54,8 @@ public sealed class MonthlyAmountFileGenerator : CsvFileGeneratorBase<Settlement
 
             Map(r => r.GridArea)
                 .Name("METERINGGRIDAREAID")
-                .Index(2);
+                .Index(2)
+                .Convert(row => row.Value.GridArea?.PadLeft(3, '0'));
 
             Map(r => r.EnergySupplierId)
                 .Name("ENERGYSUPPLIERID")

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/SettlementReports_v2/Generators/WholesaleResultFileGenerator.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/SettlementReports_v2/Generators/WholesaleResultFileGenerator.cs
@@ -56,7 +56,8 @@ public sealed class WholesaleResultFileGenerator : CsvFileGeneratorBase<Settleme
 
             Map(r => r.GridArea)
                 .Name("METERINGGRIDAREAID")
-                .Index(2);
+                .Index(2)
+                .Convert(row => row.Value.GridArea?.PadLeft(3, '0'));
 
             Map(r => r.EnergySupplierId)
                 .Name("ENERGYSUPPLIERID")

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/SettlementReports_v2/Statements/SettlementReportChargeLinkPeriodsCountQueryStatement.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/SettlementReports_v2/Statements/SettlementReportChargeLinkPeriodsCountQueryStatement.cs
@@ -40,8 +40,8 @@ public sealed class SettlementReportChargeLinkPeriodsCountQueryStatement : Datab
                     WHERE
                         {SettlementReportChargeLinkPeriodsViewColumns.GridArea} = '{SqlStringSanitizer.Sanitize(_filter.GridAreaCode)}' AND
                         {SettlementReportChargeLinkPeriodsViewColumns.CalculationType} = '{CalculationTypeMapper.ToDeltaTableValue(_filter.CalculationType)}' AND
-                        ({SettlementReportChargeLinkPeriodsViewColumns.FromDate}<= '{_filter.PeriodEnd}' AND
-                        {SettlementReportChargeLinkPeriodsViewColumns.ToDate}>= '{_filter.PeriodStart}') AND
+                        ({SettlementReportChargeLinkPeriodsViewColumns.FromDate} <= '{_filter.PeriodEnd}' AND
+                        {SettlementReportChargeLinkPeriodsViewColumns.ToDate} >= '{_filter.PeriodStart}') AND
                         {(_filter.EnergySupplier is null ? string.Empty : SettlementReportChargeLinkPeriodsViewColumns.EnergySupplierId + " = '" + SqlStringSanitizer.Sanitize(_filter.EnergySupplier) + "' AND")} 
                         {SettlementReportChargeLinkPeriodsViewColumns.CalculationId} = '{_filter.CalculationId}'
                 """;

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Application/SettlementReports/SettlementReportFileRequestHandlerIntegrationTests.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Application/SettlementReports/SettlementReportFileRequestHandlerIntegrationTests.cs
@@ -339,7 +339,12 @@ public sealed class SettlementReportFileRequestHandlerIntegrationTests : TestBas
         // Arrange
         var calculationId = Guid.Parse("f8af5e30-3c65-439e-8fd0-1da0c40a26de");
         var filter = new SettlementReportRequestFilterDto(
-            _gridAreaCodes.ToDictionary(x => x, _ => (CalculationId?)new CalculationId(calculationId)),
+            new Dictionary<string, CalculationId?>
+            {
+                {
+                    "4", new CalculationId(calculationId)
+                },
+            },
             _january1St.ToDateTimeOffset(),
             _january5Th.ToDateTimeOffset(),
             CalculationType.FirstCorrectionSettlement,
@@ -358,8 +363,8 @@ public sealed class SettlementReportFileRequestHandlerIntegrationTests : TestBas
         await _databricksSqlStatementApiFixture.DatabricksSchemaManager.InsertAsync<SettlementReportMonthlyAmountViewColumns>(
             _databricksSqlStatementApiFixture.DatabricksSchemaManager.DeltaTableOptions.Value.MONTHLY_AMOUNTS_V1_VIEW_NAME,
             [
-                ["'f8af5e30-3c65-439e-8fd0-1da0c40a26de'", "'first_correction_settlement'", "'15cba911-b91e-4782-bed4-f0d2841829e1'", "'018'", "8397670583196", "'2022-01-02T02:00:00.000+00:00'", "'PT1H'", "'kWh'", "'DKK'", "18.012345", "'tariff'", "'123'", "8397670583197" ],
-                ["'f8af5e30-3c65-439e-8fd0-1da0c40a26de'", "'first_correction_settlement'", "'15cba911-b91e-4782-bed4-f0d2841829e2'", "'018'", "8397670583196", "'2022-01-02T04:00:00.000+00:00'", "'P1D'", "'pcs'", "'DKK'", "18.012346", "'subscription'", "'122'", "8397670583197" ],
+                ["'f8af5e30-3c65-439e-8fd0-1da0c40a26de'", "'first_correction_settlement'", "'15cba911-b91e-4782-bed4-f0d2841829e1'", "'4'", "8397670583196", "'2022-01-02T02:00:00.000+00:00'", "'PT1H'", "'kWh'", "'DKK'", "18.012345", "'tariff'", "'123'", "8397670583197" ],
+                ["'f8af5e30-3c65-439e-8fd0-1da0c40a26de'", "'first_correction_settlement'", "'15cba911-b91e-4782-bed4-f0d2841829e2'", "'4'", "8397670583196", "'2022-01-02T04:00:00.000+00:00'", "'P1D'", "'pcs'", "'DKK'", "18.012346", "'subscription'", "'122'", "8397670583197" ],
             ]);
 
         // Act
@@ -379,10 +384,10 @@ public sealed class SettlementReportFileRequestHandlerIntegrationTests : TestBas
             "ENERGYBUSINESSPROCESS,PROCESSVARIANT,METERINGGRIDAREAID,ENERGYSUPPLIERID,STARTDATETIME,RESOLUTIONDURATION,MEASUREUNIT,ENERGYCURRENCY,AMOUNT,CHARGETYPE,CHARGETYPEID,CHARGETYPEOWNERID",
             fileLines[0]);
         Assert.Equal(
-            "D32,1ST,018,8397670583196,2022-01-02T02:00:00Z,PT1H,KWH,DKK,18.012345,D03,123,8397670583197",
+            "D32,1ST,004,8397670583196,2022-01-02T02:00:00Z,PT1H,KWH,DKK,18.012345,D03,123,8397670583197",
             fileLines[1]);
         Assert.Equal(
-            "D32,1ST,018,8397670583196,2022-01-02T04:00:00Z,P1D,PCS,DKK,18.012346,D01,122,8397670583197",
+            "D32,1ST,004,8397670583196,2022-01-02T04:00:00Z,P1D,PCS,DKK,18.012346,D01,122,8397670583197",
             fileLines[2]);
     }
 }


### PR DESCRIPTION
# Description

We need to ensure that all grid area values in the basis data CSV files are always 3 characters in length, padded with 0'es if they are less.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
