### PR TITLE
fix: Fix missing orchestration state map in Web API

### DIFF
--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/V3/CalculationOrchestrationStateMapperTests.cs
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/V3/CalculationOrchestrationStateMapperTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Wholesale.WebApi.V3.Calculation;
+using FluentAssertions;
+using Xunit;
+
+namespace Energinet.DataHub.Wholesale.WebApi.UnitTests.WebApi.V3;
+
+public class CalculationOrchestrationStateMapperTests
+{
+    // Create test that check that all values in CalculationOrchestrationState are mapped
+    // to the corresponding values in Common.Interfaces.Models.CalculationOrchestrationState
+    public static IEnumerable<object[]> AllCalculationOrchestrationStateInputs()
+    {
+        var allValues = Enum
+            .GetValues<Common.Interfaces.Models.CalculationOrchestrationState>()
+            .Select(s => new object[] { s })
+            .ToArray();
+
+        return allValues;
+    }
+
+    public static IReadOnlyCollection<CalculationOrchestrationState> AllCalculationOrchestrationStateOutputs()
+    {
+        var allValues = Enum
+            .GetValues<CalculationOrchestrationState>()
+            .ToList();
+
+        return allValues;
+    }
+
+    [Theory]
+    [MemberData(nameof(AllCalculationOrchestrationStateInputs))]
+    public void MapState_WhenCalledWithAllPossibleValues_ReturnsValidValue(Common.Interfaces.Models.CalculationOrchestrationState input)
+    {
+        // Arrange
+        var expectedValues = AllCalculationOrchestrationStateOutputs();
+
+        // Act
+        var act = () => CalculationOrchestrationStateMapper.MapState(input);
+
+        // Assert
+        var actualValue = act.Should().NotThrow().Subject;
+
+        actualValue.Should().BeOneOf(expectedValues);
+    }
+}

--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/V3/CalculationOrchestrationStateMapperTests.cs
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi/V3/CalculationOrchestrationStateMapperTests.cs
@@ -20,8 +20,6 @@ namespace Energinet.DataHub.Wholesale.WebApi.UnitTests.WebApi.V3;
 
 public class CalculationOrchestrationStateMapperTests
 {
-    // Create test that check that all values in CalculationOrchestrationState are mapped
-    // to the corresponding values in Common.Interfaces.Models.CalculationOrchestrationState
     public static IEnumerable<object[]> AllCalculationOrchestrationStateInputs()
     {
         var allValues = Enum

--- a/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationOrchestrationState.cs
+++ b/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationOrchestrationState.cs
@@ -22,6 +22,11 @@ public enum CalculationOrchestrationState
     Scheduled = 1,
 
     /// <summary>
+    /// The calculation orchestration is started (after the schedule has been met)
+    /// </summary>
+    Started = 11,
+
+    /// <summary>
     /// The calculation results are being calculated by the calculation engine.
     /// </summary>
     Calculating = 2,

--- a/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationOrchestrationState.cs
+++ b/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationOrchestrationState.cs
@@ -60,4 +60,9 @@ public enum CalculationOrchestrationState
     /// The calculation orchestration is completed
     /// </summary>
     Completed = 8,
+
+    /// <summary>
+    /// The calculation orchestration is canceled (it can only be canceled if it is scheduled and not started yet)
+    /// </summary>
+    Canceled = 9,
 }

--- a/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationOrchestrationStateMapper.cs
+++ b/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationOrchestrationStateMapper.cs
@@ -29,6 +29,7 @@ public static class CalculationOrchestrationStateMapper
             Common.Interfaces.Models.CalculationOrchestrationState.ActorMessagesEnqueued => CalculationOrchestrationState.ActorMessagesEnqueued,
             Common.Interfaces.Models.CalculationOrchestrationState.ActorMessagesEnqueuingFailed => CalculationOrchestrationState.ActorMessagesEnqueuingFailed,
             Common.Interfaces.Models.CalculationOrchestrationState.Completed => CalculationOrchestrationState.Completed,
+            Common.Interfaces.Models.CalculationOrchestrationState.Canceled => CalculationOrchestrationState.Canceled,
             _ => throw new ArgumentOutOfRangeException(nameof(calculationOrchestrationState), calculationOrchestrationState, $"Unknown {typeof(Common.Interfaces.Models.CalculationOrchestrationState).FullName}"),
         };
     }

--- a/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationOrchestrationStateMapper.cs
+++ b/source/dotnet/wholesale-api/WebApi/V3/Calculation/CalculationOrchestrationStateMapper.cs
@@ -21,6 +21,7 @@ public static class CalculationOrchestrationStateMapper
         return calculationOrchestrationState switch
         {
             Common.Interfaces.Models.CalculationOrchestrationState.Scheduled => CalculationOrchestrationState.Scheduled,
+            Common.Interfaces.Models.CalculationOrchestrationState.Started => CalculationOrchestrationState.Started,
             Common.Interfaces.Models.CalculationOrchestrationState.Calculating => CalculationOrchestrationState.Calculating,
             Common.Interfaces.Models.CalculationOrchestrationState.Calculated => CalculationOrchestrationState.Calculated,
             Common.Interfaces.Models.CalculationOrchestrationState.CalculationFailed => CalculationOrchestrationState.CalculationFailed,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

- Fix missing orchestration state map in Web API
- Add test to ensure all possible inputs are mapped

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
