### PR TITLE
refac: Pre-fix charge basis data schema to 'hive_

### DIFF
--- a/source/databricks/calculation_engine/package/calculation/basis_data/schemas/__init__.py
+++ b/source/databricks/calculation_engine/package/calculation/basis_data/schemas/__init__.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from .calculations_schema import calculations_schema
-from .charge_link_periods_schema import charge_link_periods_schema
+from .charge_link_periods_schema import hive_charge_link_periods_schema
 from .charge_price_information_periods_schema import (
-    charge_price_information_periods_schema,
+    hive_charge_price_information_periods_schema,
 )
 from .charge_price_points_schema import charge_price_points_schema
 from .grid_loss_metering_points_schema import (

--- a/source/databricks/calculation_engine/package/calculation/basis_data/schemas/charge_link_periods_schema.py
+++ b/source/databricks/calculation_engine/package/calculation/basis_data/schemas/charge_link_periods_schema.py
@@ -20,7 +20,7 @@ from pyspark.sql.types import (
     StructType,
 )
 
-charge_link_periods_schema = StructType(
+hive_charge_link_periods_schema = StructType(
     [
         StructField("calculation_id", StringType(), False),
         StructField("charge_key", StringType(), False),

--- a/source/databricks/calculation_engine/package/calculation/basis_data/schemas/charge_price_information_periods_schema.py
+++ b/source/databricks/calculation_engine/package/calculation/basis_data/schemas/charge_price_information_periods_schema.py
@@ -20,7 +20,7 @@ from pyspark.sql.types import (
     StructType,
 )
 
-charge_price_information_periods_schema = StructType(
+hive_charge_price_information_periods_schema = StructType(
     [
         StructField("calculation_id", StringType(), False),
         StructField("charge_key", StringType(), False),

--- a/source/databricks/calculation_engine/package/datamigration_hive/schema_config.py
+++ b/source/databricks/calculation_engine/package/datamigration_hive/schema_config.py
@@ -85,11 +85,11 @@ schema_config = [
             ),
             Table(
                 name=paths.HiveBasisDataDatabase.CHARGE_LINK_PERIODS_TABLE_NAME,
-                schema=basis_data_schemas.charge_link_periods_schema,
+                schema=basis_data_schemas.hive_charge_link_periods_schema,
             ),
             Table(
                 name=paths.HiveBasisDataDatabase.CHARGE_PRICE_INFORMATION_PERIODS_TABLE_NAME,
-                schema=basis_data_schemas.charge_price_information_periods_schema,
+                schema=basis_data_schemas.hive_charge_price_information_periods_schema,
             ),
             Table(
                 name=paths.HiveBasisDataDatabase.CHARGE_PRICE_POINTS_TABLE_NAME,

--- a/source/databricks/calculation_engine/tests/calculation/basis_data/basis_data_test_factory.py
+++ b/source/databricks/calculation_engine/tests/calculation/basis_data/basis_data_test_factory.py
@@ -23,10 +23,10 @@ from calculation.output.calculations_storage_model_test_factory import (
     create_calculations,
 )
 from package.calculation.basis_data.schemas.charge_link_periods_schema import (
-    charge_link_periods_schema,
+    hive_charge_link_periods_schema,
 )
 from package.calculation.basis_data.schemas.charge_price_information_periods_schema import (
-    charge_price_information_periods_schema,
+    hive_charge_price_information_periods_schema,
 )
 from package.calculation.basis_data.schemas.charge_price_points_schema import (
     charge_price_points_schema,
@@ -177,7 +177,7 @@ def create_charge_price_information(
         data = [create_charge_price_information_row()]
     elif isinstance(data, Row):
         data = [data]
-    df = spark.createDataFrame(data, charge_price_information_periods_schema)
+    df = spark.createDataFrame(data, hive_charge_price_information_periods_schema)
     return ChargePriceInformation(df)
 
 
@@ -199,7 +199,7 @@ def create_charge_links(
         data = [create_charge_link_row()]
     elif isinstance(data, Row):
         data = [data]
-    return spark.createDataFrame(data, charge_link_periods_schema)
+    return spark.createDataFrame(data, hive_charge_link_periods_schema)
 
 
 def create_calculation_args() -> CalculatorArgs:

--- a/source/databricks/calculation_engine/tests/calculation/basis_data/test_basis_data_factory.py
+++ b/source/databricks/calculation_engine/tests/calculation/basis_data/test_basis_data_factory.py
@@ -16,10 +16,10 @@ from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType
 
 from package.calculation.basis_data.schemas.charge_link_periods_schema import (
-    charge_link_periods_schema,
+    hive_charge_link_periods_schema,
 )
 from package.calculation.basis_data.schemas.charge_price_information_periods_schema import (
-    charge_price_information_periods_schema,
+    hive_charge_price_information_periods_schema,
 )
 from package.calculation.basis_data.schemas.charge_price_points_schema import (
     charge_price_points_schema,
@@ -49,10 +49,10 @@ from tests.calculation.basis_data.basis_data_test_factory import (
             "time_series_points",
             time_series_point_schema,
         ),
-        ("charge_link_periods", charge_link_periods_schema),
+        ("charge_link_periods", hive_charge_link_periods_schema),
         (
             "charge_price_information_periods",
-            charge_price_information_periods_schema,
+            hive_charge_price_information_periods_schema,
         ),
         ("charge_price_points", charge_price_points_schema),
         (

--- a/source/databricks/calculation_engine/tests/calculator_job/test_wholesale_calculation.py
+++ b/source/databricks/calculation_engine/tests/calculator_job/test_wholesale_calculation.py
@@ -18,10 +18,10 @@ from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import StructType
 
 from package.calculation.basis_data.schemas.charge_link_periods_schema import (
-    charge_link_periods_schema,
+    hive_charge_link_periods_schema,
 )
 from package.calculation.basis_data.schemas.charge_price_information_periods_schema import (
-    charge_price_information_periods_schema,
+    hive_charge_price_information_periods_schema,
 )
 from package.calculation.basis_data.schemas.charge_price_points_schema import (
     charge_price_points_schema,
@@ -304,11 +304,11 @@ def test__when_wholesale_calculation__basis_data_is_stored(
         ),
         (
             paths.HiveBasisDataDatabase.CHARGE_LINK_PERIODS_TABLE_NAME,
-            charge_link_periods_schema,
+            hive_charge_link_periods_schema,
         ),
         (
             paths.HiveBasisDataDatabase.CHARGE_PRICE_INFORMATION_PERIODS_TABLE_NAME,
-            charge_price_information_periods_schema,
+            hive_charge_price_information_periods_schema,
         ),
         (
             paths.HiveBasisDataDatabase.CHARGE_PRICE_POINTS_TABLE_NAME,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Prefix introduced so that we can afterwards use the original name for unity catalog. On UC the to_date will be NOT NULL

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
