### PR TITLE
feat: Avoid truncating pytest test output in CI

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -32,7 +32,7 @@ set -e
 shopt -s extglob
 
 cd source/databricks/calculation_engine/tests/
-coverage run --branch -m pytest -v --junitxml=pytest-results.xml $1
+coverage run --branch -m pytest -vv --junitxml=pytest-results.xml $1
 
 # Create data for threshold evaluation
 coverage json


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Example of test output that was truncated:
![pytest truncated test output](https://github.com/user-attachments/assets/a2689798-eaf3-4215-9232-b9e3e7d52264)


<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
