### PR TITLE
fix: Fix calculation api endpoints for scheduled calculations

### DIFF
--- a/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/CalculationDtoMapper.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/CalculationDtoMapper.cs
@@ -28,6 +28,7 @@ public class CalculationDtoMapper : ICalculationDtoMapper
             calculation.PeriodEnd.ToDateTimeOffset(),
             calculation.GetResolution(),
             calculation.GetQuantityUnit().ToString(),
+            calculation.ScheduledAt.ToDateTimeOffset(),
             calculation.ExecutionTimeStart?.ToDateTimeOffset(),
             calculation.ExecutionTimeEnd?.ToDateTimeOffset() ?? null,
             MapState(calculation.ExecutionState),

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Persistence/Calculations/CalculationRepository.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Persistence/Calculations/CalculationRepository.cs
@@ -51,8 +51,14 @@ public class CalculationRepository : ICalculationRepository
     {
         var query = _context
             .Calculations
-            .Where(b => minExecutionTimeStart == null || b.ExecutionTimeStart >= minExecutionTimeStart)
-            .Where(b => maxExecutionTimeStart == null || b.ExecutionTimeStart <= maxExecutionTimeStart)
+            // If the calculation's ExecutionTimeStart is null the calculation is not yet started,
+            // and we need to use the ScheduledAt property to filter for instead.
+            .Where(b => minExecutionTimeStart == null
+                        || (b.ExecutionTimeStart == null && b.ScheduledAt >= minExecutionTimeStart)
+                        || b.ExecutionTimeStart >= minExecutionTimeStart)
+            .Where(b => maxExecutionTimeStart == null
+                        || (b.ExecutionTimeStart == null && b.ScheduledAt <= maxExecutionTimeStart)
+                        || b.ExecutionTimeStart <= maxExecutionTimeStart)
             .Where(b => periodEnd == null || b.PeriodStart < periodEnd)
             .Where(b => periodStart == null || b.PeriodEnd > periodStart)
             .Where(b => filterByExecutionState.Count == 0 || filterByExecutionState.Contains(b.ExecutionState))

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Interfaces/Models/CalculationDto.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Interfaces/Models/CalculationDto.cs
@@ -26,6 +26,7 @@ public sealed record CalculationDto(
     DateTimeOffset PeriodEnd,
     string Resolution,
     string Unit,
+    DateTimeOffset ScheduledAt,
     DateTimeOffset? ExecutionTimeStart,
     DateTimeOffset? ExecutionTimeEnd,
     CalculationState ExecutionState,

--- a/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationDto.cs
+++ b/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationDto.cs
@@ -24,6 +24,7 @@ public sealed record CalculationDto(
     DateTimeOffset PeriodEnd,
     string Resolution,
     string Unit,
+    DateTimeOffset ScheduledAt,
     DateTimeOffset? ExecutionTimeStart,
     DateTimeOffset? ExecutionTimeEnd,
     CalculationOrchestrationState OrchestrationState,

--- a/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationDtoMapper.cs
+++ b/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationDtoMapper.cs
@@ -25,6 +25,7 @@ public static class CalculationDtoMapper
             calculation.PeriodEnd,
             calculation.Resolution,
             calculation.Unit,
+            calculation.ScheduledAt,
             calculation.ExecutionTimeStart,
             calculation.ExecutionTimeEnd,
             CalculationOrchestrationStateMapper.MapState(calculation.OrchestrationState),


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

- Fix calculation API not including `ScheduledAt` field
- Fix search endpoint not returning scheduled calculations that hasn't started yet
- [ ] Requires merging BFF PR afterwards: https://github.com/Energinet-DataHub/greenforce-frontend/pull/3449

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [x] Subsystem tests have been tested (by manually deploying to `dev_002`) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/10488125416
