### PR TITLE
fix: Subsystem name in subsystem tests

### DIFF
--- a/source/dotnet/subsystem-tests/Features/Calculations/WholesaleFixingCalculationScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/WholesaleFixingCalculationScenario.cs
@@ -128,7 +128,7 @@ AppTraces
 | where SeverityLevel == 1 // Information
 | where Message startswith_cs ""Command line arguments:""
 | where OperationId != ""00000000000000000000000000000000""
-| where Properties.Subsystem == ""wholesale-dotnet""
+| where Properties.Subsystem == ""wholesale-aggregations""
 | where Properties.calculation_id == ""{Fixture.ScenarioState.CalculationId}""
 | where Properties.CategoryName == ""Energinet.DataHub.package.calculator_job_args""
 | count";
@@ -152,7 +152,7 @@ AppDependencies
 | where Success == true
 | where ResultCode == 0
 | where AppRoleName == ""dbr-calculation-engine""
-| where Properties.Subsystem == ""wholesale-dotnet""
+| where Properties.Subsystem == ""wholesale-aggregations""
 | where Properties.calculation_id == ""{Fixture.ScenarioState.CalculationId}""
 | count";
 


### PR DESCRIPTION
# Description

See title.

Deployed to `dev_002`: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/10633750896

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [x] Subsystem tests have been tested (by manually deploying to `dev_002`)
