### PR TITLE
feat: Use report_id in zip-filename for settlement reports

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
@@ -21,7 +21,6 @@ def execute(spark: SparkSession, args: SettlementReportArgs) -> None:
     """
     dbutils = get_dbutils(spark)
     report_directory = f"{get_output_volume_name()}/{args.report_id}"
-    zip_file_path = f"{report_directory}/final_report.zip"
 
     hourly_time_series_files = create_time_series(
         spark,
@@ -39,9 +38,8 @@ def execute(spark: SparkSession, args: SettlementReportArgs) -> None:
     files_to_zip = []
     files_to_zip.extend(hourly_time_series_files)
     files_to_zip.extend(quarterly_time_series_files)
-    print(files_to_zip)
-    print(hourly_time_series_files)
-    print(quarterly_time_series_files)
+    log.info(f"Files to zip: {files_to_zip}")
+    zip_file_path = f"{get_output_volume_name()}/{args.report_id}.zip"
     log.info(f"Creating zip file: '{zip_file_path}'")
     create_zip_file(dbutils, args.report_id, zip_file_path, files_to_zip)
     log.info(f"Finished creating '{zip_file_path}'")


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

This PR places the zip file in the root instead of in a dedicated folder. Also its name should be the id of the report

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
