### PR TITLE
Changed prevent-large-files behaviour

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/utils.py
+++ b/source/databricks/settlement_report/settlement_report_job/utils.py
@@ -154,11 +154,12 @@ def write_files(
         list[str]: Headers for the csv file.
     """
     if EphemeralColumns.chunk_index in partition_columns:
-        w = Window().orderBy(order_by)
-        chunk_index_col = F.floor(
-            (F.row_number().over(w) - F.lit(1)) / F.lit(rows_per_file)
-        )  # Subtract one as row_number starts at 1
-        df = df.withColumn(EphemeralColumns.chunk_index, chunk_index_col)
+        if df.count() > rows_per_file:
+            w = Window().orderBy(order_by)
+            chunk_index_col = F.ceil((F.row_number().over(w)) / F.lit(rows_per_file))
+            df = df.withColumn(EphemeralColumns.chunk_index, chunk_index_col)
+        else:
+            partition_columns.remove(EphemeralColumns.chunk_index)
 
     df = df.orderBy(order_by)
 

--- a/source/databricks/settlement_report/settlement_report_job/utils.py
+++ b/source/databricks/settlement_report/settlement_report_job/utils.py
@@ -154,12 +154,9 @@ def write_files(
         list[str]: Headers for the csv file.
     """
     if EphemeralColumns.chunk_index in partition_columns:
-        if df.count() > rows_per_file:
-            w = Window().orderBy(order_by)
-            chunk_index_col = F.ceil((F.row_number().over(w)) / F.lit(rows_per_file))
-            df = df.withColumn(EphemeralColumns.chunk_index, chunk_index_col)
-        else:
-            partition_columns.remove(EphemeralColumns.chunk_index)
+        w = Window().orderBy(order_by)
+        chunk_index_col = F.ceil((F.row_number().over(w)) / F.lit(rows_per_file))
+        df = df.withColumn(EphemeralColumns.chunk_index, chunk_index_col)
 
     df = df.orderBy(order_by)
 
@@ -228,7 +225,7 @@ def get_new_files(
         else:
             energy_supplier_id = None
 
-        if EphemeralColumns.chunk_index in partition_columns:
+        if EphemeralColumns.chunk_index in partition_columns and len(files) > 1:
             group_count += 1
             chunk_index = groups[group_count]
         else:


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Changes a few things on the advice of Irene, such that:
Chunks are now 1-indexed instead of 0-indexed.
If a file is already small enough that it would be in one chunk, the flag prevent-large-files is disregarded basically.

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
