### PR TITLE
Ensure settlement reports uses unity catalogue

### DIFF
--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Experimental/DatabricksContextBase.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Experimental/DatabricksContextBase.cs
@@ -15,10 +15,12 @@
 using System.Data;
 using System.Linq.Expressions;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution;
+using Energinet.DataHub.Wholesale.Common.Infrastructure.Options;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Options;
 
 namespace Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.Experimental;
 
@@ -27,10 +29,10 @@ public abstract class DatabricksContextBase : IDisposable
     private readonly DatabricksSqlQueryExecutor _executor;
     private readonly DbContextCore _dbContext;
 
-    protected DatabricksContextBase(DatabricksSqlWarehouseQueryExecutor databricksSqlWarehouseQueryExecutor)
+    protected DatabricksContextBase(DatabricksSqlWarehouseQueryExecutor databricksSqlWarehouseQueryExecutor, IOptions<DeltaTableOptions> options)
     {
         _dbContext = new DbContextCore(OnModelCreating);
-        _executor = new DatabricksSqlQueryExecutor(_dbContext, databricksSqlWarehouseQueryExecutor);
+        _executor = new DatabricksSqlQueryExecutor(_dbContext, databricksSqlWarehouseQueryExecutor, options);
     }
 
     public void Dispose()

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Experimental/DatabricksSqlQueryExecutor.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Experimental/DatabricksSqlQueryExecutor.cs
@@ -15,7 +15,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Formats;
+using Energinet.DataHub.Wholesale.Common.Infrastructure.Options;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace Energinet.DataHub.Wholesale.CalculationResults.Infrastructure.Experimental;
 
@@ -25,9 +27,9 @@ public sealed class DatabricksSqlQueryExecutor
     private readonly DatabricksSqlQueryBuilder _sqlQueryBuilder;
     private readonly DatabricksSqlRowHydrator _sqlRowHydrator;
 
-    public DatabricksSqlQueryExecutor(DbContext dbContext, DatabricksSqlWarehouseQueryExecutor databricksSqlWarehouseQueryExecutor)
+    public DatabricksSqlQueryExecutor(DbContext dbContext, DatabricksSqlWarehouseQueryExecutor databricksSqlWarehouseQueryExecutor, IOptions<DeltaTableOptions> options)
     {
-        _sqlQueryBuilder = new DatabricksSqlQueryBuilder(dbContext);
+        _sqlQueryBuilder = new DatabricksSqlQueryBuilder(dbContext, options);
         _sqlRowHydrator = new DatabricksSqlRowHydrator();
         _databricksSqlWarehouseQueryExecutor = databricksSqlWarehouseQueryExecutor;
     }

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Extensions/Options/DeltaTableOptions.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Extensions/Options/DeltaTableOptions.cs
@@ -24,6 +24,11 @@ public class DeltaTableOptions
     public string CalculationResultViewsSource => $"{DatabricksCatalogName}.{WholesaleCalculationResultsSchemaName}";
 
     /// <summary>
+    /// The source where the different databricks views are located, consisting of the catalog and schema name.
+    /// </summary>
+    public string SettlementReportViewsSource => $"{DatabricksCatalogName}.{SettlementReportSchemaName}";
+
+    /// <summary>
     /// Name of the catalog in which the databricks views are located.
     /// Should point at the unity catalog when running in Azure, and use hive_metastore to be able to populate testsdata when running tests
     /// </summary>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Extensions/Options/DeltaTableOptions.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Extensions/Options/DeltaTableOptions.cs
@@ -48,7 +48,7 @@ public class DeltaTableOptions
     /// <summary>
     /// Name of the schema/database under which the settlement report views are associated.
     /// </summary>
-    public string SettlementReportSchemaName { get; set; } = "settlement_report";
+    public string SettlementReportSchemaName { get; set; } = "wholesale_settlement_reports";
 
     /// <summary>
     /// Name of the schema/database to which the calculation result views belong.

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Extensions/Options/DeltaTableOptions.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Extensions/Options/DeltaTableOptions.cs
@@ -72,11 +72,11 @@ public class DeltaTableOptions
 
     public string CURRENT_BALANCE_FIXING_CALCULATION_VERSION_VIEW_NAME { get; set; } = "current_balance_fixing_calculation_version_v1";
 
-    public string WHOLESALE_RESULTS_V1_VIEW_NAME { get; set; } = "wholesale_results_v1";
+    public string WHOLESALE_RESULTS_V1_VIEW_NAME { get; set; } = "amounts_per_charge_v1";
 
-    public string ENERGY_RESULTS_POINTS_PER_GA_V1_VIEW_NAME { get; set; } = "energy_result_points_per_ga_v1";
+    public string ENERGY_RESULTS_POINTS_PER_GA_V1_VIEW_NAME { get; set; } = "energy_v1";
 
-    public string ENERGY_RESULTS_POINTS_PER_ES_GA_V1_VIEW_NAME { get; set; } = "energy_result_points_per_es_ga_v1";
+    public string ENERGY_RESULTS_POINTS_PER_ES_GA_V1_VIEW_NAME { get; set; } = "energy_per_es_v1";
 
     public string ENERGY_RESULTS_METERING_POINT_TIME_SERIES_V1_VIEW_NAME { get; set; } = "metering_point_time_series_v1";
 

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Persistence/Databricks/SettlementReportDatabricksContext.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Persistence/Databricks/SettlementReportDatabricksContext.cs
@@ -52,7 +52,7 @@ public sealed class SettlementReportDatabricksContext : DatabricksContextBase, I
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.HasDefaultSchema(_deltaTableOptions.Value.SettlementReportSchemaName);
+        modelBuilder.HasDefaultSchema(_deltaTableOptions.Value.SettlementReportViewsSource);
         modelBuilder.ApplyConfiguration(new SettlementReportLatestBalanceFixingCalculationVersionViewEntityConfiguration());
         modelBuilder.ApplyConfiguration(new SettlementReportWholesaleViewEntityConfiguration());
         modelBuilder.ApplyConfiguration(new SettlementReportEnergyResultPointsPerGridAreaViewEntityConfiguration());

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Persistence/Databricks/SettlementReportDatabricksContext.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Persistence/Databricks/SettlementReportDatabricksContext.cs
@@ -27,7 +27,7 @@ public sealed class SettlementReportDatabricksContext : DatabricksContextBase, I
     public SettlementReportDatabricksContext(
         IOptions<DeltaTableOptions> deltaTableOptions,
         DatabricksSqlWarehouseQueryExecutor sqlWarehouseQueryExecutor)
-        : base(sqlWarehouseQueryExecutor)
+        : base(sqlWarehouseQueryExecutor, deltaTableOptions)
     {
         _deltaTableOptions = deltaTableOptions;
     }

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Persistence/Databricks/SettlementReportEnergyResultPointsPerEnergySupplierGridAreaViewEntityConfiguration.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Persistence/Databricks/SettlementReportEnergyResultPointsPerEnergySupplierGridAreaViewEntityConfiguration.cs
@@ -21,7 +21,7 @@ public sealed class SettlementReportEnergyResultPointsPerEnergySupplierGridAreaV
 {
     public void Configure(EntityTypeBuilder<SettlementReportEnergyResultPointsPerEnergySupplierGridAreaViewEntity> builder)
     {
-        builder.ToTable("energy_result_points_per_es_ga_v1");
+        builder.ToTable("energy_per_es_v1");
         builder.HasNoKey();
     }
 }

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Persistence/Databricks/SettlementReportEnergyResultPointsPerGridAreaViewEntityConfiguration.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Persistence/Databricks/SettlementReportEnergyResultPointsPerGridAreaViewEntityConfiguration.cs
@@ -21,7 +21,7 @@ public sealed class SettlementReportEnergyResultPointsPerGridAreaViewEntityConfi
 {
     public void Configure(EntityTypeBuilder<SettlementReportEnergyResultPointsPerGridAreaViewEntity> builder)
     {
-        builder.ToTable("energy_result_points_per_ga_v1");
+        builder.ToTable("energy_v1");
         builder.HasNoKey();
     }
 }

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Persistence/Databricks/SettlementReportWholesaleViewEntityConfiguration.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/Persistence/Databricks/SettlementReportWholesaleViewEntityConfiguration.cs
@@ -21,7 +21,7 @@ public sealed class SettlementReportWholesaleViewEntityConfiguration : IEntityTy
 {
     public void Configure(EntityTypeBuilder<SettlementReportWholesaleViewEntity> builder)
     {
-        builder.ToTable("wholesale_results_v1");
+        builder.ToTable("amounts_per_charge_v1");
         builder.HasNoKey();
     }
 }

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Application/SettlementReports/SettlementReportFileRequestHandlerIntegrationTests.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Application/SettlementReports/SettlementReportFileRequestHandlerIntegrationTests.cs
@@ -50,6 +50,7 @@ public sealed class SettlementReportFileRequestHandlerIntegrationTests : TestBas
         var mockedOptions = new Mock<IOptions<DeltaTableOptions>>();
         mockedOptions.Setup(x => x.Value).Returns(new DeltaTableOptions
         {
+            DatabricksCatalogName = _databricksSqlStatementApiFixture.DatabricksSchemaManager.DeltaTableOptions.Value.DatabricksCatalogName,
             SettlementReportSchemaName = _databricksSqlStatementApiFixture.DatabricksSchemaManager.DeltaTableOptions.Value.SCHEMA_NAME,
             SCHEMA_NAME = _databricksSqlStatementApiFixture.DatabricksSchemaManager.DeltaTableOptions.Value.SCHEMA_NAME,
         });

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Fixtures/MigrationsFreeDatabricksSchemaManager.cs
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/Fixtures/MigrationsFreeDatabricksSchemaManager.cs
@@ -57,7 +57,7 @@ public class MigrationsFreeDatabricksSchemaManager
 
     public async Task CreateSchemaAsync()
     {
-        await ExecuteSqlAsync($"CREATE DATABASE IF NOT EXISTS {DeltaTableOptions.Value.SCHEMA_NAME}");
+        await ExecuteSqlAsync($"CREATE DATABASE IF NOT EXISTS {SchemaName}");
         await CreateTableAsync(DeltaTableOptions.Value.ENERGY_RESULTS_POINTS_PER_GA_V1_VIEW_NAME, SettlementReportEnergyResultViewSchemaDefinition.SchemaDefinition);
         await CreateTableAsync(DeltaTableOptions.Value.ENERGY_RESULTS_POINTS_PER_ES_GA_V1_VIEW_NAME, SettlementReportEnergyResultPerEnergySupplierViewSchemaDefinition.SchemaDefinition);
         await CreateTableAsync(DeltaTableOptions.Value.WHOLESALE_RESULTS_V1_VIEW_NAME, SettlementReportWholesaleViewColumns.SchemaDefinition);


### PR DESCRIPTION
# Description

Ensure that settlement reports uses unity catalogues instead of hive

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
