### PR TITLE
refac: Remove usages of IsNullOrEmpty

### DIFF
--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/AggregatedTimeSeriesQuerySnippetProvider.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/AggregatedTimeSeriesQuerySnippetProvider.cs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.SqlStatements.DeltaTableConstants;
 using Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.SqlStatements.Mappers;
 using Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.SqlStatements.Mappers.EnergyResult;
 using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults.Model.EnergyResults;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.CalculationResults.Statements;
 
@@ -75,7 +73,7 @@ public sealed class AggregatedTimeSeriesQuerySnippetProvider(
                     """;
         }
 
-        if (calculationTypeForGridAreas.IsNullOrEmpty())
+        if (calculationTypeForGridAreas.Count <= 0)
         {
             return """
                    FALSE

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/WholesaleServicesQuerySnippetProvider.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults/Statements/WholesaleServicesQuerySnippetProvider.cs
@@ -15,7 +15,6 @@
 using Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.SqlStatements.Mappers;
 using Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.SqlStatements.Mappers.WholesaleResult;
 using Energinet.DataHub.Wholesale.CalculationResults.Interfaces.CalculationResults.Model.WholesaleResults;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.CalculationResults.Statements;
 
@@ -83,7 +82,7 @@ public sealed class WholesaleServicesQuerySnippetProvider(
                     """;
         }
 
-        if (calculationTypePerGridAreas.IsNullOrEmpty())
+        if (calculationTypePerGridAreas.Count <= 0)
         {
             return """
                    FALSE

--- a/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi/ControllerAuthorizeAttributeTests.cs
+++ b/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi/ControllerAuthorizeAttributeTests.cs
@@ -17,7 +17,7 @@ using Energinet.DataHub.Wholesale.WebApi.V3;
 using Energinet.DataHub.Wholesale.WebApi.V3.Calculation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Routing;
-using Microsoft.IdentityModel.Tokens;
+
 using Xunit;
 
 namespace Energinet.DataHub.Wholesale.WebApi.IntegrationTests.WebApi;
@@ -49,7 +49,7 @@ public class ControllerAuthorizeAttributeTests
                             action.GetCustomAttribute<AllowAnonymousAttribute>() == null)
                     .ToList();
 
-            if (!methods.IsNullOrEmpty())
+            if (methods.Count > 0)
             {
                 methods.ForEach(x => methodsWithoutAuthorizeAttribute.Add($"{x.Name} in {controller.Name}."));
             }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

The method `Microsoft.IdentityModel.Tokens.IsNullOrEmpty` should not be used unless required.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
