### PR TITLE
feat: Include is_tax results for charge owners in wholesale requests

### DIFF
--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/AmountsPerChargeWholesaleServicesDatabricksContract.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/AmountsPerChargeWholesaleServicesDatabricksContract.cs
@@ -75,6 +75,11 @@ public class AmountsPerChargeWholesaleServicesDatabricksContract : IWholesaleSer
         return AmountsPerChargeViewColumnNames.CalculationId;
     }
 
+    public string GetIsTaxColumnName()
+    {
+        return AmountsPerChargeViewColumnNames.IsTax;
+    }
+
     public string[] GetColumnsToProject()
     {
         return ColumnsToProjectForAmountsPerCharge;

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/IWholesaleServicesDatabricksContract.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/IWholesaleServicesDatabricksContract.cs
@@ -41,6 +41,8 @@ public interface IWholesaleServicesDatabricksContract
 
     string GetCalculationIdColumnName();
 
+    string GetIsTaxColumnName();
+
     string[] GetColumnsToProject();
 
     string[] GetColumnsToAggregateBy();

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/MonthlyAmountsPerChargeWholesaleServicesDatabricksContract.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/MonthlyAmountsPerChargeWholesaleServicesDatabricksContract.cs
@@ -77,6 +77,11 @@ public class
         return MonthlyAmountsPerChargeViewColumnNames.CalculationId;
     }
 
+    public string GetIsTaxColumnName()
+    {
+        return MonthlyAmountsPerChargeViewColumnNames.IsTax;
+    }
+
     public string[] GetColumnsToProject()
     {
         return ColumnsToProjectForMonthlyAmountsPerCharge;

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/TotalMonthlyAmountWholesaleServicesDatabricksContract.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/TotalMonthlyAmountWholesaleServicesDatabricksContract.cs
@@ -76,6 +76,11 @@ public class TotalMonthlyAmountWholesaleServicesDatabricksContract : IWholesaleS
         return TotalMonthlyAmountsViewColumnNames.CalculationId;
     }
 
+    public string GetIsTaxColumnName()
+    {
+        throw new InvalidOperationException("Oh dear, there is no is_tax for total monthly amounts");
+    }
+
     public string[] GetColumnsToProject()
     {
         return ColumnsToProjectForTotalMonthlyAmounts;

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/WholesaleServicesQueryStatementHelper.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/WholesaleServicesQueryStatementHelper.cs
@@ -187,34 +187,23 @@ public class WholesaleServicesQueryStatementHelper(
                     """;
         }
 
-        if (_queryParameters.RequestedForEnergySupplier)
+        if (_queryParameters.ChargeOwnerId is not null)
         {
-            if (_queryParameters.ChargeOwnerId is not null)
-            {
-                sql += $"""
-                        AND {table}.{GetChargeOwnerIdColumnName()} = '{_queryParameters.ChargeOwnerId}'
-                        """;
-            }
+            sql += $"""
+                    AND {table}.{GetChargeOwnerIdColumnName()} = '{_queryParameters.ChargeOwnerId}'
+                    """;
         }
-        else
+
+        if (_queryParameters is { RequestedForEnergySupplier: false, ChargeOwnerId: null })
         {
-            if (_queryParameters.ChargeOwnerId is not null)
-            {
-                sql += $"""
-                        AND {table}.{GetChargeOwnerIdColumnName()} = '{_queryParameters.ChargeOwnerId}'
-                        """;
-            }
-            else
-            {
-                // The following is sufficient, as the validations ensure that the grid area(s) is/are a non-empty,
-                // finite set of grid areas the charge owner owns.
-                // If this assumption changes, then the following should be changed to a more complex query,
-                // to ensure the charge owner only gets 'is_tax' charges from grid areas they own.
-                sql += $"""
-                        AND ({table}.{GetChargeOwnerIdColumnName()} = '{_queryParameters.RequestedForActorNumber}'
-                             OR {table}.{_databricksContract.GetIsTaxColumnName()} = true)
-                        """;
-            }
+            // The following is sufficient, as the validations ensure that the grid area(s) is/are a non-empty,
+            // finite set of grid areas the charge owner owns.
+            // If this assumption changes, then the following should be changed to a more complex query,
+            // to ensure the charge owner only gets 'is_tax' charges from grid areas they own.
+            sql += $"""
+                    AND ({table}.{GetChargeOwnerIdColumnName()} = '{_queryParameters.RequestedForActorNumber}'
+                         OR {table}.{_databricksContract.GetIsTaxColumnName()} = true)
+                    """;
         }
 
         return sql;

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/WholesaleServicesQueryStatementHelper.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/WholesaleServicesQueryStatementHelper.cs
@@ -187,11 +187,34 @@ public class WholesaleServicesQueryStatementHelper(
                     """;
         }
 
-        if (_queryParameters.ChargeOwnerId is not null)
+        if (_queryParameters.RequestedForEnergySupplier)
         {
-            sql += $"""
-                    AND {table}.{GetChargeOwnerIdColumnName()} = '{_queryParameters.ChargeOwnerId}'
-                    """;
+            if (_queryParameters.ChargeOwnerId is not null)
+            {
+                sql += $"""
+                        AND {table}.{GetChargeOwnerIdColumnName()} = '{_queryParameters.ChargeOwnerId}'
+                        """;
+            }
+        }
+        else
+        {
+            if (_queryParameters.ChargeOwnerId is not null)
+            {
+                sql += $"""
+                        AND {table}.{GetChargeOwnerIdColumnName()} = '{_queryParameters.ChargeOwnerId}'
+                        """;
+            }
+            else
+            {
+                // The following is sufficient, as the validations ensure that the grid area(s) is/are a non-empty,
+                // finite set of grid areas the charge owner owns.
+                // If this assumption changes, then the following should be changed to a more complex query,
+                // to ensure the charge owner only gets 'is_tax' charges from grid areas they own.
+                sql += $"""
+                        AND ({table}.{GetChargeOwnerIdColumnName()} = '{_queryParameters.RequestedForActorNumber}'
+                             OR {table}.{_databricksContract.GetIsTaxColumnName()} = true)
+                        """;
+            }
         }
 
         return sql;

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Infrastructure/RequestCalculationResult/WholesaleServicesQueriesCsvTests.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Infrastructure/RequestCalculationResult/WholesaleServicesQueriesCsvTests.cs
@@ -64,7 +64,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: null,
             ChargeTypes: [],
             CalculationType: CalculationType.WholesaleFixing,
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: true,
+            RequestedForActorNumber: "5790000701278");
 
         // Act
         var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -125,8 +127,12 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ]);
     }
 
-    [Fact]
-    public async Task Given_EnergySupplierAndChargeOwnerWithTotalMonthlyAmountAndSecondCorrection_Then_CorrespondingDataReturned()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task
+        Given_EnergySupplierAndChargeOwnerWithTotalMonthlyAmountAndSecondCorrection_Then_CorrespondingDataReturned(
+            bool isEnergySupplier)
     {
         await ClearAndAddDatabricksDataAsync();
 
@@ -141,7 +147,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: "5790000610976",
             ChargeTypes: [],
             CalculationType: CalculationType.SecondCorrectionSettlement,
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: isEnergySupplier,
+            RequestedForActorNumber: isEnergySupplier ? "5790000701278" : "5790000610976");
 
         // Act
         var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -172,7 +180,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: null,
             ChargeTypes: [],
             CalculationType: CalculationType.SecondCorrectionSettlement,
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: true,
+            RequestedForActorNumber: "5790000701278");
 
         // Act
         var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -190,8 +200,11 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ]);
     }
 
-    [Fact]
-    public async Task Given_AllQueryParametersAssignedValuesWithLatestCorrection_Then_LatestCorrectionReturned()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Given_AllQueryParametersAssignedValuesWithLatestCorrection_Then_LatestCorrectionReturned(
+        bool isEnergySupplier)
     {
         await ClearAndAddDatabricksDataAsync();
 
@@ -206,7 +219,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: "5790000432752",
             ChargeTypes: [("EA-003", ChargeType.Tariff)],
             CalculationType: null, // This is how we denote 'latest correction'
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: isEnergySupplier,
+            RequestedForActorNumber: isEnergySupplier ? "5790001687137" : "5790000432752");
 
         // Act
         var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -238,7 +253,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: "5790000432752",
             ChargeTypes: [("EA-003", ChargeType.Tariff)],
             CalculationType: null, // This is how we denote 'latest correction'
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: true,
+            RequestedForActorNumber: "5790001687137");
 
         // Act
         var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -259,7 +276,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: "5790000432752",
             ChargeTypes: [("EA-003", ChargeType.Tariff)],
             CalculationType: null, // This is how we denote 'latest correction'
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: true,
+            RequestedForActorNumber: "5790001687137");
 
         // Act
         actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -279,7 +298,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: "5790000432752",
             ChargeTypes: [],
             CalculationType: null, // This is how we denote 'latest correction'
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: true,
+            RequestedForActorNumber: "5790001687137");
 
         // Act
         actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -292,8 +313,11 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ]);
     }
 
-    [Fact]
-    public async Task Given_ChargeOwnerForSpecificGridAreaAndLatestCorrection_Then_LatestCorrectionReturned()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Given_ChargeOwnerForSpecificGridAreaAndLatestCorrection_Then_LatestCorrectionReturned(
+        bool isEnergySupplier)
     {
         await ClearAndAddDatabricksDataAsync();
 
@@ -301,6 +325,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             Instant.FromUtc(2021, 12, 31, 23, 0),
             Instant.FromUtc(2022, 1, 31, 23, 0));
 
+        // The charge owner case isn't technically possible,
+        // as an energy supplier must always provide an energy supplier.
+        // But we keep the case for completeness.
         var parameters = new WholesaleServicesQueryParameters(
             AmountType: AmountType.AmountPerCharge,
             GridAreaCodes: ["804", "584"],
@@ -308,7 +335,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: "5790000432752",
             ChargeTypes: [],
             CalculationType: null,
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: isEnergySupplier,
+            RequestedForActorNumber: isEnergySupplier ? "5790001687137" : "5790000432752");
 
         // Act
         var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -370,7 +399,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: null,
             ChargeTypes: [("40000", ChargeType.Tariff), ("AB1025", ChargeType.Subscription)],
             CalculationType: CalculationType.SecondCorrectionSettlement,
-            Period: totalPeriod);
+            Period: totalPeriod,
+            false,
+            "5790000432752");
 
         // Act
         var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -381,9 +412,7 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
                 ats.CalculationType, ats.Version, ats.TimeSeriesPoints.Count))
             .Should()
             .BeEquivalentTo([
-                ("543", "5790000701278", "5790000610976", ChargeType.Subscription, "AB1025", AmountType.MonthlyAmountPerCharge, Resolution.Month, (MeteringPointType?)null, (SettlementMethod?)null, CalculationType.SecondCorrectionSettlement, 4, 1),
-
-                ("533", "5790000701278", "5790000432752", ChargeType.Tariff, "40000", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.SecondCorrectionSettlement, 3, 1),
+                ("533", "5790000701278", "5790000432752", ChargeType.Tariff, "40000", AmountType.MonthlyAmountPerCharge, Resolution.Month, (MeteringPointType?)null, (SettlementMethod?)null, CalculationType.SecondCorrectionSettlement, 3, 1),
                 ("533", "5790001095390", "5790000432752", ChargeType.Tariff, "40000", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.SecondCorrectionSettlement, 3, 1),
                 ("543", "5790000701278", "5790000432752", ChargeType.Tariff, "40000", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.SecondCorrectionSettlement, 4, 1),
                 ("543", "5790001095390", "5790000432752", ChargeType.Tariff, "40000", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.SecondCorrectionSettlement, 4, 1),
@@ -393,7 +422,57 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
     }
 
     [Fact]
-    public async Task Given_EnergySupplierOnlyHaveDataForHalfOfThePeriod_Then_DataReturnedWithModifiedPeriod()
+    public async Task
+        Given_ChargeOwnerRequestsWithoutChargeOwnerOrEnergySupplier_Then_DataReturnedContainsChargeOwnerChargesAndIsTaxCharges()
+    {
+        await ClearAndAddDatabricksDataAsync();
+
+        var totalPeriod = new Period(
+            Instant.FromUtc(2021, 12, 31, 23, 0),
+            Instant.FromUtc(2022, 1, 31, 23, 0));
+
+        var parameters = new WholesaleServicesQueryParameters(
+            AmountType: AmountType.MonthlyAmountPerCharge,
+            GridAreaCodes: ["804"],
+            EnergySupplierId: null,
+            ChargeOwnerId: null,
+            ChargeTypes: [],
+            CalculationType: null, // This is how we denote 'latest correction'
+            Period: totalPeriod,
+            RequestedForEnergySupplier: false,
+            RequestedForActorNumber: "8100000000047");
+
+        // Act
+        var actual = await Sut.GetAsync(parameters).ToListAsync();
+
+        using var assertionScope = new AssertionScope();
+        actual.Select(ats => (ats.GridArea, ats.EnergySupplierId, ats.ChargeOwnerId, ats.ChargeType, ats.ChargeCode,
+                ats.AmountType, ats.Resolution, ats.MeteringPointType, ats.SettlementMethod, ats.CalculationType,
+                ats.Version, ats.TimeSeriesPoints.Count))
+            .Should()
+            .BeEquivalentTo([
+                // Tax charges for grid area
+                ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-001", AmountType.MonthlyAmountPerCharge, Resolution.Month, (MeteringPointType?)null, (SettlementMethod?)null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-002", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-003", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                // Charge owners own charges
+                ("804", "5790001687137", "8100000000047", ChargeType.Tariff, "100", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                ("804", "5790000701278", "8100000000047", ChargeType.Tariff, "4300", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                ("804", "5790001687137", "8100000000047", ChargeType.Tariff, "4300", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                ("804", "5790001687137", "8100000000047", ChargeType.Tariff, "Rabat-T", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                ("804", "5790001687137", "8100000000047", ChargeType.Tariff, "Tarif_Ny", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                ("804", "5790001687137", "8100000000047", ChargeType.Subscription, "100", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                ("804", "5790000701278", "8100000000047", ChargeType.Subscription, "4310", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                ("804", "5790001687137", "8100000000047", ChargeType.Subscription, "4310", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                ("804", "5790001687137", "8100000000047", ChargeType.Subscription, "Abb Flex", AmountType.MonthlyAmountPerCharge, Resolution.Month, null, null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+            ]);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Given_EnergySupplierOnlyHaveDataForHalfOfThePeriod_Then_DataReturnedWithModifiedPeriod(
+        bool isEnergySupplier)
     {
         /*
          Business case example:
@@ -416,7 +495,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: "5790000432752",
             ChargeTypes: [("EA-001", ChargeType.Tariff)],
             CalculationType: CalculationType.SecondCorrectionSettlement,
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: isEnergySupplier,
+            RequestedForActorNumber: isEnergySupplier ? "5790001687137" : "5790000432752");
 
         // Act
         var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -453,7 +534,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: "5790000432752",
             ChargeTypes: [("EA-001", ChargeType.Tariff)],
             CalculationType: CalculationType.SecondCorrectionSettlement,
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: true,
+            RequestedForActorNumber: "5790001687137");
 
         // Act
         var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -514,7 +597,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: null,
             ChargeTypes: [],
             CalculationType: null,
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: false,
+            RequestedForActorNumber: "5790000432752");
 
         // Act
         var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -523,8 +608,12 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
         actual.Should().BeEmpty();
     }
 
-    [Fact]
-    public async Task Given_EnergySupplierAndChargeOwnerWithLatestCorrectionButOnlyOneGridAreaWithCorrectionData_Then_DataReturnedForGridArea()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task
+        Given_EnergySupplierAndChargeOwnerWithLatestCorrectionButOnlyOneGridAreaWithCorrectionData_Then_DataReturnedForGridArea(
+            bool isEnergySupplier)
     {
         await ClearAndAddDatabricksDataAsync();
         await RemoveDataForCorrections(["804", "543"]);
@@ -540,7 +629,9 @@ public class WholesaleServicesQueriesCsvTests : TestBase<WholesaleServicesQuerie
             ChargeOwnerId: "5790000432752",
             ChargeTypes: [],
             CalculationType: null,
-            Period: totalPeriod);
+            Period: totalPeriod,
+            RequestedForEnergySupplier: isEnergySupplier,
+            RequestedForActorNumber: isEnergySupplier ? "5790000701278" : "5790000432752");
 
         // Act
         var actual = await Sut.GetAsync(parameters).ToListAsync();

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults/Model/WholesaleResults/WholesaleServicesQueryParameters.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults/Model/WholesaleResults/WholesaleServicesQueryParameters.cs
@@ -23,4 +23,6 @@ public record WholesaleServicesQueryParameters(
     string? ChargeOwnerId,
     List<(string? ChargeCode, ChargeType? ChargeType)> ChargeTypes,
     CalculationType? CalculationType,
-    Period Period);
+    Period Period,
+    bool RequestedForEnergySupplier,
+    string RequestedForActorNumber);

--- a/source/dotnet/wholesale-api/Edi/Factories/WholesaleServicesRequestMapper.cs
+++ b/source/dotnet/wholesale-api/Edi/Factories/WholesaleServicesRequestMapper.cs
@@ -45,7 +45,11 @@ public class WholesaleServicesRequestMapper(DateTimeZone dateTimeZone)
             new Period(
                 periodStart,
                 periodEnd),
-            RequestedCalculationTypeMapper.ToRequestedCalculationType(request.BusinessReason, request.HasSettlementVersion ? request.SettlementVersion : null));
+            RequestedCalculationTypeMapper.ToRequestedCalculationType(
+                request.BusinessReason,
+                request.HasSettlementVersion ? request.SettlementVersion : null),
+            request.RequestedForActorRole,
+            request.RequestedForActorNumber);
     }
 
     private List<ChargeCodeAndType> MapChargeTypes(RepeatedField<Energinet.DataHub.Edi.Requests.ChargeType> chargeTypes)

--- a/source/dotnet/wholesale-api/Edi/Models/WholesaleServicesRequest.cs
+++ b/source/dotnet/wholesale-api/Edi/Models/WholesaleServicesRequest.cs
@@ -21,4 +21,6 @@ public record WholesaleServicesRequest(
     string? ChargeOwnerId,
     List<ChargeCodeAndType> ChargeTypes,
     Period Period,
-    RequestedCalculationType RequestedCalculationType);
+    RequestedCalculationType RequestedCalculationType,
+    string RequestedForActorRole,
+    string RequestedForActorNumber);

--- a/source/dotnet/wholesale-api/Edi/WholesaleServicesRequestHandler.cs
+++ b/source/dotnet/wholesale-api/Edi/WholesaleServicesRequestHandler.cs
@@ -111,7 +111,9 @@ public class WholesaleServicesRequestHandler(
             request.RequestedCalculationType == RequestedCalculationType.LatestCorrection
                 ? null
                 : CalculationTypeMapper.FromRequestedCalculationType(request.RequestedCalculationType),
-            new Period(request.Period.Start, request.Period.End));
+            new Period(request.Period.Start, request.Period.End),
+            request.RequestedForActorRole == DataHubNames.ActorRole.EnergySupplier,
+            request.RequestedForActorNumber);
     }
 
     private async Task<bool> HasDataInAnotherGridAreaAsync(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description
Include is_tax charges in request results for charge owners, when no charge owner is provided as part of request parameters. Only is_tax results for the provided set of grid areas are included. The validation rules ensures, that the charge owner is the owner of all of the grid areas in the requests.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
