### PR TITLE
refac: Rename to shared_wholesale_input

### DIFF
--- a/source/databricks/calculation_engine/package/infrastructure/paths.py
+++ b/source/databricks/calculation_engine/package/infrastructure/paths.py
@@ -48,7 +48,7 @@ class InputDatabase:
 
 
 class MigrationsWholesaleDatabase:
-    DATABASE_NAME = "migrations_wholesale"
+    DATABASE_NAME = "shared_wholesale_input"
     METERING_POINT_PERIODS_TABLE_NAME = "metering_point_periods_view_v1"
     TIME_SERIES_POINTS_TABLE_NAME = "time_series_points_view_v1"
     CHARGE_LINK_PERIODS_TABLE_NAME = "charge_link_periods_view_v1"

--- a/source/databricks/calculation_engine/tests/contracts/data_products_databases_and_schemas.py
+++ b/source/databricks/calculation_engine/tests/contracts/data_products_databases_and_schemas.py
@@ -29,7 +29,7 @@ def get_data_product_databases(spark: SparkSession) -> List[Database]:
         "default",
         "schema_migration",
         "wholesale_output",
-        "migrations_wholesale",
+        "shared_wholesale_input",
         "wholesale_input",
         "basis_data",
         "wholesale_basis_data_internal",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

quick change of hardcode "migrations_wholesale" to new "shared_wholesale_input", i will make another PR that makes this not harcoded and fixes other naming inconsistencies 

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
