### PR TITLE
feat: enable making internal calculations

### DIFF
--- a/source/databricks/calculation_engine/contracts/calculation-job-parameters-reference.txt
+++ b/source/databricks/calculation_engine/contracts/calculation-job-parameters-reference.txt
@@ -12,4 +12,4 @@
 --calculation-type=balance_fixing
 --created-by-user-id=c2975345-d935-44a2-b7bf-2629db4aa8bf
 # It's a flag: True if present, otherwise false
---is-internal-calculation
+#--is-internal-calculation

--- a/source/databricks/calculation_engine/contracts/internal-calculation-job-parameters-reference.txt
+++ b/source/databricks/calculation_engine/contracts/internal-calculation-job-parameters-reference.txt
@@ -1,0 +1,15 @@
+# This file is kind of a contract between the parameters used by .NET invocation of the calculator job
+# and the parameters expected by the calculator job.
+# There is a test on both sides verifying that both conform to the same parameters format
+# and that the calculator job is able to consume the parameters.
+#
+# Empty lines and lines starting with '#' are ignores in the tests.
+
+--calculation-id={calculation-id}
+--grid-areas=[805, 806, 033]
+--period-start-datetime=2022-05-31T22:00:00Z
+--period-end-datetime=2022-06-01T22:00:00Z
+--calculation-type=aggregation
+--created-by-user-id=c2975345-d935-44a2-b7bf-2629db4aa8bf
+# It's a flag: True if present, otherwise false
+--is-internal-calculation

--- a/source/databricks/calculation_engine/tests/infrastructure/test_get_calculator_args.py
+++ b/source/databricks/calculation_engine/tests/infrastructure/test_get_calculator_args.py
@@ -73,8 +73,24 @@ def contract_parameters(contracts_path: str) -> list[str]:
 
 
 @pytest.fixture(scope="session")
+def contract_parameters_of_internal_calculation(contracts_path: str) -> list[str]:
+    job_parameters = _get_contract_parameters(
+        f"{contracts_path}/internal-calculation-job-parameters-reference.txt"
+    )
+
+    return job_parameters
+
+
+@pytest.fixture(scope="session")
 def sys_argv_from_contract(contract_parameters) -> list[str]:
     return ["dummy_script_name"] + contract_parameters
+
+
+@pytest.fixture(scope="session")
+def sys_argv_from_internal_contract(
+    contract_parameters_of_internal_calculation,
+) -> list[str]:
+    return ["dummy_script_name_internal"] + contract_parameters_of_internal_calculation
 
 
 @pytest.fixture(scope="session")
@@ -422,10 +438,10 @@ class TestWhenIsControlCalculationFlagPresent:
     def test_flag_is_true(
         self,
         job_environment_variables: dict,
-        sys_argv_from_contract: list[str],
+        sys_argv_from_internal_contract: list[str],
     ) -> None:
         # Arrange
-        with patch("sys.argv", sys_argv_from_contract):
+        with patch("sys.argv", sys_argv_from_internal_contract):
             with patch.dict("os.environ", job_environment_variables):
                 command_line_args = parse_command_line_arguments()
 
@@ -443,7 +459,6 @@ class TestWhenIsControlCalculationFlagNotPresent:
         sys_argv_from_contract: list[str],
     ) -> None:
         # Arrange
-        sys_argv_from_contract.remove("--is-internal-calculation")
         with patch("sys.argv", sys_argv_from_contract):
             with patch.dict("os.environ", job_environment_variables):
                 command_line_args = parse_command_line_arguments()

--- a/source/dotnet/database-migration/DatabaseMigration.csproj
+++ b/source/dotnet/database-migration/DatabaseMigration.csproj
@@ -63,6 +63,7 @@ limitations under the License.
     <EmbeddedResource Include="Scripts\202408161458_Add_OrchestrationInstanceId_to_Calculation.sql" />
     <EmbeddedResource Include="Scripts\202408201311_Make_OrchestrationInstanceId_required.sql" />
     <EmbeddedResource Include="Scripts\202408202024_Add_CanceledByUserId_to_Calculation.sql" />
+    <EmbeddedResource Include="Scripts\202408221540_Add_IsInternalCalculation_to_Calculation.sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/dotnet/database-migration/Scripts/202408221540_Add_IsInternalCalculation_to_Calculation.sql
+++ b/source/dotnet/database-migration/Scripts/202408221540_Add_IsInternalCalculation_to_Calculation.sql
@@ -1,0 +1,3 @@
+ALTER TABLE [calculations].[Calculation]
+    ADD [IsInternalCalculation] BIT NOT NULL DEFAULT 0;
+GO

--- a/source/dotnet/subsystem-tests/Features/Calculations/BalanceFixingCalculationScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/BalanceFixingCalculationScenario.cs
@@ -43,7 +43,8 @@ public class BalanceFixingCalculationScenario : SubsystemTestsBase<CalculationSc
             GridAreaCodes: ["543"],
             StartDate: new DateTimeOffset(2022, 1, 11, 23, 0, 0, TimeSpan.Zero),
             EndDate: new DateTimeOffset(2022, 1, 12, 23, 0, 0, TimeSpan.Zero),
-            ScheduledAt: DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(4)));
+            ScheduledAt: DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(4)),
+            false);
     }
 
     [ScenarioStep(1)]

--- a/source/dotnet/subsystem-tests/Features/Calculations/WholesaleFixingCalculationScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/WholesaleFixingCalculationScenario.cs
@@ -45,7 +45,8 @@ public class WholesaleFixingCalculationScenario : SubsystemTestsBase<Calculation
             GridAreaCodes: new List<string> { "804" },
             StartDate: new DateTimeOffset(2023, 1, 31, 23, 0, 0, TimeSpan.Zero),
             EndDate: new DateTimeOffset(2023, 2, 28, 23, 0, 0, TimeSpan.Zero),
-            ScheduledAt: DateTimeOffset.UtcNow);
+            ScheduledAt: DateTimeOffset.UtcNow,
+            false);
     }
 
     [ScenarioStep(1)]

--- a/source/dotnet/subsystem-tests/Performance/CalculationJobScenario.cs
+++ b/source/dotnet/subsystem-tests/Performance/CalculationJobScenario.cs
@@ -49,7 +49,8 @@ public class CalculationJobScenario : SubsystemTestsBase<CalculationJobScenarioF
             scheduledAt: createdTime, // Schedule to run immediately
             dateTimeZone: DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!,
             createdByUserId: createdByUserId,
-            version: createdTime.ToDateTimeUtc().Ticks);
+            version: createdTime.ToDateTimeUtc().Ticks,
+            false);
     }
 
     [ScenarioStep(1)]

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Application/CalculationsClient.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Application/CalculationsClient.cs
@@ -86,7 +86,8 @@ public class CalculationsClient(
         DateTimeOffset startDate,
         DateTimeOffset endDate,
         DateTimeOffset scheduledAt,
-        Guid currentUserId)
+        Guid currentUserId,
+        bool isInternalCalculation)
     {
         var calculation = _calculationFactory.Create(
             calculationType,
@@ -94,7 +95,8 @@ public class CalculationsClient(
             startDate,
             endDate,
             scheduledAt,
-            currentUserId);
+            currentUserId,
+            isInternalCalculation);
 
         await _calculationRepository.AddAsync(calculation).ConfigureAwait(false);
         await _unitOfWork.CommitAsync().ConfigureAwait(false);

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/CalculationDtoMapper.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/CalculationDtoMapper.cs
@@ -38,7 +38,8 @@ public class CalculationDtoMapper : ICalculationDtoMapper
             calculation.CreatedByUserId,
             calculation.Version,
             calculation.OrchestrationState,
-            calculation.CompletedTime?.ToDateTimeOffset() ?? null);
+            calculation.CompletedTime?.ToDateTimeOffset() ?? null,
+            calculation.IsInternalCalculation);
     }
 
     private static Interfaces.Models.CalculationState MapState(CalculationExecutionState state)

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/CalculationFactory.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/CalculationFactory.cs
@@ -34,7 +34,8 @@ public class CalculationFactory : ICalculationFactory
         DateTimeOffset startDate,
         DateTimeOffset endDate,
         DateTimeOffset scheduledAt,
-        Guid createdByUserId)
+        Guid createdByUserId,
+        bool isInternalCalculation)
     {
         var createdTime = _clock.GetCurrentInstant();
         var gridAreas = gridAreaCodes.Select(c => new GridAreaCode(c)).ToList();
@@ -43,6 +44,16 @@ public class CalculationFactory : ICalculationFactory
         var scheduledAtInstant = Instant.FromDateTimeOffset(scheduledAt);
 
         var version = _clock.GetCurrentInstant().ToDateTimeUtc().Ticks;
-        return new Calculation(createdTime, calculationType, gridAreas, periodStart, periodEnd, scheduledAtInstant, _dateTimeZone, createdByUserId, version);
+        return new Calculation(
+            createdTime,
+            calculationType,
+            gridAreas,
+            periodStart,
+            periodEnd,
+            scheduledAtInstant,
+            _dateTimeZone,
+            createdByUserId,
+            version,
+            isInternalCalculation);
     }
 }

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/ICalculationFactory.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/ICalculationFactory.cs
@@ -24,5 +24,6 @@ public interface ICalculationFactory
         DateTimeOffset startDate,
         DateTimeOffset endDate,
         DateTimeOffset scheduledAt,
-        Guid createdByUserId);
+        Guid createdByUserId,
+        bool isInternalCalculation);
 }

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Calculations/DatabricksCalculationParametersFactory.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Calculations/DatabricksCalculationParametersFactory.cs
@@ -33,6 +33,10 @@ public class DatabricksCalculationParametersFactory : ICalculationParametersFact
             $"--calculation-type={CalculationTypeMapper.ToDeltaTableValue(calculation.CalculationType)}",
             $"--created-by-user-id={calculation.CreatedByUserId}",
         };
+        if (calculation.IsInternalCalculation)
+        {
+            jobParameters.Add("--is-internal-calculation");
+        }
 
         return RunParameters.CreatePythonParams(jobParameters);
     }

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Persistence/Calculations/CalculationEntityConfiguration.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Persistence/Calculations/CalculationEntityConfiguration.cs
@@ -51,6 +51,7 @@ public class CalculationEntityConfiguration : IEntityTypeConfiguration<Calculati
         builder.Property(b => b.CalculationType);
         builder.Property(b => b.CreatedTime);
         builder.Property(b => b.CreatedByUserId);
+        builder.Property(b => b.IsInternalCalculation);
 
         // Grid area IDs are stored as a JSON array
         var gridAreaCodes = builder.Metadata

--- a/source/dotnet/wholesale-api/Calculations/Calculations.IntegrationTests/Infrastructure/Persistence/Calculation/CalculationRepositoryTests.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.IntegrationTests/Infrastructure/Persistence/Calculation/CalculationRepositoryTests.cs
@@ -70,6 +70,7 @@ public class CalculationRepositoryTests
         actual.Should().BeEquivalentTo(expectedCalculation);
         actual.GridAreaCodes.Should().BeEquivalentTo(someGridAreasIds);
         actual.CalculationType.Should().Be(CalculationType.Aggregation);
+        actual.IsInternalCalculation.Should().BeFalse();
     }
 
     [Fact]
@@ -229,7 +230,8 @@ public class CalculationRepositoryTests
             Instant.FromUtc(2022, 4, 4, 0, 0),
             period.DateTimeZone,
             Guid.NewGuid(),
-            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks);
+            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks,
+            false);
         calculation.MarkAsStarted();
         calculation.MarkAsCalculationJobSubmitted(new CalculationJobId(1), executionTimeStart); // Sets execution time start
 
@@ -463,7 +465,8 @@ public class CalculationRepositoryTests
             scheduledAt ?? SystemClock.Instance.GetCurrentInstant(),
             period.DateTimeZone,
             Guid.NewGuid(),
-            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks);
+            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks,
+            false);
     }
 
     private static Application.Model.Calculations.Calculation CreateCalculation(Instant scheduledAt)

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Interfaces/ICalculationsClient.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Interfaces/ICalculationsClient.cs
@@ -43,5 +43,6 @@ public interface ICalculationsClient
         DateTimeOffset startDate,
         DateTimeOffset endDate,
         DateTimeOffset scheduledAt,
-        Guid currentUserId);
+        Guid currentUserId,
+        bool isInternalCalculation);
 }

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Interfaces/Models/CalculationDto.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Interfaces/Models/CalculationDto.cs
@@ -36,4 +36,5 @@ public sealed record CalculationDto(
     Guid CreatedByUserId,
     long Version,
     CalculationOrchestrationState OrchestrationState,
-    DateTimeOffset? CompletedTime);
+    DateTimeOffset? CompletedTime,
+    bool IsInternalCalculation);

--- a/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Application/Calculations/Model/CalculationDtoMapperTests.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Application/Calculations/Model/CalculationDtoMapperTests.cs
@@ -16,6 +16,7 @@ using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
 using Energinet.DataHub.Wholesale.Calculations.Application.Model.Calculations;
 using Energinet.DataHub.Wholesale.Calculations.Interfaces.Models;
 using Energinet.DataHub.Wholesale.Calculations.UnitTests.Infrastructure.CalculationAggregate;
+using Energinet.DataHub.Wholesale.Common.Interfaces.Models;
 using FluentAssertions;
 using NodaTime;
 using Xunit;
@@ -53,6 +54,24 @@ public class CalculationDtoMapperTests
         // Assert
         calculationDto.PeriodStart.Should().Be(calculation.PeriodStart.ToDateTimeOffset());
         calculationDto.PeriodEnd.Should().Be(calculation.PeriodEnd.ToDateTimeOffset());
+    }
+
+    [Theory]
+    [InlineAutoMoqData]
+    public void Map_Returns_AsInternalCalculation(
+        CalculationDtoMapper sut)
+    {
+        // Arrange
+        var calculation = new CalculationBuilder()
+            .WithCalculationType(CalculationType.Aggregation)
+            .AsInternalCalculation()
+            .Build();
+
+        // Act
+        var calculationDto = sut.Map(calculation);
+
+        // Assert
+        calculationDto.IsInternalCalculation.Should().BeTrue();
     }
 
     [Theory]

--- a/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/CalculationAggregate/CalculationBuilder.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/CalculationAggregate/CalculationBuilder.cs
@@ -30,6 +30,7 @@ public class CalculationBuilder
     private CalculationExecutionState? _state;
     private List<GridAreaCode> _gridAreaCodes = [new("805")];
     private CalculationType _calculationType = CalculationType.BalanceFixing;
+    private bool _isInternalCalculation = false;
 
     public CalculationBuilder()
     {
@@ -105,6 +106,12 @@ public class CalculationBuilder
         return this;
     }
 
+    public CalculationBuilder AsInternalCalculation()
+    {
+        _isInternalCalculation = true;
+        return this;
+    }
+
     public Calculation Build()
     {
         var calculation = new Calculation(
@@ -116,7 +123,8 @@ public class CalculationBuilder
             SystemClock.Instance.GetCurrentInstant(),
             DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!,
             Guid.NewGuid(),
-            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks);
+            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks,
+            _isInternalCalculation);
         var orchestrationInstanceId = new OrchestrationInstanceId("instance-id");
         var jobRunId = new CalculationJobId(new Random().Next(1, 1000));
 

--- a/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/CalculationAggregate/CalculationFactoryTests.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/CalculationAggregate/CalculationFactoryTests.cs
@@ -39,7 +39,7 @@ public class CalculationFactoryTests
         var sut = new CalculationFactory(SystemClock.Instance, _timeZone);
 
         // Act
-        var calculation = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid());
+        var calculation = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid(), false);
 
         // Assert
         calculation.PeriodStart.Should().Be(Instant.FromDateTimeOffset(_startDate));
@@ -53,10 +53,25 @@ public class CalculationFactoryTests
         var sut = new CalculationFactory(SystemClock.Instance, _timeZone);
 
         // Act
-        var calculation = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid());
+        var calculation = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid(), false);
 
         // Assert
         calculation.ScheduledAt.Should().Be(Instant.FromDateTimeOffset(_scheduledAt));
+    }
+
+    [Fact]
+    public void Create_ReturnsCalculationAsInternalCalculation()
+    {
+        // Arrange
+        var isInternalCalculations = true;
+        var sut = new CalculationFactory(SystemClock.Instance, _timeZone);
+
+        // Act
+        var calculation = sut.Create(CalculationType.Aggregation, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid(), isInternalCalculations);
+
+        // Assert
+        calculation.IsInternalCalculation.Should()
+            .BeTrue("Because the calculation type is Aggregation and the calculation is internal");
     }
 
     [Fact]
@@ -66,7 +81,7 @@ public class CalculationFactoryTests
         var sut = new CalculationFactory(SystemClock.Instance, _timeZone);
 
         // Act
-        var calculation = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid());
+        var calculation = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid(), false);
 
         // Assert
         calculation.GridAreaCodes.Select(x => x.Code).Should().Contain(_someGridAreasIds);
@@ -81,7 +96,7 @@ public class CalculationFactoryTests
         var sut = new CalculationFactory(clockMock.Object, _timeZone);
 
         // Act
-        var calculation = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid());
+        var calculation = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid(), false);
         calculation.MarkAsStarted();
         calculation.MarkAsCalculationJobSubmitted(new CalculationJobId(1), Instant.FromDateTimeOffset(_executionStartedAt));
 
@@ -100,7 +115,7 @@ public class CalculationFactoryTests
         var sut = new CalculationFactory(clockMock.Object, _timeZone);
 
         // Act
-        var actual = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid()).Version;
+        var actual = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid(), false).Version;
 
         // Assert
         actual.Should().Be(expected);
@@ -111,11 +126,11 @@ public class CalculationFactoryTests
     {
         // Arrange
         var sut = new CalculationFactory(SystemClock.Instance, _timeZone);
-        var earlierCalculation = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid());
+        var earlierCalculation = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid(), false);
         var earlierVersion = earlierCalculation.Version;
 
         // Act
-        var actual = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid()).Version;
+        var actual = sut.Create(CalculationType.BalanceFixing, _someGridAreasIds, _startDate, _endDate, _scheduledAt, Guid.NewGuid(), false).Version;
 
         // Assert
         actual.Should().BeGreaterThan(earlierVersion);

--- a/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/CalculationAggregate/CalculationTests.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/CalculationAggregate/CalculationTests.cs
@@ -42,6 +42,23 @@ public class CalculationTests
         sut.GridAreaCodes.Should().NotContain(unexpectedGridAreaCode);
     }
 
+    [Theory]
+    [InlineAutoMoqData(CalculationType.WholesaleFixing)]
+    [InlineAutoMoqData(CalculationType.FirstCorrectionSettlement)]
+    [InlineAutoMoqData(CalculationType.SecondCorrectionSettlement)]
+    [InlineAutoMoqData(CalculationType.ThirdCorrectionSettlement)]
+    public void Ctor_WhenIsAggregationAndCalculationTypeIsNotAggregation_ThrowsBusinessValidationException(CalculationType calculationType)
+    {
+        // Arrange & Act
+        var actual = Assert.Throws<BusinessValidationException>(() => new CalculationBuilder()
+            .WithCalculationType(calculationType)
+            .AsInternalCalculation()
+            .Build());
+
+        // Assert
+        actual.Message.Should().Contain($"Internal calculations is not allowed for {calculationType}.");
+    }
+
     [Fact]
     public void Ctor_WhenNoGridAreaCodes_ThrowsBusinessValidationException()
     {
@@ -56,7 +73,8 @@ public class CalculationTests
             SystemClock.Instance.GetCurrentInstant(),
             DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!,
             Guid.NewGuid(),
-            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks));
+            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks,
+            false));
         actual.Message.Should().Contain("Calculation must contain at least one grid area code");
     }
 
@@ -137,7 +155,8 @@ public class CalculationTests
             SystemClock.Instance.GetCurrentInstant(),
             DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!,
             Guid.NewGuid(),
-            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks);
+            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks,
+            false);
 
         // Assert
         if (isEntireMonth)
@@ -256,7 +275,8 @@ public class CalculationTests
             SystemClock.Instance.GetCurrentInstant(),
             DateTimeZoneProviders.Tzdb.GetZoneOrNull(timeZoneId)!,
             Guid.NewGuid(),
-            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks));
+            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks,
+            false));
 
         // Assert
         actual.Message.Should().ContainAll("period", "end");
@@ -282,7 +302,8 @@ public class CalculationTests
             SystemClock.Instance.GetCurrentInstant(),
             DateTimeZoneProviders.Tzdb.GetZoneOrNull(timeZoneId)!,
             Guid.NewGuid(),
-            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks));
+            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks,
+            false));
 
         // Assert
         actual.Message.Should().Contain($"The period start '{startPeriod.ToString()}' must be midnight.");

--- a/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/Calculations/DatabricksCalculatorJobParametersFactoryTests.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Infrastructure/Calculations/DatabricksCalculatorJobParametersFactoryTests.cs
@@ -43,7 +43,8 @@ public class DatabricksCalculatorJobParametersFactoryTests
             DateTimeOffset.Parse("2022-06-04T22:00Z").ToInstant(),
             DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!,
             new Guid("c2975345-d935-44a2-b7bf-2629db4aa8bf"),
-            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks);
+            SystemClock.Instance.GetCurrentInstant().ToDateTimeUtc().Ticks,
+            false);
 
         using var stream = EmbeddedResources.GetStream<Root>("DeltaTableContracts.calculation-job-parameters-reference.txt");
         using var reader = new StreamReader(stream);

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/CalculationCompletedV1/CalculationCompletedV1.cs
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/CalculationCompletedV1/CalculationCompletedV1.cs
@@ -24,7 +24,7 @@ public partial class CalculationCompletedV1 : IEventMessage
     /// </summary>
     public const string EventName = "CalculationCompletedV1";
 
-    public const int EventMinorVersion = 1;
+    public const int EventMinorVersion = 2;
 
     string IEventMessage.EventName => EventName;
 

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/CalculationCompletedV1/Factories/CalculationCompletedV1Factory.cs
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/CalculationCompletedV1/Factories/CalculationCompletedV1Factory.cs
@@ -19,7 +19,12 @@ namespace Energinet.DataHub.Wholesale.Events.Infrastructure.IntegrationEvents.Ca
 
 public class CalculationCompletedV1Factory : ICalculationCompletedFactory
 {
-    public Contracts.IntegrationEvents.CalculationCompletedV1 Create(Guid calculationId, string orchestrationInstanceId, CalculationType calculationType, long calculationVersion)
+    public Contracts.IntegrationEvents.CalculationCompletedV1 Create(
+        Guid calculationId,
+        string orchestrationInstanceId,
+        CalculationType calculationType,
+        long calculationVersion,
+        bool isInternalCalculation)
     {
         return new Contracts.IntegrationEvents.CalculationCompletedV1
         {
@@ -27,6 +32,7 @@ public class CalculationCompletedV1Factory : ICalculationCompletedFactory
             InstanceId = orchestrationInstanceId,
             CalculationType = CalculationTypeMapper.MapCalculationType(calculationType),
             CalculationVersion = calculationVersion,
+            IsInternalCalculation = isInternalCalculation,
         };
     }
 }

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/CalculationCompletedV1/Factories/ICalculationCompletedFactory.cs
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/CalculationCompletedV1/Factories/ICalculationCompletedFactory.cs
@@ -18,5 +18,10 @@ namespace Energinet.DataHub.Wholesale.Events.Infrastructure.IntegrationEvents.Ca
 
 public interface ICalculationCompletedFactory
 {
-    Contracts.IntegrationEvents.CalculationCompletedV1 Create(Guid calculationId, string orchestrationInstanceId, CalculationType calculationType, long calculationVersion);
+    Contracts.IntegrationEvents.CalculationCompletedV1 Create(
+        Guid calculationId,
+        string orchestrationInstanceId,
+        CalculationType calculationType,
+        long calculationVersion,
+        bool isInternalCalculation);
 }

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/CalculationCompletedV1/Protos/calculation_completed_v1.proto
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/CalculationCompletedV1/Protos/calculation_completed_v1.proto
@@ -44,6 +44,12 @@ message CalculationCompletedV1 {
   * Is the version number corresponding to the calculation for the given type and period.
   */
   int64 calculation_version = 4;
+
+  /*
+   * When calculation is internal, the calculation result is for internal use only
+   * and should not be exposed to external user.
+   */
+  bool is_internal_calculation = 5;
   
   enum CalculationType {
   /*

--- a/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/EventProviders/CalculationCompletedEventProvider.cs
+++ b/source/dotnet/wholesale-api/Events/Events.Infrastructure/IntegrationEvents/EventProviders/CalculationCompletedEventProvider.cs
@@ -34,7 +34,8 @@ public class CalculationCompletedEventProvider : ICalculationCompletedEventProvi
             unpublishedCalculation.CalculationId,
             orchestrationInstanceId,
             unpublishedCalculation.CalculationType,
-            unpublishedCalculation.Version);
+            unpublishedCalculation.Version,
+            unpublishedCalculation.IsInternalCalculation);
 
         return new IntegrationEvent(
             EventIdentification: unpublishedCalculation.CalculationId,

--- a/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Fixtures/OrchestrationsAppFixture.cs
+++ b/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Fixtures/OrchestrationsAppFixture.cs
@@ -242,7 +242,8 @@ public class OrchestrationsAppFixture : IAsyncLifetime
             GridAreaCodes: ["256", "512"],
             StartDate: dateAtMidnight,
             EndDate: dateAtMidnight.AddDays(2),
-            ScheduledAt: DateTimeOffset.UtcNow);
+            ScheduledAt: DateTimeOffset.UtcNow,
+            false);
 
         request.Content = new StringContent(
             JsonConvert.SerializeObject(requestDto),

--- a/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/ScheduleCalculations/CalculationsSchedulerHandlerTests.cs
+++ b/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/ScheduleCalculations/CalculationsSchedulerHandlerTests.cs
@@ -535,6 +535,7 @@ public class CalculationsSchedulerHandlerTests : IClassFixture<CalculationSchedu
             scheduledToRunAt,
             DateTimeZone.Utc,
             Guid.Empty,
-            1);
+            1,
+            false);
     }
 }

--- a/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/SettlementReports/SettlementReportOrchestrationTests.cs
+++ b/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/SettlementReports/SettlementReportOrchestrationTests.cs
@@ -86,7 +86,8 @@ public class SettlementReportOrchestrationTests : IAsyncLifetime
             SystemClock.Instance.GetCurrentInstant(),
             DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!,
             Guid.NewGuid(),
-            1);
+            1,
+            false);
 
         dbContext.Calculations.Add(calculationEntity);
         await dbContext.SaveChangesAsync();
@@ -157,7 +158,8 @@ public class SettlementReportOrchestrationTests : IAsyncLifetime
             SystemClock.Instance.GetCurrentInstant(),
             DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!,
             Guid.NewGuid(),
-            1);
+            1,
+            false);
 
         dbContext.Calculations.Add(calculationEntity);
         await dbContext.SaveChangesAsync();
@@ -241,7 +243,8 @@ public class SettlementReportOrchestrationTests : IAsyncLifetime
             SystemClock.Instance.GetCurrentInstant(),
             DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!,
             Guid.NewGuid(),
-            1);
+            1,
+            false);
 
         dbContext.Calculations.Add(calculationEntity);
         await dbContext.SaveChangesAsync();

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
@@ -50,9 +50,6 @@ internal class CalculationTrigger
         [FromBody] StartCalculationRequestDto startCalculationRequestDto,
         FunctionContext executionContext)
     {
-        // consumers of the API should not be able to trigger internal calculations yet.
-        var isInternalCalculation = false;
-
         var calculationId = await _calculationsClient.CreateAndCommitAsync(
             startCalculationRequestDto.CalculationType,
             startCalculationRequestDto.GridAreaCodes,
@@ -60,7 +57,7 @@ internal class CalculationTrigger
             startCalculationRequestDto.EndDate,
             startCalculationRequestDto.ScheduledAt,
             _userContext.CurrentUser.UserId,
-            isInternalCalculation).ConfigureAwait(false);
+            startCalculationRequestDto.IsInternalCalculation).ConfigureAwait(false);
 
         _logger.LogInformation("Calculation created with id {calculationId}", calculationId);
 

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
@@ -50,13 +50,17 @@ internal class CalculationTrigger
         [FromBody] StartCalculationRequestDto startCalculationRequestDto,
         FunctionContext executionContext)
     {
+        // consumers of the API should not be able to trigger internal calculations yet.
+        var isInternalCalculation = false;
+
         var calculationId = await _calculationsClient.CreateAndCommitAsync(
             startCalculationRequestDto.CalculationType,
             startCalculationRequestDto.GridAreaCodes,
             startCalculationRequestDto.StartDate,
             startCalculationRequestDto.EndDate,
             startCalculationRequestDto.ScheduledAt,
-            _userContext.CurrentUser.UserId).ConfigureAwait(false);
+            _userContext.CurrentUser.UserId,
+            isInternalCalculation).ConfigureAwait(false);
 
         _logger.LogInformation("Calculation created with id {calculationId}", calculationId);
 

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/Model/StartCalculationRequestDto.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/Model/StartCalculationRequestDto.cs
@@ -24,4 +24,5 @@ public sealed record StartCalculationRequestDto(
     IEnumerable<string> GridAreaCodes,
     DateTimeOffset StartDate,
     DateTimeOffset EndDate,
-    DateTimeOffset ScheduledAt);
+    DateTimeOffset ScheduledAt,
+    bool IsInternalCalculation);

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Documentation/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Wholesale Contracts Release notes
 
+## Version 10.1.0
+
+Added `IsInternalCalculation` property to `CalculationCompletedV1`
+
 ## Version 10.0.0
 
 - Removed the following contracts:

--- a/source/dotnet/wholesale-integration-events-package/Contracts.Tests/CalculationCompletedV1Tests.cs
+++ b/source/dotnet/wholesale-integration-events-package/Contracts.Tests/CalculationCompletedV1Tests.cs
@@ -63,7 +63,7 @@ public class CalculationCompletedV1Tests
         Assert.Equal(LastKnownContentOfContract, actualContent, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
     }
 
-    private const int LastKnownMinorEventVersion = 1;
+    private const int LastKnownMinorEventVersion = 2;
     private const string LastKnownContentOfContract = @"/* Copyright 2020 Energinet DataHub A/S
  *
  * Licensed under the Apache License, Version 2.0 (the ""License2"");
@@ -110,6 +110,12 @@ message CalculationCompletedV1 {
   * Is the version number corresponding to the calculation for the given type and period.
   */
   int64 calculation_version = 4;
+
+  /*
+   * When calculation is internal, the calculation result is for internal use only
+   * and should not be exposed to external user.
+   */
+  bool is_internal_calculation = 5;
   
   enum CalculationType {
   /*

--- a/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
+++ b/source/dotnet/wholesale-integration-events-package/Contracts/Contracts.csproj
@@ -21,7 +21,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Wholesale.Contracts</PackageId>
-    <PackageVersion>10.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>10.1.0$(VersionSuffix)</PackageVersion>
     <Title>Wholesale Contracts</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->
🛑 Dont merge before Markpart and EDI is ready to receiver internal calculations 🛑

Support internal calculations.

_Just to let you know, the IsInternal flag is not exposed to any consumer. It is set as false until Wholesale and any affected subsystem are ready to receive completedCalculationEvents from an internal calculation._

This PR contains the following:
- Expose IsInternalCalculation field on StartCalculation endpoint

Just to let you know, the IsInternal flag is not exposed to any consumer. It is set as false until Wholesale and any affected subsystem are ready to receive completedCalculationEvents from an internal calculation.

In the following PRs, 


Previous PRs:
- The calculation class and table have been extended with a new IsInternal flag that marks the calculation as internal. 
  - https://github.com/Energinet-DataHub/opengeh-wholesale/pull/2703
- I will update the start calculation action to start it as -is-control-calculation if IsInternal==true. 
  - https://github.com/Energinet-DataHub/opengeh-wholesale/pull/2704
- Update the completedCalculationEvent with the isInternalCalculation flag
  - https://github.com/Energinet-DataHub/opengeh-wholesale/pull/2705
 
Task: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/242

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
