### PR TITLE
refac: Refac logging and remove domain dependencies to infra logging

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
@@ -15,11 +15,11 @@ from typing import Any, List
 
 from pyspark.sql import DataFrame
 
+from settlement_report_job import logging
 from settlement_report_job.domain.market_role import MarketRole
 from settlement_report_job.domain.report_data_type import ReportDataType
 from settlement_report_job.domain.report_name_factory import FileNameFactory
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
-from settlement_report_job.logger import Logger
 from settlement_report_job.domain.csv_column_names import (
     TimeSeriesPointCsvColumnNames,
     EphemeralColumns,
@@ -29,13 +29,12 @@ from settlement_report_job.utils import (
     get_new_files,
     merge_files,
 )
-from settlement_report_job.infrastructure import logging_configuration
 from settlement_report_job.wholesale.column_names import DataProductColumnNames
 
-log = Logger(__name__)
+log = logging.Logger(__name__)
 
 
-@logging_configuration.use_span("settlement_report_job.csv_writer.write")
+@logging.use_span()
 def write(
     dbutils: Any,
     args: SettlementReportArgs,

--- a/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
@@ -12,7 +12,7 @@ from settlement_report_job.domain.time_series.time_series_factory import (
 from settlement_report_job.domain.task_type import TaskType
 
 from settlement_report_job.utils import create_zip_file
-from settlement_report_job.logger import Logger
+from settlement_report_job.logging import Logger
 from settlement_report_job.wholesale.data_values import (
     MeteringPointResolutionDataProductValue,
 )

--- a/source/databricks/settlement_report/settlement_report_job/domain/time_series/prepare_for_csv.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/time_series/prepare_for_csv.py
@@ -14,10 +14,10 @@
 
 from pyspark.sql import DataFrame, functions as F, Window, Column
 
+from settlement_report_job import logging
 from settlement_report_job.domain.report_naming_convention import (
     METERING_POINT_TYPES,
 )
-from settlement_report_job.logger import Logger
 from settlement_report_job.domain.csv_column_names import (
     TimeSeriesPointCsvColumnNames,
     EphemeralColumns,
@@ -25,18 +25,15 @@ from settlement_report_job.domain.csv_column_names import (
 from settlement_report_job.utils import (
     map_from_dict,
 )
-from settlement_report_job.infrastructure import logging_configuration
 from settlement_report_job.wholesale.column_names import DataProductColumnNames
 from settlement_report_job.wholesale.data_values import (
     MeteringPointResolutionDataProductValue,
 )
 
-log = Logger(__name__)
+log = logging.Logger(__name__)
 
 
-@logging_configuration.use_span(
-    "settlement_report_job.time_series_factory.prepare_for_csv"
-)
+@logging.use_span()
 def prepare_for_csv(
     filtered_time_series_points: DataFrame,
     metering_point_resolution: MeteringPointResolutionDataProductValue,

--- a/source/databricks/settlement_report/settlement_report_job/domain/time_series/read_and_filter.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/time_series/read_and_filter.py
@@ -16,24 +16,21 @@ from uuid import UUID
 
 from pyspark.sql import DataFrame, functions as F, Column
 
+from settlement_report_job import logging
 from settlement_report_job.domain.market_role import MarketRole
 from settlement_report_job.domain.repository import WholesaleRepository
 from settlement_report_job.domain.system_operator_filter import (
     filter_time_series_on_charge_owner,
 )
-from settlement_report_job.logger import Logger
-from settlement_report_job.infrastructure import logging_configuration
 from settlement_report_job.wholesale.column_names import DataProductColumnNames
 from settlement_report_job.wholesale.data_values import (
     MeteringPointResolutionDataProductValue,
 )
 
-log = Logger(__name__)
+log = logging.Logger(__name__)
 
 
-@logging_configuration.use_span(
-    "settlement_report_job.time_series_factory.read_and_filter"
-)
+@logging.use_span()
 def read_and_filter_for_wholesale(
     period_start: datetime,
     period_end: datetime,
@@ -73,9 +70,7 @@ def read_and_filter_for_wholesale(
     return time_series_points
 
 
-@logging_configuration.use_span(
-    "settlement_report_job.time_series_factory._read_from_view"
-)
+@logging.use_span()
 def _read_from_view(
     period_start: datetime,
     period_end: datetime,

--- a/source/databricks/settlement_report/settlement_report_job/domain/time_series/time_series_factory.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/time_series/time_series_factory.py
@@ -16,6 +16,7 @@ from uuid import UUID
 
 from pyspark.sql import DataFrame
 
+from settlement_report_job import logging
 from settlement_report_job.domain.market_role import MarketRole
 from settlement_report_job.domain.repository import WholesaleRepository
 from settlement_report_job.domain.time_series.prepare_for_csv import (
@@ -24,18 +25,14 @@ from settlement_report_job.domain.time_series.prepare_for_csv import (
 from settlement_report_job.domain.time_series.read_and_filter import (
     read_and_filter_for_wholesale,
 )
-from settlement_report_job.logger import Logger
-from settlement_report_job.infrastructure import logging_configuration
 from settlement_report_job.wholesale.data_values import (
     MeteringPointResolutionDataProductValue,
 )
 
-log = Logger(__name__)
+log = logging.Logger(__name__)
 
 
-@logging_configuration.use_span(
-    "settlement_report_job.time_series_factory.create_time_series_for_wholesale"
-)
+@logging.use_span()
 def create_time_series_for_wholesale(
     period_start: datetime,
     period_end: datetime,

--- a/source/databricks/settlement_report/settlement_report_job/entry_point.py
+++ b/source/databricks/settlement_report/settlement_report_job/entry_point.py
@@ -22,7 +22,7 @@ from pyspark.sql.session import SparkSession
 
 from opentelemetry.trace import SpanKind, Status, StatusCode, Span
 
-import settlement_report_job.infrastructure.logging_configuration as config
+import settlement_report_job.logging.logging_configuration as config
 from settlement_report_job.domain import report_generator
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
 from settlement_report_job.infrastructure.settlement_report_job_args import (
@@ -73,6 +73,7 @@ def start_task_with_deps(
 
     config.configure_logging(
         cloud_role_name=cloud_role_name,
+        tracer_name="settlement-report-job",
         applicationinsights_connection_string=applicationinsights_connection_string,
         extras={"Subsystem": "wholesale-aggregations"},
     )

--- a/source/databricks/settlement_report/settlement_report_job/infrastructure/settlement_report_job_args.py
+++ b/source/databricks/settlement_report/settlement_report_job/infrastructure/settlement_report_job_args.py
@@ -19,7 +19,6 @@ from argparse import Namespace
 import configargparse
 from configargparse import argparse
 
-from settlement_report_job.infrastructure import logging_configuration
 from settlement_report_job.infrastructure.args_helper import (
     valid_date,
     valid_energy_supplier_ids,
@@ -28,7 +27,7 @@ from settlement_report_job.infrastructure.calculation_type import CalculationTyp
 from settlement_report_job.infrastructure.paths import (
     get_settlement_reports_output_path,
 )
-from settlement_report_job.logger import Logger
+from settlement_report_job.logging import Logger, logging_configuration
 from settlement_report_job.domain.market_role import MarketRole
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
 import settlement_report_job.infrastructure.environment_variables as env_vars

--- a/source/databricks/settlement_report/settlement_report_job/logging/__init__.py
+++ b/source/databricks/settlement_report/settlement_report_job/logging/__init__.py
@@ -1,0 +1,8 @@
+"""
+To configure the logging module use the submodule `logging_configuration.py`.
+
+The following are the generally available hooks for logging from code.
+"""
+
+from .logger import Logger
+from .decorators import use_span

--- a/source/databricks/settlement_report/settlement_report_job/logging/decorators.py
+++ b/source/databricks/settlement_report/settlement_report_job/logging/decorators.py
@@ -1,0 +1,19 @@
+from typing import Callable, Any, Tuple, Dict
+
+from settlement_report_job.logging.logging_configuration import start_span
+
+
+def use_span(name: str | None = None) -> Callable[..., Any]:
+    """
+    Decorator for creating spans.
+    If name is not provided then the __qualname__ of the decorated function is used.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        def wrapper(*args: Tuple[Any], **kwargs: Dict[str, Any]) -> Any:
+            with start_span(name or func.__qualname__):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/source/databricks/settlement_report/settlement_report_job/logging/logger.py
+++ b/source/databricks/settlement_report/settlement_report_job/logging/logger.py
@@ -15,7 +15,7 @@
 import logging
 from typing import Any
 
-import settlement_report_job.infrastructure.logging_configuration as config
+import settlement_report_job.logging.logging_configuration as config
 
 
 class Logger:

--- a/source/databricks/settlement_report/tests/conftest.py
+++ b/source/databricks/settlement_report/tests/conftest.py
@@ -233,3 +233,14 @@ def spark(
 
     yield session
     session.stop()
+
+
+@pytest.fixture(autouse=True)
+def configure_dummy_logging() -> None:
+    """Ensure that logging hooks don't fail due to _TRACER_NAME not being set."""
+
+    from settlement_report_job.logging.logging_configuration import configure_logging
+
+    configure_logging(
+        cloud_role_name="any-cloud-role-name", tracer_name="any-tracer-name"
+    )


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Move all logging to a logging subpackage. This removes most of the remaining dependencies from `domain` to `infrastructure`. This also makes logging almost ready to extract into its own shared package.

![image](https://github.com/user-attachments/assets/f09b3c12-c031-47b2-b1f2-7076657a4c3a)


## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
