### PR TITLE
fix: Added timestampFormat as CSV option

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/utils.py
+++ b/source/databricks/settlement_report/settlement_report_job/utils.py
@@ -104,7 +104,7 @@ def get_dbutils(spark: SparkSession) -> Any:
 
 
 def _get_csv_writer_options_based_on_locale(locale: str) -> dict[str, str]:
-    options_to_always_include = {"timestampFormat": "yyyy-MM-dd HH:mm:ss"}
+    options_to_always_include = {"timestampFormat": "yyyy-MM-dd'T'HH:mm:ss'Z'"}
     if locale.lower() == "en-gb":
         return options_to_always_include | {"locale": "en-gb", "delimiter": ","}
     if locale.lower() == "da-dk":

--- a/source/databricks/settlement_report/settlement_report_job/utils.py
+++ b/source/databricks/settlement_report/settlement_report_job/utils.py
@@ -104,12 +104,13 @@ def get_dbutils(spark: SparkSession) -> Any:
 
 
 def _get_csv_writer_options_based_on_locale(locale: str) -> dict[str, str]:
+    options_to_always_include = {"timestampFormat": "yyyy-MM-dd HH:mm:ss"}
     if locale.lower() == "en-gb":
-        return {"locale": "en-gb", "delimiter": ","}
+        return options_to_always_include | {"locale": "en-gb", "delimiter": ","}
     if locale.lower() == "da-dk":
-        return {"locale": "da-dk", "delimiter": ";"}
+        return options_to_always_include | {"locale": "da-dk", "delimiter": ";"}
     else:
-        return {"locale": "en-us", "delimiter": ","}
+        return options_to_always_include | {"locale": "en-us", "delimiter": ","}
 
 
 def _convert_all_floats_to_danish_csv_format(df: DataFrame) -> DataFrame:

--- a/source/databricks/settlement_report/tests/test_settlement_report_utils.py
+++ b/source/databricks/settlement_report/tests/test_settlement_report_utils.py
@@ -331,15 +331,15 @@ def test_write_files__when_df_includes_timestamps__creates_csv_without_milliseco
 
                 assert (
                     all_lines_written[0]
-                    == f"a{expected_delimiter}2024-10-21 12:10:30\n"
+                    == f"a{expected_delimiter}2024-10-21T12:10:30Z\n"
                 )
                 assert (
                     all_lines_written[1]
-                    == f"b{expected_delimiter}2024-10-21 12:10:30\n"
+                    == f"b{expected_delimiter}2024-10-21T12:10:30Z\n"
                 )
                 assert (
                     all_lines_written[2]
-                    == f"c{expected_delimiter}2024-10-21 12:10:30\n"
+                    == f"c{expected_delimiter}2024-10-21T12:10:30Z\n"
                 )
 
     assert columns == ["key", "value"]

--- a/source/databricks/settlement_report/tests/test_settlement_report_utils.py
+++ b/source/databricks/settlement_report/tests/test_settlement_report_utils.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import pytest
+from datetime import datetime
 from tempfile import TemporaryDirectory
 from pyspark.sql import SparkSession, DataFrame, Row, functions as F
 from pyspark.sql.types import (
@@ -291,3 +292,46 @@ def test_convert_all_floats_to_danish_csv_format__when_locale_danish__floating_p
         assert "," in row.float
         assert "," in row.decimal
         assert "," in row.double
+
+
+@pytest.mark.parametrize("locale", ["da-dk", "en-gb", "en-us"])
+def test_write_files__when_df_includes_timestamps__creates_csv_without_milliseconds(
+    spark: SparkSession, locale: str
+):
+    # Arrange
+    df = spark.createDataFrame(
+        [
+            ("a", datetime(2024, 10, 21, 12, 10, 30, 0)),
+            ("b", datetime(2024, 10, 21, 12, 10, 30, 30)),
+            ("c", datetime(2024, 10, 21, 12, 10, 30, 123)),
+        ],
+        ["key", "value"],
+    )
+    tmp_dir = TemporaryDirectory()
+    csv_path = f"{tmp_dir.name}/csv_file"
+
+    # Act
+    columns = write_files(
+        df,
+        csv_path,
+        partition_columns=[],
+        order_by=[],
+        locale=locale,
+        rows_per_file=1000,
+    )
+
+    # Assert
+    assert Path(csv_path).exists()
+
+    for x in Path(csv_path).iterdir():
+        if x.is_file() and x.name[-4:] == ".csv":
+            with x.open(mode="r") as f:
+                all_lines_written = f.readlines()
+
+                assert all_lines_written[0] == "a;2024-10-21 12:10:30\n"
+                assert all_lines_written[1] == "b;2024-10-21 12:10:30\n"
+                assert all_lines_written[2] == "c;2024-10-21 12:10:30\n"
+
+    assert columns == ["key", "value"]
+
+    tmp_dir.cleanup()

--- a/source/databricks/settlement_report/tests/test_settlement_report_utils.py
+++ b/source/databricks/settlement_report/tests/test_settlement_report_utils.py
@@ -309,6 +309,7 @@ def test_write_files__when_df_includes_timestamps__creates_csv_without_milliseco
     )
     tmp_dir = TemporaryDirectory()
     csv_path = f"{tmp_dir.name}/csv_file"
+    expected_delimiter = ";" if locale == "da-dk" else ","
 
     # Act
     columns = write_files(
@@ -328,9 +329,15 @@ def test_write_files__when_df_includes_timestamps__creates_csv_without_milliseco
             with x.open(mode="r") as f:
                 all_lines_written = f.readlines()
 
-                assert all_lines_written[0] == "a;2024-10-21 12:10:30\n"
-                assert all_lines_written[1] == "b;2024-10-21 12:10:30\n"
-                assert all_lines_written[2] == "c;2024-10-21 12:10:30\n"
+                assert (
+                    all_lines_written[0] == "a{expected_delimiter}2024-10-21 12:10:30\n"
+                )
+                assert (
+                    all_lines_written[1] == "b{expected_delimiter}2024-10-21 12:10:30\n"
+                )
+                assert (
+                    all_lines_written[2] == "c{expected_delimiter}2024-10-21 12:10:30\n"
+                )
 
     assert columns == ["key", "value"]
 

--- a/source/databricks/settlement_report/tests/test_settlement_report_utils.py
+++ b/source/databricks/settlement_report/tests/test_settlement_report_utils.py
@@ -330,13 +330,16 @@ def test_write_files__when_df_includes_timestamps__creates_csv_without_milliseco
                 all_lines_written = f.readlines()
 
                 assert (
-                    all_lines_written[0] == "a{expected_delimiter}2024-10-21 12:10:30\n"
+                    all_lines_written[0]
+                    == f"a{expected_delimiter}2024-10-21 12:10:30\n"
                 )
                 assert (
-                    all_lines_written[1] == "b{expected_delimiter}2024-10-21 12:10:30\n"
+                    all_lines_written[1]
+                    == f"b{expected_delimiter}2024-10-21 12:10:30\n"
                 )
                 assert (
-                    all_lines_written[2] == "c{expected_delimiter}2024-10-21 12:10:30\n"
+                    all_lines_written[2]
+                    == f"c{expected_delimiter}2024-10-21 12:10:30\n"
                 )
 
     assert columns == ["key", "value"]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

As noted by Irene, the current default CSV writer's options has a timestampFormat using milliseconds. 
This PR gets rid of it, regardless of what locale has been chosen.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
