### PR TITLE
fix: Don't try to zip energy results until it is supported in dh3-infrastructure

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
@@ -115,7 +115,6 @@ def execute_zip(spark: SparkSession, dbutils: Any, args: SettlementReportArgs) -
     task_types_to_zip = {
         TaskType.HOURLY_TIME_SERIES: "hourly_time_series_files",
         TaskType.QUARTERLY_TIME_SERIES: "quarterly_time_series_files",
-        TaskType.ENERGY_RESULTS: "energy_result_files",
     }
 
     for taskKey, key in task_types_to_zip.items():


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
