### PR TITLE
feat: Added entry point for execute_energy_results

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
@@ -119,14 +119,7 @@ def execute_zip(spark: SparkSession, dbutils: Any, args: SettlementReportArgs) -
     }
 
     for taskKey, key in task_types_to_zip.items():
-        try:
-            files_to_zip.extend(
-                dbutils.jobs.taskValues.get(taskKey=taskKey.value, key=key)
-            )
-        except ValueError:
-            log.info(
-                f"Task Key {taskKey.value} was not found in TaskValues, continuing without it."
-            )
+        files_to_zip.extend(dbutils.jobs.taskValues.get(taskKey=taskKey.value, key=key))
 
     log.info(f"Files to zip: {files_to_zip}")
     zip_file_path = f"{args.settlement_reports_output_path}/{args.report_id}.zip"

--- a/source/databricks/settlement_report/settlement_report_job/entry_point.py
+++ b/source/databricks/settlement_report/settlement_report_job/entry_point.py
@@ -44,6 +44,10 @@ def start_quarterly_time_series() -> None:
     _start_task(report_generator.execute_quarterly_time_series)
 
 
+def start_energy_results() -> None:
+    _start_task(report_generator.execute_energy_results)
+
+
 def start_zip() -> None:
     _start_task(report_generator.execute_zip)
 

--- a/source/databricks/settlement_report/setup.py
+++ b/source/databricks/settlement_report/setup.py
@@ -34,6 +34,7 @@ setup(
         "console_scripts": [
             "create_hourly_time_series    = settlement_report_job.entry_point:start_hourly_time_series",
             "create_quarterly_time_series = settlement_report_job.entry_point:start_quarterly_time_series",
+            "create_energy_results        = settlement_report_job.entry_point:start_energy_results",
             "create_zip                   = settlement_report_job.entry_point:start_zip",
         ]
     },

--- a/source/databricks/settlement_report/tests/entry_points/test_entry_points.py
+++ b/source/databricks/settlement_report/tests/entry_points/test_entry_points.py
@@ -40,6 +40,7 @@ def assert_entry_point_exists(entry_point_name: str) -> Any:
     [
         "create_hourly_time_series",
         "create_quarterly_time_series",
+        "create_energy_results",
         "create_zip",
     ],
 )


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Adds the entry point necessary to start a task that points to execute_energy_results.
This is needed for a DH3 infrastructure PR that will follow this one, such that the job includes the energy_result file type.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
