### PR TITLE
feat: Test settlement report entrypoint

### DIFF
--- a/source/databricks/.gitignore
+++ b/source/databricks/.gitignore
@@ -1,5 +1,5 @@
 # Exclude directory created by wheel creation
-package.egg-info
+*.egg-info
 dist
 build
 

--- a/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
@@ -1,0 +1,11 @@
+from pyspark.sql import SparkSession
+
+from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
+from settlement_report_job.domain.time_series_factory import create_time_series
+
+
+def execute(spark: SparkSession, args: SettlementReportArgs) -> None:
+    """
+    Entry point for the logic of creating settlement reports.
+    """
+    create_time_series(spark, args)

--- a/source/databricks/settlement_report/settlement_report_job/entrypoint.py
+++ b/source/databricks/settlement_report/settlement_report_job/entrypoint.py
@@ -20,13 +20,13 @@ from typing import Callable
 from opentelemetry.trace import SpanKind, Status, StatusCode, Span
 
 import settlement_report_job.infrastructure.logging_configuration as config
+from settlement_report_job.domain import report_generator
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
 from settlement_report_job.infrastructure.settlement_report_job_args import (
     parse_job_arguments,
     parse_command_line_arguments,
 )
 from settlement_report_job.infrastructure.spark_initializor import initialize_spark
-from settlement_report_job.domain.time_series_factory import create_time_series
 
 
 # The start() method should only have its name updated in correspondence with the
@@ -72,7 +72,7 @@ def start_with_deps(
 
             args = parse_job_args(command_line_args)
             spark = initialize_spark()
-            create_time_series(spark, args)
+            report_generator.execute(spark, args)
 
         # Added as ConfigArgParse uses sys.exit() rather than raising exceptions
         except SystemExit as e:

--- a/source/databricks/settlement_report/setup.py
+++ b/source/databricks/settlement_report/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "create_settlement_report = settlement_report_job.settlement_report:start",
+            "create_settlement_report = settlement_report_job.entrypoint:start",
         ]
     },
 )

--- a/source/databricks/settlement_report/tests/conftest.py
+++ b/source/databricks/settlement_report/tests/conftest.py
@@ -109,6 +109,17 @@ def tests_path(settlement_report_path: str) -> str:
 
 
 @pytest.fixture(scope="session")
+def settlement_report_job_container_path(databricks_path: str) -> str:
+    """
+    Returns the <repo-root>/source folder path.
+    Please note that this only works if current folder haven't been changed prior using `os.chdir()`.
+    The correctness also relies on the prerequisite that this function is actually located in a
+    file located directly in the tests folder.
+    """
+    return f"{databricks_path}/settlement_report"
+
+
+@pytest.fixture(scope="session")
 def spark(
     tests_path: str,
 ) -> Generator[SparkSession, None, None]:

--- a/source/databricks/settlement_report/tests/domain/test_settlement_report_args.py
+++ b/source/databricks/settlement_report/tests/domain/test_settlement_report_args.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 import pytest
 
 from settlement_report_job.domain.market_role import MarketRole
-from settlement_report_job.settlement_report import (
+from settlement_report_job.entrypoint import (
     parse_job_arguments,
     parse_command_line_arguments,
 )

--- a/source/databricks/settlement_report/tests/entrypoints/conftest.py
+++ b/source/databricks/settlement_report/tests/entrypoints/conftest.py
@@ -1,0 +1,49 @@
+import os
+import subprocess
+from typing import Generator
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def virtual_environment() -> Generator:
+    """Fixture ensuring execution in a virtual environment.
+    Uses `virtualenv` instead of conda environments due to problems
+    activating the virtual environment from pytest."""
+
+    # Create and activate the virtual environment
+    subprocess.call(["virtualenv", ".wholesale-pytest"])
+    subprocess.call(
+        "source .wholesale-pytest/bin/activate", shell=True, executable="/bin/bash"
+    )
+
+    yield None
+
+    # Deactivate virtual environment upon test suite tear down
+    subprocess.call("deactivate", shell=True, executable="/bin/bash")
+
+
+@pytest.fixture(scope="session")
+def installed_package(
+    virtual_environment: Generator, settlement_report_job_container_path: str
+) -> None:
+    """Ensures that the wholesale package is installed (after building it)."""
+
+    # Build the package wheel
+    os.chdir(settlement_report_job_container_path)
+    subprocess.call("python -m build --wheel", shell=True, executable="/bin/bash")
+
+    # Uninstall the package in case it was left by a cancelled test suite
+    subprocess.call(
+        "pip uninstall -y package",
+        shell=True,
+        executable="/bin/bash",
+    )
+
+    # Install wheel, which will also create console scripts for invoking
+    # the entry points of the package
+    subprocess.call(
+        f"pip install {settlement_report_job_container_path}/dist/opengeh_settlement_report-1.0-py3-none-any.whl",
+        shell=True,
+        executable="/bin/bash",
+    )

--- a/source/databricks/settlement_report/tests/entrypoints/test_entry_points.py
+++ b/source/databricks/settlement_report/tests/entrypoints/test_entry_points.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.metadata
+from typing import Any
+
+import pytest
+
+
+# IMPORTANT:
+# If we add/remove tests here, we also update the "retry logic" in '.docker/entrypoint.sh',
+# which depends on the number of "entry point tests".
+
+
+def assert_entry_point_exists(entry_point_name: str) -> Any:
+    # Load the entry point function from the installed wheel
+    try:
+        entry_point = importlib.metadata.entry_points(
+            group="console_scripts", name=entry_point_name
+        )
+        if not entry_point:
+            assert False, f"The {entry_point_name} entry point was not found."
+    except importlib.metadata.PackageNotFoundError:
+        assert False, f"The {entry_point_name} entry point was not found."
+
+
+@pytest.mark.parametrize(
+    "entry_point_name",
+    [
+        "create_settlement_report",
+    ],
+)
+def test__installed_package__can_load_entry_point(
+    installed_package: None,
+    entry_point_name: str,
+) -> None:
+    assert_entry_point_exists(entry_point_name)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Add test of settlement report job wheel entrypoint.
Refac for a single domain logic entry point (`report_generator.execute()`).

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
