### PR TITLE
refac: Generalise time_series_writer as csv_writer

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
@@ -47,11 +47,11 @@ def write(
     report_output_path = f"{args.settlement_reports_output_path}/{args.report_id}"
     spark_output_path = f"{report_output_path}/{_get_folder_name(report_data_type)}"
 
-    df_ready_for_writing = apply_report_type_df_changes(df, args, report_data_type)
+    df_ready_for_writing = _apply_report_type_df_changes(df, args, report_data_type)
 
-    partition_columns = get_partition_columns_for_report_type(report_data_type, args)
+    partition_columns = _get_partition_columns_for_report_type(report_data_type, args)
 
-    order_by_columns = get_order_by_columns_for_report_type(report_data_type)
+    order_by_columns = _get_order_by_columns_for_report_type(report_data_type)
 
     headers = write_files(
         df=df_ready_for_writing,
@@ -77,7 +77,7 @@ def write(
     return files
 
 
-def get_partition_columns_for_report_type(
+def _get_partition_columns_for_report_type(
     report_type: ReportDataType, args: SettlementReportArgs
 ) -> List[str]:
     partition_columns = []
@@ -95,7 +95,7 @@ def get_partition_columns_for_report_type(
     return partition_columns
 
 
-def get_order_by_columns_for_report_type(report_type: ReportDataType) -> List[str]:
+def _get_order_by_columns_for_report_type(report_type: ReportDataType) -> List[str]:
     if report_type in [
         ReportDataType.TimeSeriesHourly,
         ReportDataType.TimeSeriesQuarterly,
@@ -110,7 +110,7 @@ def get_order_by_columns_for_report_type(report_type: ReportDataType) -> List[st
     return []
 
 
-def apply_report_type_df_changes(
+def _apply_report_type_df_changes(
     df: DataFrame,
     args: SettlementReportArgs,
     report_type: ReportDataType,

--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any
+from typing import Any, List
 
 from pyspark.sql import DataFrame
 
@@ -35,13 +35,11 @@ from settlement_report_job.infrastructure import logging_configuration
 log = Logger(__name__)
 
 
-@logging_configuration.use_span(
-    "settlement_report_job.time_series_factory.create_time_series"
-)
+@logging_configuration.use_span("settlement_report_job.csv_writer.write")
 def write(
     dbutils: Any,
     args: SettlementReportArgs,
-    prepared_time_series: DataFrame,
+    df: DataFrame,
     report_data_type: ReportDataType,
     rows_per_file: int = 1_000_000,
 ) -> list[str]:
@@ -49,32 +47,21 @@ def write(
     report_output_path = f"{args.settlement_reports_output_path}/{args.report_id}"
     spark_output_path = f"{report_output_path}/{_get_folder_name(report_data_type)}"
 
-    if args.requesting_actor_market_role is MarketRole.GRID_ACCESS_PROVIDER:
-        prepared_time_series = prepared_time_series.drop(
-            DataProductColumnNames.energy_supplier_id
-        )
+    df_ready_for_writing = apply_report_type_df_changes(df, args, report_data_type)
 
-    partition_columns = [DataProductColumnNames.grid_area_code]
+    partition_columns = get_partition_columns_for_report_type(report_data_type, args)
 
-    if _is_partitioning_by_energy_supplier_id_needed(args):
-        partition_columns.append(DataProductColumnNames.energy_supplier_id)
-
-    if args.prevent_large_text_files:
-        partition_columns.append(EphemeralColumns.chunk_index)
+    order_by_columns = get_order_by_columns_for_report_type(report_data_type)
 
     headers = write_files(
-        df=prepared_time_series,
+        df=df_ready_for_writing,
         path=spark_output_path,
         partition_columns=partition_columns,
-        order_by=[
-            DataProductColumnNames.grid_area_code,
-            TimeSeriesPointCsvColumnNames.metering_point_type,
-            TimeSeriesPointCsvColumnNames.metering_point_id,
-            TimeSeriesPointCsvColumnNames.start_of_day,
-        ],
+        order_by=order_by_columns,
         rows_per_file=rows_per_file,
         locale=args.locale,
     )
+
     file_name_factory = FileNameFactory(report_data_type, args)
     new_files = get_new_files(
         spark_output_path,
@@ -88,6 +75,54 @@ def write(
         headers=headers,
     )
     return files
+
+
+def get_partition_columns_for_report_type(
+    report_type: ReportDataType, args: SettlementReportArgs
+) -> List[str]:
+    partition_columns = []
+    if report_type in [
+        ReportDataType.TimeSeriesHourly,
+        ReportDataType.TimeSeriesQuarterly,
+    ]:
+        partition_columns = [DataProductColumnNames.grid_area_code]
+        if _is_partitioning_by_energy_supplier_id_needed(args):
+            partition_columns.append(DataProductColumnNames.energy_supplier_id)
+
+        if args.prevent_large_text_files:
+            partition_columns.append(EphemeralColumns.chunk_index)
+
+    return partition_columns
+
+
+def get_order_by_columns_for_report_type(report_type: ReportDataType) -> List[str]:
+    if report_type in [
+        ReportDataType.TimeSeriesHourly,
+        ReportDataType.TimeSeriesQuarterly,
+    ]:
+        return [
+            DataProductColumnNames.grid_area_code,
+            TimeSeriesPointCsvColumnNames.metering_point_type,
+            TimeSeriesPointCsvColumnNames.metering_point_id,
+            TimeSeriesPointCsvColumnNames.start_of_day,
+        ]
+
+    return []
+
+
+def apply_report_type_df_changes(
+    df: DataFrame,
+    args: SettlementReportArgs,
+    report_type: ReportDataType,
+) -> DataFrame:
+    if (
+        report_type
+        in [ReportDataType.TimeSeriesHourly, ReportDataType.TimeSeriesQuarterly]
+        and args.requesting_actor_market_role is MarketRole.GRID_ACCESS_PROVIDER
+    ):
+        df = df.drop(DataProductColumnNames.energy_supplier_id)
+
+    return df
 
 
 def _get_folder_name(report_data_type: ReportDataType) -> str:

--- a/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from pyspark.sql import SparkSession
 
-from settlement_report_job.domain import time_series_writer
+from settlement_report_job.domain import csv_writer
 from settlement_report_job.domain.metering_point_resolution import (
     DataProductMeteringPointResolution,
 )
@@ -72,7 +72,7 @@ def _execute_time_series(
         requesting_actor_market_role=args.requesting_actor_market_role,
         requesting_actor_id=args.requesting_actor_id,
     )
-    time_series_files = time_series_writer.write(
+    time_series_files = csv_writer.write(
         dbutils,
         args,
         time_series_df,

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from settlement_report_job.domain import time_series_writer
+from settlement_report_job.domain import csv_writer
 
 from pyspark.sql import SparkSession, DataFrame
 import pyspark.sql.functions as F
@@ -68,10 +68,10 @@ def test_write__returns_files_corresponding_to_grid_area_codes(
     df_prepared_time_series = factory.create(spark, test_spec)
 
     # Act
-    result_files = time_series_writer.write(
+    result_files = csv_writer.write(
         dbutils=dbutils,
         args=standard_wholesale_fixing_scenario_args,
-        prepared_time_series=df_prepared_time_series,
+        df=df_prepared_time_series,
         report_data_type=report_data_type,
     )
 
@@ -97,10 +97,10 @@ def test_write__when_higher_default_parallelism__number_of_files_is_unchanged(
     df_prepared_time_series = factory.create(spark, test_spec)
 
     # Act
-    result_files = time_series_writer.write(
+    result_files = csv_writer.write(
         dbutils=dbutils,
         args=standard_wholesale_fixing_scenario_args,
-        prepared_time_series=df_prepared_time_series,
+        df=df_prepared_time_series,
         report_data_type=report_data_type,
     )
 
@@ -136,10 +136,10 @@ def test_write__when_prevent_large_files_is_enabled__writes_expected_number_of_f
     df_prepared_time_series = factory.create(spark, test_spec)
 
     # Act
-    result_files = time_series_writer.write(
+    result_files = csv_writer.write(
         dbutils=dbutils,
         args=standard_wholesale_fixing_scenario_args,
-        prepared_time_series=df_prepared_time_series,
+        df=df_prepared_time_series,
         report_data_type=report_data_type,
         rows_per_file=rows_per_file,
     )
@@ -184,10 +184,10 @@ def test_write__files_have_correct_ordering_for_each_file(
     df_prepared_time_series = df_prepared_time_series.orderBy(F.rand())
 
     # Act
-    result_files = time_series_writer.write(
+    result_files = csv_writer.write(
         dbutils=dbutils,
         args=standard_wholesale_fixing_scenario_args,
-        prepared_time_series=df_prepared_time_series,
+        df=df_prepared_time_series,
         report_data_type=report_data_type,
         rows_per_file=rows_per_file,
     )
@@ -234,10 +234,10 @@ def test_write__files_have_correct_ordering_for_each_grid_area_code_file(
     df_prepared_time_series = df_prepared_time_series.orderBy(F.rand())
 
     # Act
-    result_files = time_series_writer.write(
+    result_files = csv_writer.write(
         dbutils=dbutils,
         args=standard_wholesale_fixing_scenario_args,
-        prepared_time_series=df_prepared_time_series,
+        df=df_prepared_time_series,
         report_data_type=report_data_type,
     )
 
@@ -285,10 +285,10 @@ def test_write__files_have_correct_ordering_for_multiple_metering_point_types(
     ).orderBy(F.rand())
 
     # Act
-    result_files = time_series_writer.write(
+    result_files = csv_writer.write(
         dbutils=dbutils,
         args=standard_wholesale_fixing_scenario_args,
-        prepared_time_series=df_prepared_time_series,
+        df=df_prepared_time_series,
         report_data_type=report_data_type,
         rows_per_file=10,
     )
@@ -341,10 +341,10 @@ def test_write__files_have_correct_sorting_across_multiple_files(
     df_prepared_time_series = df_prepared_time_series.orderBy(F.rand())
 
     # Act
-    result_files = time_series_writer.write(
+    result_files = csv_writer.write(
         dbutils=dbutils,
         args=standard_wholesale_fixing_scenario_args,
-        prepared_time_series=df_prepared_time_series,
+        df=df_prepared_time_series,
         report_data_type=report_data_type,
         rows_per_file=rows_per_file,
     )


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description
Refactors the time_series_writer of the SettlementReportJob to be more generic, in preparation for the remaining file types.
It now generalises the pre-processing of input, and allows for clear separations based on ReportType.

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
