### PR TITLE
fix: Set locale to "da-DK" by default

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/infrastructure/settlement_report_job_args.py
+++ b/source/databricks/settlement_report/settlement_report_job/infrastructure/settlement_report_job_args.py
@@ -61,7 +61,7 @@ def parse_job_arguments(
             settlement_reports_output_path=get_settlement_reports_output_path(
                 env_vars.get_catalog_name()
             ),
-            locale=job_args.locale,
+            locale=job_args.locale if job_args.locale is not None else "da-DK",
         )
 
         return settlement_report_args


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
