### PR TITLE
feat: calculation orchestration now supports internal calculations

### DIFF
--- a/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/Calculation.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/Calculation.cs
@@ -167,7 +167,7 @@ public class Calculation
 
                 // The state can move from Calculating  -> Started if the databricks job is canceled and the calculation is reset and started again
                 CalculationOrchestrationState.Calculating => [CalculationOrchestrationState.Calculated, CalculationOrchestrationState.CalculationFailed, CalculationOrchestrationState.Started],
-                CalculationOrchestrationState.Calculated => [CalculationOrchestrationState.ActorMessagesEnqueuing],
+                CalculationOrchestrationState.Calculated => [CalculationOrchestrationState.ActorMessagesEnqueuing, CalculationOrchestrationState.Completed],
                 CalculationOrchestrationState.CalculationFailed => [CalculationOrchestrationState.Scheduled],
                 CalculationOrchestrationState.ActorMessagesEnqueuing => [CalculationOrchestrationState.ActorMessagesEnqueued, CalculationOrchestrationState.ActorMessagesEnqueuingFailed],
                 CalculationOrchestrationState.ActorMessagesEnqueued => [CalculationOrchestrationState.Completed],
@@ -392,6 +392,13 @@ public class Calculation
 
     public void MarkAsCompleted(Instant completedAt)
     {
+        if (OrchestrationState == CalculationOrchestrationState.Calculated
+            && IsInternalCalculation == false)
+        {
+            throw new BusinessValidationException(
+                $"Calculation with ID '{Id}' cannot be marked as '{CalculationOrchestrationState.Completed}' because it is not an internal calculation. Current orchestration state: '{OrchestrationState}'.");
+        }
+
         OrchestrationState = CalculationOrchestrationState.Completed;
         CompletedTime = completedAt;
     }

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/ScheduledCalculation.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Application/Model/Calculations/ScheduledCalculation.cs
@@ -16,4 +16,7 @@ using Energinet.DataHub.Wholesale.Common.Interfaces.Models;
 
 namespace Energinet.DataHub.Wholesale.Calculations.Application.Model.Calculations;
 
-public sealed record ScheduledCalculation(CalculationId CalculationId, OrchestrationInstanceId OrchestrationInstanceId);
+public sealed record ScheduledCalculation(
+    CalculationId CalculationId,
+    OrchestrationInstanceId OrchestrationInstanceId,
+    bool IsInternalCalculation);

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Persistence/Calculations/CalculationRepository.cs
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Persistence/Calculations/CalculationRepository.cs
@@ -79,7 +79,8 @@ public class CalculationRepository : ICalculationRepository
             .Where(c => c.ScheduledAt <= scheduledToRunBefore)
             .Select(c => new ScheduledCalculation(
                 new CalculationId(c.Id),
-                c.OrchestrationInstanceId))
+                c.OrchestrationInstanceId,
+                c.IsInternalCalculation))
             .ToListAsync()
             .ConfigureAwait(false);
 

--- a/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/DurableTask/DurableClientExtensions.cs
+++ b/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/DurableTask/DurableClientExtensions.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.TestCommon;
+using Energinet.DataHub.Wholesale.Orchestrations.IntegrationTests.Functions.Calculation;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Newtonsoft.Json;
 
@@ -73,7 +74,10 @@ public static class DurableClientExtensions
             async () =>
             {
                 // Do not retrieve history here as it could be expensive
-                var completeOrchestrationStatus = await client.GetStatusAsync(instanceId);
+                var completeOrchestrationStatus = await client.GetStatusAsync(instanceId, showHistory: true, showHistoryOutput: true);
+                var h = completeOrchestrationStatus.History.OrderBy(item => item["Timestamp"])
+                                          .Select(item => item.ToObject<OrchestrationHistoryItem>())
+                                          .ToList();
                 return completeOrchestrationStatus.RuntimeStatus == OrchestrationRuntimeStatus.Completed;
             },
             waitTimeLimit ?? TimeSpan.FromSeconds(30),

--- a/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Fixtures/OrchestrationsAppFixture.cs
+++ b/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Fixtures/OrchestrationsAppFixture.cs
@@ -225,8 +225,9 @@ public class OrchestrationsAppFixture : IAsyncLifetime
     /// Calls the <see cref="AppHostManager"/> to send a post request to start the
     /// calculation.
     /// </summary>
+    /// <param name="isInternalCalculation"></param>
     /// <returns>Calculation id of the started calculation.</returns>
-    public async Task<Guid> StartCalculationAsync()
+    public async Task<Guid> StartCalculationAsync(bool isInternalCalculation = false)
     {
         var request = new HttpRequestMessage(HttpMethod.Post, "api/StartCalculation");
 
@@ -242,7 +243,8 @@ public class OrchestrationsAppFixture : IAsyncLifetime
             GridAreaCodes: ["256", "512"],
             StartDate: dateAtMidnight,
             EndDate: dateAtMidnight.AddDays(2),
-            ScheduledAt: DateTimeOffset.UtcNow);
+            ScheduledAt: DateTimeOffset.UtcNow,
+            IsInternalCalculation: isInternalCalculation);
 
         request.Content = new StringContent(
             JsonConvert.SerializeObject(requestDto),

--- a/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/Calculation/CalculationOrchestrationActivitiesTests.cs
+++ b/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/Calculation/CalculationOrchestrationActivitiesTests.cs
@@ -132,6 +132,82 @@ public class CalculationOrchestrationActivitiesTests : IAsyncLifetime
     }
 
     /// <summary>
+    /// Verifies that:
+    ///  - The orchestration can complete a full run.
+    ///  - Every activity is executed once and in correct order.
+    /// </summary>
+    [Fact]
+    public async Task MockExternalDependencies_WhenCallingDurableFunctionEndPointWithAnInternalCalculationRequest_OrchestrationCompletes()
+    {
+        // Arrange
+        // => Databricks Jobs API
+        Fixture.MockServer.MockCalculationJobStatusResponse(RunLifeCycleState.TERMINATED); // Terminated is success
+
+        // => Databricks SQL Statement API
+        // This is the calculationId returned in the energyResult from the mocked databricks.
+        // It should be set to the ID returned by the http client calling 'api/StartCalculation'.
+        // The mocked response waits for this to not be null before responding, so it must be updated
+        // when we have the actual id.
+        var calculationIdCallback = new CallbackValue<Guid?>(null);
+        Fixture.MockServer.MockEnergyResultsResponse(calculationIdCallback.GetValue);
+
+        // Act
+        var beforeOrchestrationCreated = DateTime.UtcNow;
+        var calculationId = await Fixture.StartCalculationAsync(isInternalCalculation: true);
+        calculationIdCallback.SetValue(calculationId);
+
+        // Assert
+        // => Verify expected behaviour by searching the orchestration history
+        var orchestrationStatus = await Fixture.DurableClient.WaitForOrchestationStartedAsync(createdTimeFrom: beforeOrchestrationCreated);
+
+        // => Function has the expected calculation id
+        var calculationMetadata = orchestrationStatus.CustomStatus.ToObject<CalculationMetadata>();
+        calculationMetadata!.Id.Should().Be(calculationId);
+
+        // // => Wait for the orchestration to reach the "ActorMessagesEnqueuing" state
+        // await Fixture.DurableClient.WaitForCustomStatusAsync<CalculationMetadata>(orchestrationStatus.InstanceId, (status) => status.OrchestrationProgress == "ActorMessagesEnqueuing");
+        //
+        // // => Send "ActorMessagesEnqueued" event to Wholesale inbox
+        // await Fixture.WholesaleInboxQueue.SendActorMessagesEnqueuedAsync(calculationId, orchestrationStatus.InstanceId);
+
+        // => Wait for completion, this should be fairly quick, since we have mocked databricks
+        var completeOrchestrationStatus = await Fixture.DurableClient.WaitForInstanceCompletedAsync(
+            orchestrationStatus.InstanceId,
+            TimeSpan.FromMinutes(3));
+
+        // => Expect history
+        using var assertionScope = new AssertionScope();
+
+        var activities = completeOrchestrationStatus.History
+            .OrderBy(item => item["Timestamp"])
+            .Select(item => item.ToObject<OrchestrationHistoryItem>())
+            .ToList();
+
+        activities.Should().NotBeNull().And.Equal(
+        [
+            new OrchestrationHistoryItem("ExecutionStarted", FunctionName: "CalculationOrchestration"),
+            new OrchestrationHistoryItem("TaskCompleted", FunctionName: "SetCalculationAsStartedActivity"),
+            new OrchestrationHistoryItem("TaskCompleted", FunctionName: "StartCalculationActivity"),
+            new OrchestrationHistoryItem("TaskCompleted", FunctionName: "GetJobStatusActivity"),
+            new OrchestrationHistoryItem("TaskCompleted", FunctionName: "UpdateCalculationStateFromJobStatusActivity"),
+            //new OrchestrationHistoryItem("TaskCompleted", FunctionName: "SendCalculationResultsActivity"),
+            //new OrchestrationHistoryItem("TaskCompleted", FunctionName: "UpdateCalculationOrchestrationStateActivity"),
+            //new OrchestrationHistoryItem("TimerCreated"), // Wait for raised event (ActorMessagesEnqueued)
+            //new OrchestrationHistoryItem("EventRaised", Name: "ActorMessagesEnqueuedV1"),
+            //new OrchestrationHistoryItem("TaskCompleted", FunctionName: "UpdateCalculationOrchestrationStateActivity"),
+            new OrchestrationHistoryItem("TaskCompleted", FunctionName: "UpdateCalculationOrchestrationStateActivity"),
+            new OrchestrationHistoryItem("ExecutionCompleted"),
+        ]);
+
+        // => Verify that the durable function completed successfully
+        var last = completeOrchestrationStatus.History
+            .OrderBy(item => item["Timestamp"])
+            .Last();
+        last.Value<string>("EventType").Should().Be("ExecutionCompleted");
+        last.Value<string>("Result").Should().Be("Success");
+    }
+
+    /// <summary>
     /// Verify the job status monitor (loop) is working with the expected job status state changes.
     /// </summary>
     [Fact]

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/CalculationTrigger.cs
@@ -50,9 +50,6 @@ internal class CalculationTrigger
         [FromBody] StartCalculationRequestDto startCalculationRequestDto,
         FunctionContext executionContext)
     {
-        // consumers of the API should not be able to trigger internal calculations yet.
-        var isInternalCalculation = false;
-
         var calculationId = await _calculationsClient.CreateAndCommitAsync(
             startCalculationRequestDto.CalculationType,
             startCalculationRequestDto.GridAreaCodes,
@@ -60,7 +57,7 @@ internal class CalculationTrigger
             startCalculationRequestDto.EndDate,
             startCalculationRequestDto.ScheduledAt,
             _userContext.CurrentUser.UserId,
-            isInternalCalculation).ConfigureAwait(false);
+            startCalculationRequestDto.IsInternalCalculation).ConfigureAwait(false);
 
         _logger.LogInformation("Calculation created with id {calculationId}", calculationId);
 

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/Model/CalculationOrchestrationInput.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/Model/CalculationOrchestrationInput.cs
@@ -22,4 +22,5 @@ namespace Energinet.DataHub.Wholesale.Orchestrations.Functions.Calculation.Model
 /// </summary>
 public sealed record CalculationOrchestrationInput(
     CalculationOrchestrationMonitorOptions OrchestrationMonitorOptions,
-    CalculationId CalculationId);
+    CalculationId CalculationId,
+    bool IsInternalCalculation);

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/Model/StartCalculationRequestDto.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/Calculation/Model/StartCalculationRequestDto.cs
@@ -24,4 +24,5 @@ public sealed record StartCalculationRequestDto(
     IEnumerable<string> GridAreaCodes,
     DateTimeOffset StartDate,
     DateTimeOffset EndDate,
-    DateTimeOffset ScheduledAt);
+    DateTimeOffset ScheduledAt,
+    bool IsInternalCalculation);

--- a/source/dotnet/wholesale-api/Orchestrations/Functions/ScheduleCalculation/CalculationStarter.cs
+++ b/source/dotnet/wholesale-api/Orchestrations/Functions/ScheduleCalculation/CalculationStarter.cs
@@ -42,7 +42,8 @@ public class CalculationStarter(
     {
         var orchestrationInput = new CalculationOrchestrationInput(
             _orchestrationMonitorOptions,
-            calculationToStart.CalculationId);
+            calculationToStart.CalculationId,
+            calculationToStart.IsInternalCalculation);
 
         var alreadyStarted = await OrchestrationIsAlreadyStartedAsync(calculationToStart.OrchestrationInstanceId)
             .ConfigureAwait(false);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->
Support internal calculations.

This PR contains the following:
Extend Calculation Orchestration to handle internal calculations and bypass activities related to sending out calculation-completed events. This also exposes the IsInternalCalculation to consumers of the StartCalculation endpoint.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
