### PR TITLE
feat: Adds functionality to print parameters passed to settlement report job

### DIFF
--- a/source/databricks/calculation_engine/package/settlement_report_job/settlement_report.py
+++ b/source/databricks/calculation_engine/package/settlement_report_job/settlement_report.py
@@ -22,7 +22,15 @@ from package.infrastructure.paths import (
 )
 from package.common.logger import Logger
 import package.infrastructure.environment_variables as env_vars
+from package.settlement_report_job.utils import (
+    get_dbutils,
+    log_params,
+)
 
 
 def run() -> None:
+    spark = initialize_spark()
+    dbutils = get_dbutils(spark)
+    params = dbutils.widgets.getAll()
+    log_params(params)
     print("Hello world")

--- a/source/databricks/calculation_engine/package/settlement_report_job/utils.py
+++ b/source/databricks/calculation_engine/package/settlement_report_job/utils.py
@@ -57,6 +57,8 @@ def log_params(d: dict, title: str = "Received parameters:") -> None:
         d (dict): The dictionary to log.
         title (str, optional): The title of the log. Defaults to "Received parameters:".
     """
+    if len(d) == 0:
+        return
     max_key_len = max(len(key) for key in d.keys())
     print(title)
     for key, value in d.items():

--- a/source/databricks/calculation_engine/package/settlement_report_job/utils.py
+++ b/source/databricks/calculation_engine/package/settlement_report_job/utils.py
@@ -1,0 +1,64 @@
+from pyspark import SparkConf
+from pyspark.sql import functions as F, types as T
+from pyspark.sql.session import SparkSession
+from typing import Any
+
+
+def get_dbutils(spark: SparkSession):
+    """Get the DBUtils object from the SparkSession.
+
+    Args:
+        spark (SparkSession): The SparkSession object.
+
+    Returns:
+        DBUtils: The DBUtils object.
+    """
+    try:
+        from pyspark.dbutils import DBUtils  # type: ignore
+
+        dbutils = DBUtils(spark)
+    except ImportError:
+        raise ImportError(
+            "DBUtils is not available in local mode. This is expected when running tests."  # noqa
+        )
+    return dbutils
+
+
+def get_param_or_fail(
+    d: dict,
+    key: str,
+    message: str,
+    _type: T.DataType = T.StringType(),
+    default: Any = None,
+):
+    """Get a parameter from a dictionary or fail if it is missing.
+
+    Args:
+        d (dict): The dictionary to get the parameter from.
+        key (str): The key of the parameter.
+        message (str): The message to display if the parameter is missing.
+        _type (T.DataType, optional): The type of the parameter.
+            Defaults to T.StringType().
+        default (Any, optional): The default value of the parameter.
+            Defaults to None.
+
+    Returns:
+        Any: The value of the parameter.
+    """
+    val = d.get(key) or default
+    if val is None:
+        raise Exception(f"Parameter '{key}' is missing without a default: '{message}'")
+    return F.lit(val).cast(_type)
+
+
+def log_params(d, title: str = "Received parameters:"):
+    """Log the parameters in a dictionary.
+
+    Args:
+        d (dict): The dictionary to log.
+        title (str, optional): The title of the log. Defaults to "Received parameters:".
+    """
+    max_key_len = max(len(key) for key in d.keys())
+    print(title)
+    for key, value in d.items():
+        print(f"   {key:{max_key_len + 1}s}: {value}")

--- a/source/databricks/calculation_engine/package/settlement_report_job/utils.py
+++ b/source/databricks/calculation_engine/package/settlement_report_job/utils.py
@@ -1,10 +1,9 @@
-from pyspark import SparkConf
 from pyspark.sql import functions as F, types as T
 from pyspark.sql.session import SparkSession
 from typing import Any
 
 
-def get_dbutils(spark: SparkSession):
+def get_dbutils(spark: SparkSession) -> Any:
     """Get the DBUtils object from the SparkSession.
 
     Args:
@@ -30,7 +29,7 @@ def get_param_or_fail(
     message: str,
     _type: T.DataType = T.StringType(),
     default: Any = None,
-):
+) -> F.Column:
     """Get a parameter from a dictionary or fail if it is missing.
 
     Args:
@@ -51,7 +50,7 @@ def get_param_or_fail(
     return F.lit(val).cast(_type)
 
 
-def log_params(d, title: str = "Received parameters:"):
+def log_params(d: dict, title: str = "Received parameters:") -> None:
     """Log the parameters in a dictionary.
 
     Args:


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Will print out parameters passed to the settlement report job

Supply parameters to the job as follows:
```py
HOST = "https://adb-544979639376646.6.azuredatabricks.net"
TOKEN = "..."
JOB_ID = "954036901868629"

body = {
    "job_id": JOB_ID,
    "job_parameters": {
        "SplitReportPerGridArea": True,
        "PreventLargeTextFiles": True,
        "IncludeBasisData": True,
        "IncludeMonthlyAmount": True,
        "GridAreas": json.dumps(
            {
                "GridArea1": "1",
            }
        ),
        "PeriodStart": "2021-01-01",
        "PeriodEnd": "2021-02-01",
        "CalculationType": "test",
        "EnergySupplier": "test",
        "CsvFormatLocale": "test",
        "role": "test",
        "chargeOwnerId": "test",
    },
}

req = requests.post(
    f"{HOST}/api/2.1/jobs/run-now",
    headers={"Authorization": f"Bearer {TOKEN}"},
    data=json.dumps(body),
)

```
## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
