### PR TITLE
fix: Add --include-basis-data argument to settlement report job in subsystem test

### DIFF
--- a/source/dotnet/subsystem-tests/Features/SettlementReports/SettlementReportJobGeneratesZipScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/SettlementReports/SettlementReportJobGeneratesZipScenario.cs
@@ -48,6 +48,7 @@ public class SettlementReportJobGeneratesZipScenario : SubsystemTestsBase<Settle
             "--calculation-type=wholesale_fixing",
             "--requesting-actor-market-role=datahub_administrator",
             "--requesting-actor-id=1234567890123",
+            "--include-basis-data",
             $"--calculation-id-by-grid-area={{\"804\": \"{Fixture.Configuration.InputCalculationId}\"}}",
         };
 

--- a/source/dotnet/subsystem-tests/Features/SettlementReports/SettlementReportJobPerformanceScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/SettlementReports/SettlementReportJobPerformanceScenario.cs
@@ -47,6 +47,7 @@ public class SettlementReportJobPerformanceScenario : SubsystemTestsBase<Settlem
             "--calculation-type=wholesale_fixing",
             "--requesting-actor-market-role=datahub_administrator",
             "--requesting-actor-id=1234567890123",
+            "--include-basis-data",
             "--calculation-id-by-grid-area=" +
                 "{" +
                     "\"003\": \"32e49805-20ef-4db2-ac84-c4455de7a373\"," +


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Add --include-basis-data to subsystem test - otherwise there will be no files to zip at this point

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
