### PR TITLE
Added local checkpointing instead of caching.

### DIFF
--- a/source/databricks/calculation_engine/package/databases/wholesale_results_internal/energy_results.py
+++ b/source/databricks/calculation_engine/package/databases/wholesale_results_internal/energy_results.py
@@ -44,7 +44,7 @@ def write_energy_results(energy_results_output: EnergyResultsOutput) -> None:
     for field in fields(energy_results_output):
         field_value = getattr(energy_results_output, field.name)
         if field_value is not None:
-            field_value.cache()
+            setattr(energy_results_output, field.name, field_value.localCheckpoint())
 
     # Write exchange per neighbor grid area
     _write(


### PR DESCRIPTION
# Description
Changes the ".cache()" introduced to allieviate the incident of "indeterminate" shuffles into a ".localCheckpoint()", which does a proper checkpoint of the data rather than keeping it in memory. The difference between local and non-local checkpoints, is that local saves to local executor storage, whereas proper checkpoints write to fault-reliant HDFS. 

However, writing to HDFS is expensive, and writing to locally cuts out all network involved, and is as such much faster and easier to quickly attempt. The alternative requires a specific path in storage where we can write to, but that is the next step.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
