### PR TITLE
feat: Allow choice of locale affecting CSV format

### DIFF
--- a/source/databricks/settlement_report/contracts/settlement-report-job-parameters-reference.txt
+++ b/source/databricks/settlement_report/contracts/settlement-report-job-parameters-reference.txt
@@ -16,3 +16,4 @@
 --energy-supplier-id=1234567890123
 --split-report-by-grid-area
 --prevent-large-text-files
+--locale=da-DK

--- a/source/databricks/settlement_report/settlement_report_job/domain/settlement_report_args.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/settlement_report_args.py
@@ -36,3 +36,4 @@ class SettlementReportArgs:
     catalog_name: str
     settlement_reports_output_path: str
     """The path to the folder where the settlement reports are stored."""
+    locale: str

--- a/source/databricks/settlement_report/settlement_report_job/domain/time_series_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/time_series_writer.py
@@ -57,6 +57,7 @@ def write(
             TimeSeriesPointCsvColumnNames.metering_point_id,
             TimeSeriesPointCsvColumnNames.start_of_day,
         ],
+        locale=args.locale,
     )
     file_name_factory = FileNameFactory(report_data_type, args)
     new_files = get_new_files(

--- a/source/databricks/settlement_report/settlement_report_job/infrastructure/settlement_report_job_args.py
+++ b/source/databricks/settlement_report/settlement_report_job/infrastructure/settlement_report_job_args.py
@@ -61,6 +61,7 @@ def parse_job_arguments(
             settlement_reports_output_path=get_settlement_reports_output_path(
                 env_vars.get_catalog_name()
             ),
+            locale=job_args.locale,
         )
 
         return settlement_report_args
@@ -87,6 +88,7 @@ def _parse_args_or_throw(command_line_args: list[str]) -> argparse.Namespace:
     p.add(
         "--prevent-large-text-files", action="store_true"
     )  # true if present, false otherwise
+    p.add("--locale", type=str, required=False)
 
     args, unknown_args = p.parse_known_args(args=command_line_args)
     if len(unknown_args):

--- a/source/databricks/settlement_report/tests/conftest.py
+++ b/source/databricks/settlement_report/tests/conftest.py
@@ -60,6 +60,7 @@ def standard_wholesale_fixing_scenario_args(
         requesting_actor_market_role=MarketRole.DATAHUB_ADMINISTRATOR,
         requesting_actor_id="1111111111111",
         settlement_reports_output_path=settlement_reports_output_path,
+        locale="da-dk",
     )
 
 

--- a/source/databricks/settlement_report/tests/domain/test_report_name_factory.py
+++ b/source/databricks/settlement_report/tests/domain/test_report_name_factory.py
@@ -34,6 +34,7 @@ def default_settlement_report_args() -> SettlementReportArgs:
         energy_supplier_id="1234567890123",
         requesting_actor_market_role=MarketRole.DATAHUB_ADMINISTRATOR,
         settlement_reports_output_path="some_output_volume_path",
+        locale="da-dk",
     )
 
 

--- a/source/databricks/settlement_report/tests/infrastructure/test_settlement_report_args.py
+++ b/source/databricks/settlement_report/tests/infrastructure/test_settlement_report_args.py
@@ -127,6 +127,7 @@ class TestWhenInvokedWithValidParameters:
         assert actual_args.prevent_large_text_files is True
         assert actual_args.split_report_by_grid_area is True
         assert actual_args.time_zone == "Europe/Copenhagen"
+        assert actual_args.locale == "da-DK"
 
 
 class TestWhenNoValidCalculationIdForGridArea:

--- a/source/databricks/settlement_report/tests/test_settlement_report_utils.py
+++ b/source/databricks/settlement_report/tests/test_settlement_report_utils.py
@@ -123,7 +123,7 @@ def test_write_files__when_locale_set_to_danish(spark: SparkSession):
     csv_path = f"{tmp_dir.name}/csv_file"
 
     # Act
-    write_files(df, csv_path, False, False, order_by=[], locale="da-dk")
+    write_files(df, csv_path, partition_columns=[], order_by=[], locale="da-dk")
 
     # Assert
     assert Path(csv_path).exists()
@@ -147,7 +147,9 @@ def test_write_files__when_locale_set_to_english(spark: SparkSession):
     csv_path = f"{tmp_dir.name}/csv_file"
 
     # Act
-    write_files(df, csv_path, False, False, order_by=[], locale="en-gb")
+    columns = write_files(
+        df, csv_path, partition_columns=[], order_by=[], locale="en-gb"
+    )
 
     # Assert
     assert Path(csv_path).exists()
@@ -161,6 +163,8 @@ def test_write_files__when_locale_set_to_english(spark: SparkSession):
                 assert all_lines_written[1] == "b,2.2\n"
                 assert all_lines_written[2] == "c,3.3\n"
 
+    assert columns == ["key", "value"]
+
     tmp_dir.cleanup()
 
 
@@ -171,7 +175,9 @@ def test_write_files__when_order_by_specified_on_single_partition(spark: SparkSe
     csv_path = f"{tmp_dir.name}/csv_file"
 
     # Act
-    write_files(df, csv_path, False, False, order_by=["value"], locale="da-dk")
+    columns = write_files(
+        df, csv_path, partition_columns=[], order_by=["value"], locale="da-dk"
+    )
 
     # Assert
     assert Path(csv_path).exists()
@@ -185,6 +191,8 @@ def test_write_files__when_order_by_specified_on_single_partition(spark: SparkSe
                 assert all_lines_written[1] == "b;2,2\n"
                 assert all_lines_written[2] == "c;3,3\n"
 
+    assert columns == ["key", "value"]
+
     tmp_dir.cleanup()
 
 
@@ -194,13 +202,15 @@ def test_write_files__when_order_by_specified_on_multiple_partitions(
     # Arrange
     df = spark.createDataFrame(
         [("b", 2.2), ("b", 1.1), ("c", 3.3)],
-        [DataProductColumnNames.grid_area_code, "value"],
+        ["key", "value"],
     )
     tmp_dir = TemporaryDirectory()
     csv_path = f"{tmp_dir.name}/csv_file"
 
     # Act
-    write_files(df, csv_path, False, True, order_by=["value"], locale="da-dk")
+    columns = write_files(
+        df, csv_path, partition_columns=["key"], order_by=["value"], locale="da-dk"
+    )
 
     # Assert
     assert Path(csv_path).exists()
@@ -217,5 +227,7 @@ def test_write_files__when_order_by_specified_on_multiple_partitions(
                     assert all_lines_written[1] == "b;2,2\n"
                 else:
                     raise AssertionError("Found unexpected csv file.")
+
+    assert columns == ["value"]
 
     tmp_dir.cleanup()


### PR DESCRIPTION
# Description

This PR introduces a SettlementReportArgs called "locale", which is checked in the "write_files" function of the time_series writer. 
It chooses the delimiter of the CSV file, with english being "," and danish using ";" due to danish also requireing floats/doubles/decimals to use a comma like "123,4" vs the english standard "123.4"

However, due to pyspark's CSV implementation not having a setting to change the "." to a "," it is required to do manually, by casting every relevant field to strings and replacing the character. 

It also adds unit tests to the write_files function, testing the order_by argument as well.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
