### PR TITLE
fix: Creates an ephemeral Grid Area Code to keep partition column.

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_column_names.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_column_names.py
@@ -23,9 +23,10 @@ class CsvColumnNames:
 
 
 class EphemeralColumns:
-    """Columns that are added to the DataFrame for processing but not part of the input
-    or output schema."""
+    # Columns that are added to the DataFrame for processing
+    # but not part of the input or output schema.
 
+    grid_area_code = "grid_area_code_partition"
     chunk_index = "chunk_index_partition"
     start_of_day = "start_of_day"
     quantities = "quantities"

--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
@@ -91,9 +91,10 @@ def _get_partition_columns_for_report_type(
 
         if args.prevent_large_text_files:
             partition_columns.append(EphemeralColumns.chunk_index)
+
     if report_type in [ReportDataType.EnergyResults]:
         if args.split_report_by_grid_area:
-            partition_columns = [CsvColumnNames.grid_area_code]
+            partition_columns = [EphemeralColumns.grid_area_code]
 
         if _is_partitioning_by_energy_supplier_id_needed(args):
             partition_columns.append(CsvColumnNames.energy_supplier_id)

--- a/source/databricks/settlement_report/settlement_report_job/domain/energy_results/energy_results_factory.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/energy_results/energy_results_factory.py
@@ -41,4 +41,4 @@ def create_energy_results(
 ) -> DataFrame:
     energy = read_and_filter_from_view(args, repository)
 
-    return prepare_for_csv(energy)
+    return prepare_for_csv(energy, args.split_report_by_grid_area)

--- a/source/databricks/settlement_report/settlement_report_job/domain/energy_results/energy_results_factory.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/energy_results/energy_results_factory.py
@@ -41,4 +41,6 @@ def create_energy_results(
 ) -> DataFrame:
     energy = read_and_filter_from_view(args, repository)
 
-    return prepare_for_csv(energy, args.split_report_by_grid_area)
+    return prepare_for_csv(
+        energy, create_ephemeral_grid_area_column=args.split_report_by_grid_area
+    )

--- a/source/databricks/settlement_report/settlement_report_job/domain/energy_results/prepare_for_csv.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/energy_results/prepare_for_csv.py
@@ -17,6 +17,7 @@ from pyspark.sql import DataFrame, functions as F, Window
 from settlement_report_job import logging
 from settlement_report_job.domain.csv_column_names import (
     CsvColumnNames,
+    EphemeralColumns,
 )
 from settlement_report_job.utils import (
     map_from_dict,
@@ -30,6 +31,7 @@ log = logging.Logger(__name__)
 @logging.use_span()
 def prepare_for_csv(
     energy: DataFrame,
+    create_ephemeral_grid_area_column: bool,
 ) -> DataFrame:
     select_columns = [
         F.col(DataProductColumnNames.grid_area_code).alias(
@@ -54,6 +56,13 @@ def prepare_for_csv(
             1,
             F.col(DataProductColumnNames.energy_supplier_id).alias(
                 CsvColumnNames.energy_supplier_id
+            ),
+        )
+
+    if create_ephemeral_grid_area_column:
+        select_columns.append(
+            F.col(DataProductColumnNames.grid_area_code).alias(
+                EphemeralColumns.grid_area_code
             ),
         )
 

--- a/source/databricks/settlement_report/settlement_report_job/utils.py
+++ b/source/databricks/settlement_report/settlement_report_job/utils.py
@@ -201,8 +201,8 @@ def get_new_files(
     if CsvColumnNames.grid_area_code in partition_columns:
         regex = f"{regex}/{CsvColumnNames.grid_area_code}=(\\w{{3}})"
 
-    if DataProductColumnNames.grid_area_code in partition_columns:
-        regex = f"{regex}/{DataProductColumnNames.grid_area_code}=(\\w{{3}})"
+    if EphemeralColumns.grid_area_code in partition_columns:
+        regex = f"{regex}/{EphemeralColumns.grid_area_code}=(\\w{{3}})"
 
     if CsvColumnNames.energy_supplier_id in partition_columns:
         regex = f"{regex}/{CsvColumnNames.energy_supplier_id}=(\\w+)"

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -15,13 +15,26 @@ from settlement_report_job.domain import csv_writer
 
 from pyspark.sql import SparkSession, DataFrame
 import pyspark.sql.functions as F
+from settlement_report_job.domain.market_role import (
+    MarketRole,
+)
+from settlement_report_job.domain.energy_results.prepare_for_csv import (
+    prepare_for_csv,
+)
+from tests.data_seeding import (
+    standard_wholesale_fixing_scenario_data_generator,
+)
+from tests.test_factories.default_test_data_spec import (
+    create_energy_results_data_spec,
+)
 from tests.dbutils_fixture import DBUtilsFixture
 from functools import reduce
 import pytest
 from settlement_report_job.domain.report_data_type import ReportDataType
 
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
-import test_factories.time_series_csv_factory as factory
+import test_factories.time_series_csv_factory as time_series_factory
+import test_factories.energy_factory as energy_factory
 from settlement_report_job.domain.csv_column_names import (
     CsvColumnNames,
     EphemeralColumns,
@@ -64,12 +77,12 @@ def test_write__returns_files_corresponding_to_grid_area_codes(
         if resolution == MeteringPointResolutionDataProductValue.HOUR
         else ReportDataType.TimeSeriesQuarterly
     )
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         grid_area_codes=grid_area_codes,
         resolution=resolution,
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
 
     # Act
     result_files = csv_writer.write(
@@ -94,11 +107,11 @@ def test_write__when_higher_default_parallelism__number_of_files_is_unchanged(
     spark.conf.set("spark.default.parallelism", "10")
     report_data_type = ReportDataType.TimeSeriesHourly
     expected_file_count = 2
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         grid_area_codes=["804", "805"],
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
 
     # Act
     result_files = csv_writer.write(
@@ -133,11 +146,11 @@ def test_write__when_prevent_large_files_is_enabled__writes_expected_number_of_f
     # Arrange
     report_data_type = ReportDataType.TimeSeriesHourly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=number_of_rows,
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
 
     # Act
     result_files = csv_writer.write(
@@ -179,12 +192,12 @@ def test_write__files_have_correct_ordering_for_each_file(
     ]
     report_data_type = ReportDataType.TimeSeriesHourly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=number_of_metering_points,
         num_days_per_metering_point=number_of_days_for_each_mp,
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
     df_prepared_time_series = df_prepared_time_series.orderBy(F.rand())
 
     # Act
@@ -233,12 +246,12 @@ def test_write__files_have_correct_ordering_for_each_grid_area_code_file(
         CsvColumnNames.start_of_day,
     ]
     report_data_type = ReportDataType.TimeSeriesHourly
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         grid_area_codes=grid_area_codes,
         num_metering_points=number_of_rows,
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
     df_prepared_time_series = df_prepared_time_series.orderBy(F.rand())
 
     # Act
@@ -280,18 +293,22 @@ def test_write__files_have_correct_ordering_for_multiple_metering_point_types(
     report_data_type = ReportDataType.TimeSeriesQuarterly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
     standard_wholesale_fixing_scenario_args.locale = "en-gb"
-    test_spec_consumption = factory.TimeSeriesCsvTestDataSpec(
+    test_spec_consumption = time_series_factory.TimeSeriesCsvTestDataSpec(
         metering_point_type=MeteringPointTypeDataProductValue.CONSUMPTION,
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=10,
     )
-    test_spec_production = factory.TimeSeriesCsvTestDataSpec(
+    test_spec_production = time_series_factory.TimeSeriesCsvTestDataSpec(
         metering_point_type=MeteringPointTypeDataProductValue.PRODUCTION,
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=20,
     )
-    df_prepared_time_series_consumption = factory.create(spark, test_spec_consumption)
-    df_prepared_time_series_production = factory.create(spark, test_spec_production)
+    df_prepared_time_series_consumption = time_series_factory.create(
+        spark, test_spec_consumption
+    )
+    df_prepared_time_series_production = time_series_factory.create(
+        spark, test_spec_production
+    )
     df_prepared_time_series = df_prepared_time_series_consumption.union(
         df_prepared_time_series_production
     ).orderBy(F.rand())
@@ -349,11 +366,11 @@ def test_write__files_have_correct_sorting_across_multiple_files(
     ]
     report_data_type = ReportDataType.TimeSeriesHourly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=number_of_rows,
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
     df_prepared_time_series = df_prepared_time_series.orderBy(F.rand())
 
     # Act
@@ -391,12 +408,12 @@ def test_write__when_prevent_large_files__chunk_index_start_at_1(
     report_data_type = ReportDataType.TimeSeriesQuarterly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
     standard_wholesale_fixing_scenario_args.locale = "en-gb"
-    test_spec_consumption = factory.TimeSeriesCsvTestDataSpec(
+    test_spec_consumption = time_series_factory.TimeSeriesCsvTestDataSpec(
         metering_point_type=MeteringPointTypeDataProductValue.CONSUMPTION,
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=30,
     )
-    df_prepared_time_series = factory.create(spark, test_spec_consumption)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec_consumption)
 
     # Act
     result_files = csv_writer.write(
@@ -427,12 +444,12 @@ def test_write__when_prevent_large_files_but_too_few_rows__chunk_index_should_be
     report_data_type = ReportDataType.TimeSeriesQuarterly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
     standard_wholesale_fixing_scenario_args.locale = "en-gb"
-    test_spec_consumption = factory.TimeSeriesCsvTestDataSpec(
+    test_spec_consumption = time_series_factory.TimeSeriesCsvTestDataSpec(
         metering_point_type=MeteringPointTypeDataProductValue.CONSUMPTION,
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=30,
     )
-    df_prepared_time_series = factory.create(spark, test_spec_consumption)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec_consumption)
 
     # Act
     result_files = csv_writer.write(
@@ -457,3 +474,66 @@ def test_write__when_prevent_large_files_but_too_few_rows__chunk_index_should_be
         ), "A valid integer indicating a present chunk index was found when not expected!"
     except ValueError:
         pass
+
+
+def test_write__when_energy_and_split_report_by_grid_area_is_false__returns_expected_number_of_files_and_content(
+    spark: SparkSession,
+    dbutils: DBUtilsFixture,
+    standard_wholesale_fixing_scenario_args: SettlementReportArgs,
+):
+    # Arrange
+    expected_file_count = 1  # corresponding to the number of grid areas in standard_wholesale_fixing_scenario
+    expected_columns = [
+        CsvColumnNames.grid_area_code,
+        CsvColumnNames.energy_supplier_id,
+        CsvColumnNames.calculation_type,
+        CsvColumnNames.time,
+        CsvColumnNames.resolution,
+        CsvColumnNames.metering_point_type,
+        CsvColumnNames.settlement_method,
+        CsvColumnNames.quantity,
+    ]
+
+    expected_file_names = [
+        "RESULTENERGY_804_02-01-2024_02-01-2024.csv",
+    ]
+
+    standard_wholesale_fixing_scenario_args.requesting_actor_market_role = (
+        MarketRole.DATAHUB_ADMINISTRATOR
+    )
+    standard_wholesale_fixing_scenario_args.calculation_id_by_grid_area = {
+        standard_wholesale_fixing_scenario_data_generator.GRID_AREAS[
+            0
+        ]: standard_wholesale_fixing_scenario_args.calculation_id_by_grid_area[
+            standard_wholesale_fixing_scenario_data_generator.GRID_AREAS[0]
+        ]
+    }
+    standard_wholesale_fixing_scenario_args.energy_supplier_ids = None
+    standard_wholesale_fixing_scenario_args.split_report_by_grid_area = True
+
+    df = prepare_for_csv(
+        energy_factory.create_energy_per_es_v1(
+            spark, create_energy_results_data_spec(grid_area_code="804")
+        ),
+        standard_wholesale_fixing_scenario_args.split_report_by_grid_area,
+    )
+
+    # Act
+    actual_files = csv_writer.write(
+        dbutils,
+        standard_wholesale_fixing_scenario_args,
+        df,
+        ReportDataType.EnergyResults,
+        10000,
+    )
+
+    # Assert
+    actual_file_names = [file.split("/")[-1] for file in actual_files]
+    for actual_file_name in actual_file_names:
+        assert actual_file_name in expected_file_names
+
+    assert len(actual_files) == expected_file_count
+    for file_path in actual_files:
+        df = spark.read.option("delimiter", ";").csv(file_path, header=True)
+        assert df.count() > 0
+        assert df.columns == expected_columns

--- a/source/databricks/settlement_report/tests/domain/test_execute_energy_results.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_energy_results.py
@@ -1,5 +1,6 @@
 from pyspark.sql import SparkSession
 
+from tests.data_seeding import standard_wholesale_fixing_scenario_data_generator
 from tests.dbutils_fixture import DBUtilsFixture
 from settlement_report_job.domain.report_generator import execute_energy_results
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
@@ -30,6 +31,7 @@ def test_execute_energy_results__when_standard_wholesale_fixing_scenario__return
         # Arrange
         expected_file_count = 2  # corresponding to the number of grid areas in standard_wholesale_fixing_scenario
         expected_columns = [
+            CsvColumnNames.grid_area_code,
             CsvColumnNames.calculation_type,
             CsvColumnNames.time,
             CsvColumnNames.resolution,
@@ -61,6 +63,62 @@ def test_execute_energy_results__when_standard_wholesale_fixing_scenario__return
         reset_task_values(dbutils)
 
 
+def test_execute_energy_results__when_split_report_by_grid_area_is_false__returns_expected_number_of_files_and_content(
+    spark: SparkSession,
+    dbutils: DBUtilsFixture,
+    standard_wholesale_fixing_scenario_args: SettlementReportArgs,
+    standard_wholesale_fixing_scenario_data_written_to_delta: None,
+):
+    try:
+        standard_wholesale_fixing_scenario_args.requesting_actor_market_role = (
+            MarketRole.DATAHUB_ADMINISTRATOR
+        )
+        standard_wholesale_fixing_scenario_args.calculation_id_by_grid_area = {
+            standard_wholesale_fixing_scenario_data_generator.GRID_AREAS[
+                0
+            ]: standard_wholesale_fixing_scenario_args.calculation_id_by_grid_area[
+                standard_wholesale_fixing_scenario_data_generator.GRID_AREAS[0]
+            ]
+        }
+        standard_wholesale_fixing_scenario_args.energy_supplier_ids = None
+        standard_wholesale_fixing_scenario_args.split_report_by_grid_area = True
+        # Arrange
+        expected_file_count = 1  # corresponding to the number of grid areas in standard_wholesale_fixing_scenario
+        expected_columns = [
+            CsvColumnNames.grid_area_code,
+            CsvColumnNames.energy_supplier_id,
+            CsvColumnNames.calculation_type,
+            CsvColumnNames.time,
+            CsvColumnNames.resolution,
+            CsvColumnNames.metering_point_type,
+            CsvColumnNames.settlement_method,
+            CsvColumnNames.quantity,
+        ]
+
+        expected_file_names = [
+            "RESULTENERGY_804_02-01-2024_02-01-2024.csv",
+        ]
+
+        # Act
+        execute_energy_results(spark, dbutils, standard_wholesale_fixing_scenario_args)
+
+        # Assert
+        actual_files = dbutils.jobs.taskValues.get("energy_result_files")
+
+        actual_file_names = [file.split("/")[-1] for file in actual_files]
+        for actual_file_name in actual_file_names:
+            assert actual_file_name in expected_file_names
+
+        assert len(actual_files) == expected_file_count
+        for file_path in actual_files:
+            df = spark.read.option("delimiter", ";").csv(file_path, header=True)
+            assert df.count() > 0
+            assert df.columns == expected_columns
+
+    finally:
+        reset_task_values(dbutils)
+
+
 def test_execute_energy_results__when_standard_wholesale_fixing_scenario_grid_access__returns_expected_number_of_files_and_content(
     spark: SparkSession,
     dbutils: DBUtilsFixture,
@@ -76,6 +134,7 @@ def test_execute_energy_results__when_standard_wholesale_fixing_scenario_grid_ac
         # Arrange
         expected_file_count = 2  # corresponding to the number of grid areas in standard_wholesale_fixing_scenario
         expected_columns = [
+            CsvColumnNames.grid_area_code,
             CsvColumnNames.calculation_type,
             CsvColumnNames.time,
             CsvColumnNames.resolution,
@@ -127,6 +186,7 @@ def test_execute_energy_results__when_standard_wholesale_fixing_scenario_energy_
         # Arrange
         expected_file_count = 2  # corresponding to the number of grid areas in standard_wholesale_fixing_scenario
         expected_columns = [
+            CsvColumnNames.grid_area_code,
             CsvColumnNames.calculation_type,
             CsvColumnNames.time,
             CsvColumnNames.resolution,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Currently, when we set split_report_by_grid_area, we end up partitioning by grid_area_code in energy_results.
This means that the actual column data is dropped, and we have now decided we always want to keep it.

To do so, this PR creates an EphemeralColumn copy of the grid_area_code, and uses that for the partitioning.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
