### PR TITLE
feat: Add `--simulation` flag for calculation invocation

### DIFF
--- a/source/databricks/calculation_engine/contracts/calculation-job-parameters-reference.txt
+++ b/source/databricks/calculation_engine/contracts/calculation-job-parameters-reference.txt
@@ -11,4 +11,5 @@
 --period-end-datetime=2022-06-01T22:00:00Z
 --calculation-type=balance_fixing
 --created-by-user-id=c2975345-d935-44a2-b7bf-2629db4aa8bf
---is-simulation=false
+# It's a flag: True if present, otherwise false
+--simulation

--- a/source/databricks/calculation_engine/contracts/calculation-job-parameters-reference.txt
+++ b/source/databricks/calculation_engine/contracts/calculation-job-parameters-reference.txt
@@ -11,3 +11,4 @@
 --period-end-datetime=2022-06-01T22:00:00Z
 --calculation-type=balance_fixing
 --created-by-user-id=c2975345-d935-44a2-b7bf-2629db4aa8bf
+--is-simulation=false

--- a/source/databricks/calculation_engine/package/calculation/calculator_args.py
+++ b/source/databricks/calculation_engine/package/calculation/calculator_args.py
@@ -31,3 +31,4 @@ class CalculatorArgs:
     created_by_user_id: str
     time_zone: str
     quarterly_resolution_transition_datetime: datetime
+    is_simulation: bool

--- a/source/databricks/calculation_engine/package/calculator_job.py
+++ b/source/databricks/calculation_engine/package/calculator_job.py
@@ -80,6 +80,9 @@ def start_with_deps(
             args, infrastructure_settings = parse_job_args(command_line_args)
             create_and_configure_container(infrastructure_settings)
 
+            if args.is_simulation:
+                raise NotImplementedError("Simulation is not implemented.")
+
             spark = initialize_spark()
             prepared_data_reader = create_prepared_data_reader(
                 infrastructure_settings, spark

--- a/source/databricks/calculation_engine/package/calculator_job_args.py
+++ b/source/databricks/calculation_engine/package/calculator_job_args.py
@@ -74,7 +74,7 @@ def parse_job_arguments(
             created_by_user_id=job_args.created_by_user_id,
             time_zone=time_zone,
             quarterly_resolution_transition_datetime=quarterly_resolution_transition_datetime,
-            is_simulation=job_args.is_simulation,
+            is_simulation=job_args.simulation,
         )
 
         storage_account_name = env_vars.get_storage_account_name()
@@ -110,7 +110,7 @@ def _parse_args_or_throw(command_line_args: list[str]) -> argparse.Namespace:
     p.add("--period-end-datetime", type=valid_date, required=True)
     p.add("--calculation-type", type=CalculationType, required=True)
     p.add("--created-by-user-id", type=str, required=True)
-    p.add("--is-simulation", type=bool, required=False, default=False)
+    p.add("--simulation", action="store_true")  # Flag, true if present, false otherwise
     # Infrastructure settings
     p.add("--calculation_input_folder_name", type=str, required=False)
     p.add("--time_series_points_table_name", type=str, required=False)

--- a/source/databricks/calculation_engine/package/calculator_job_args.py
+++ b/source/databricks/calculation_engine/package/calculator_job_args.py
@@ -74,6 +74,7 @@ def parse_job_arguments(
             created_by_user_id=job_args.created_by_user_id,
             time_zone=time_zone,
             quarterly_resolution_transition_datetime=quarterly_resolution_transition_datetime,
+            is_simulation=job_args.is_simulation,
         )
 
         storage_account_name = env_vars.get_storage_account_name()
@@ -109,6 +110,7 @@ def _parse_args_or_throw(command_line_args: list[str]) -> argparse.Namespace:
     p.add("--period-end-datetime", type=valid_date, required=True)
     p.add("--calculation-type", type=CalculationType, required=True)
     p.add("--created-by-user-id", type=str, required=True)
+    p.add("--is-simulation", type=bool, required=False, default=False)
     # Infrastructure settings
     p.add("--calculation_input_folder_name", type=str, required=False)
     p.add("--time_series_points_table_name", type=str, required=False)
@@ -140,8 +142,9 @@ def _validate_quarterly_resolution_transition_datetime(
             f"The quarterly resolution transition datetime must be at midnight local time ({time_zone})."
         )
     if (
-        calculation_period_start_datetime < quarterly_resolution_transition_datetime
-        and calculation_period_end_datetime > quarterly_resolution_transition_datetime
+        calculation_period_start_datetime
+        < quarterly_resolution_transition_datetime
+        < calculation_period_end_datetime
     ):
         raise Exception(
             "The calculation period must not cross the quarterly resolution transition datetime."

--- a/source/databricks/calculation_engine/tests/calculation/basis_data/basis_data_test_factory.py
+++ b/source/databricks/calculation_engine/tests/calculation/basis_data/basis_data_test_factory.py
@@ -213,6 +213,7 @@ def create_calculation_args() -> CalculatorArgs:
         time_zone=DefaultValues.TIME_ZONE,
         quarterly_resolution_transition_datetime=DefaultValues.QUARTERLY_RESOLUTION_TRANSITION_DATETIME,
         created_by_user_id=DefaultValues.CREATED_BY_USER_ID,
+        is_simulation=False,
     )
 
 

--- a/source/databricks/calculation_engine/tests/calculation/energy/test_resolution_transition_factory.py
+++ b/source/databricks/calculation_engine/tests/calculation/energy/test_resolution_transition_factory.py
@@ -99,6 +99,7 @@ class TestEnergyResultResolutionAdjustedMeteringPointTimeSeries:
             calculation_period_start_datetime=start_datetime,
             calculation_period_end_datetime=end_datetime,
             quarterly_resolution_transition_datetime=transition_datetime,
+            is_simulation=False,
         )
         rows = [
             factory.create_row(

--- a/source/databricks/calculation_engine/tests/calculator_job/conftest.py
+++ b/source/databricks/calculation_engine/tests/calculator_job/conftest.py
@@ -44,6 +44,7 @@ def calculator_args_balance_fixing() -> CalculatorArgs:
         created_by_user_id=str(uuid.uuid4()),
         time_zone="Europe/Copenhagen",
         quarterly_resolution_transition_datetime=datetime(2023, 1, 31, 23, 0, 0),
+        is_simulation=False,
     )
 
 

--- a/source/databricks/calculation_engine/tests/conftest.py
+++ b/source/databricks/calculation_engine/tests/conftest.py
@@ -352,6 +352,7 @@ def any_calculator_args() -> CalculatorArgs:
         created_by_user_id=str(uuid.uuid4()),
         time_zone="Europe/Copenhagen",
         quarterly_resolution_transition_datetime=datetime(2023, 1, 31, 23, 0, 0),
+        is_simulation=False,
     )
 
 
@@ -367,6 +368,7 @@ def any_calculator_args_for_wholesale() -> CalculatorArgs:
         created_by_user_id=str(uuid.uuid4()),
         time_zone="Europe/Copenhagen",
         quarterly_resolution_transition_datetime=datetime(2023, 1, 31, 23, 0, 0),
+        is_simulation=False,
     )
 
 

--- a/source/databricks/calculation_engine/tests/features/utils/calculation_args.py
+++ b/source/databricks/calculation_engine/tests/features/utils/calculation_args.py
@@ -61,4 +61,5 @@ def create_calculation_args(input_path: str) -> CalculatorArgs:
         created_by_user_id=calculation_args[Colname.created_by_user_id],
         time_zone=time_zone,
         quarterly_resolution_transition_datetime=quarterly_resolution_transition_datetime,
+        is_simulation=False,
     )

--- a/source/databricks/calculation_engine/tests/infrastructure/test_get_calculator_args.py
+++ b/source/databricks/calculation_engine/tests/infrastructure/test_get_calculator_args.py
@@ -417,11 +417,48 @@ class TestWhenQuarterlyResolutionTransitionDatetimeIsValid:
                     pytest.fail(f"An unexpected exception was raised: {error}")
 
 
+class TestWhenIsSimulationFlagPresent:
+    def test_simulation_is_true(
+        self,
+        job_environment_variables: dict,
+        sys_argv_from_contract: list[str],
+    ) -> None:
+        # Arrange
+        with patch("sys.argv", sys_argv_from_contract):
+            with patch.dict("os.environ", job_environment_variables):
+                command_line_args = parse_command_line_arguments()
+
+                # Act
+                actual_args, actual_settings = parse_job_arguments(command_line_args)
+
+        # Assert
+        assert actual_args.is_simulation
+
+
+class TestWhenIsSimulationFlagNotPresent:
+    def test_simulation_is_false(
+        self,
+        job_environment_variables: dict,
+        sys_argv_from_contract: list[str],
+    ) -> None:
+        # Arrange
+        sys_argv_from_contract.remove("--simulation")
+        with patch("sys.argv", sys_argv_from_contract):
+            with patch.dict("os.environ", job_environment_variables):
+                command_line_args = parse_command_line_arguments()
+
+                # Act
+                actual_args, actual_settings = parse_job_arguments(command_line_args)
+
+        # Assert
+        assert not actual_args.is_simulation
+
+
 class TestWhenQuarterlyResolutionTransitionDatetimeIsInvalid:
     def test_when_within_period_raise_exception_for_calculation(
         self,
         job_environment_variables: dict,
-        sys_argv_from_contract,
+        sys_argv_from_contract: list[str],
     ) -> None:
         # Arrange
         period_start_datetime = datetime(2023, 1, 30, 23)
@@ -451,7 +488,7 @@ class TestWhenQuarterlyResolutionTransitionDatetimeIsInvalid:
     def test_when_not_local_midnight_raise_exception_for_calculation(
         self,
         job_environment_variables: dict,
-        sys_argv_from_contract,
+        sys_argv_from_contract: list[str],
     ) -> None:
         # Arrange
         quarter_transition_datetime = "2023-01-31T22:00:00Z"


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

NOTE: This enables setting the flag from outside. Simulation is, however, not implemented and the calculation will throw an exception if a simulation is started.

This enables Mosaic to implement their part of simulation invocation when they fancy it.

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
