### PR TITLE
fix: Grid Area is no longer always assumed as a partition  column

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, List
+from typing import Any
 
 from pyspark.sql import DataFrame
 
@@ -86,7 +86,7 @@ def _check_if_only_one_grid_area_is_selected(args: SettlementReportArgs) -> bool
 
 def _get_partition_columns_for_report_type(
     report_type: ReportDataType, args: SettlementReportArgs
-) -> List[str]:
+) -> list[str]:
     partition_columns = []
     if report_type in [
         ReportDataType.TimeSeriesHourly,
@@ -113,7 +113,7 @@ def _get_partition_columns_for_report_type(
 
 def _get_order_by_columns_for_report_type(
     report_type: ReportDataType, args: SettlementReportArgs
-) -> List[str]:
+) -> list[str]:
     if report_type in [
         ReportDataType.TimeSeriesHourly,
         ReportDataType.TimeSeriesQuarterly,

--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
@@ -96,9 +96,6 @@ def _get_partition_columns_for_report_type(
         if _is_partitioning_by_energy_supplier_id_needed(args):
             partition_columns.append(CsvColumnNames.energy_supplier_id)
 
-        if args.prevent_large_text_files:
-            partition_columns.append(EphemeralColumns.chunk_index)
-
     if report_type in [ReportDataType.EnergyResults]:
         if args.split_report_by_grid_area or _check_if_only_one_grid_area_is_selected(
             args
@@ -107,6 +104,9 @@ def _get_partition_columns_for_report_type(
 
         if _is_partitioning_by_energy_supplier_id_needed(args):
             partition_columns.append(CsvColumnNames.energy_supplier_id)
+
+    if args.prevent_large_text_files:
+        partition_columns.append(EphemeralColumns.chunk_index)
 
     return partition_columns
 

--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
@@ -77,7 +77,7 @@ def write(
     return files
 
 
-def _check_if_only_one_grid_area_is_selected(args: SettlementReportArgs):
+def _check_if_only_one_grid_area_is_selected(args: SettlementReportArgs) -> bool:
     return (
         args.calculation_id_by_grid_area and len(args.calculation_id_by_grid_area) == 1
     ) or (args.grid_area_codes and len(args.grid_area_codes) == 1)

--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
@@ -79,8 +79,9 @@ def write(
 
 def _check_if_only_one_grid_area_is_selected(args: SettlementReportArgs) -> bool:
     return (
-        args.calculation_id_by_grid_area and len(args.calculation_id_by_grid_area) == 1
-    ) or (args.grid_area_codes and len(args.grid_area_codes) == 1)
+        args.calculation_id_by_grid_area is not None
+        and len(args.calculation_id_by_grid_area) == 1
+    ) or (args.grid_area_codes is not None and len(args.grid_area_codes) == 1)
 
 
 def _get_partition_columns_for_report_type(

--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
@@ -77,6 +77,12 @@ def write(
     return files
 
 
+def _check_if_only_one_grid_area_is_selected(args: SettlementReportArgs):
+    return (
+        args.calculation_id_by_grid_area and len(args.calculation_id_by_grid_area) == 1
+    ) or (args.grid_area_codes and len(args.grid_area_codes) == 1)
+
+
 def _get_partition_columns_for_report_type(
     report_type: ReportDataType, args: SettlementReportArgs
 ) -> List[str]:
@@ -93,7 +99,9 @@ def _get_partition_columns_for_report_type(
             partition_columns.append(EphemeralColumns.chunk_index)
 
     if report_type in [ReportDataType.EnergyResults]:
-        if args.split_report_by_grid_area:
+        if args.split_report_by_grid_area or _check_if_only_one_grid_area_is_selected(
+            args
+        ):
             partition_columns = [EphemeralColumns.grid_area_code]
 
         if _is_partitioning_by_energy_supplier_id_needed(args):

--- a/source/databricks/settlement_report/settlement_report_job/utils.py
+++ b/source/databricks/settlement_report/settlement_report_job/utils.py
@@ -234,8 +234,8 @@ def get_new_files(
             energy_supplier_id = None
 
         if EphemeralColumns.chunk_index in partition_columns and len(files) > 1:
-            group_count += 1
             chunk_index = groups[group_count]
+            group_count += 1
         else:
             chunk_index = None
 

--- a/source/databricks/settlement_report/settlement_report_job/utils.py
+++ b/source/databricks/settlement_report/settlement_report_job/utils.py
@@ -220,7 +220,7 @@ def get_new_files(
 
         if (
             CsvColumnNames.grid_area_code in partition_columns
-            or DataProductColumnNames.grid_area_code in partition_columns
+            or EphemeralColumns.grid_area_code in partition_columns
         ):
             grid_area = groups[group_count]
             group_count += 1
@@ -240,7 +240,9 @@ def get_new_files(
             chunk_index = None
 
         file_name = file_name_factory.create(
-            grid_area, energy_supplier_id=energy_supplier_id, chunk_index=chunk_index
+            grid_area_code=grid_area,
+            energy_supplier_id=energy_supplier_id,
+            chunk_index=chunk_index,
         )
         new_name = Path(report_output_path) / file_name
         tmp_dst = Path("/tmp") / file_name

--- a/source/databricks/settlement_report/settlement_report_job/utils.py
+++ b/source/databricks/settlement_report/settlement_report_job/utils.py
@@ -158,7 +158,7 @@ def write_files(
         chunk_index_col = F.ceil((F.row_number().over(w)) / F.lit(rows_per_file))
         df = df.withColumn(EphemeralColumns.chunk_index, chunk_index_col)
 
-    df = df.orderBy(order_by)
+    df = df.orderBy(*order_by)
 
     if locale.lower() == "da-dk":
         df = _convert_all_floats_to_danish_csv_format(df)

--- a/source/databricks/settlement_report/settlement_report_job/utils.py
+++ b/source/databricks/settlement_report/settlement_report_job/utils.py
@@ -158,7 +158,8 @@ def write_files(
         chunk_index_col = F.ceil((F.row_number().over(w)) / F.lit(rows_per_file))
         df = df.withColumn(EphemeralColumns.chunk_index, chunk_index_col)
 
-    df = df.orderBy(*order_by)
+    if len(order_by) > 0:
+        df = df.orderBy(*order_by)
 
     if locale.lower() == "da-dk":
         df = _convert_all_floats_to_danish_csv_format(df)

--- a/source/databricks/settlement_report/settlement_report_job/utils.py
+++ b/source/databricks/settlement_report/settlement_report_job/utils.py
@@ -216,12 +216,20 @@ def get_new_files(
             raise ValueError(f"File {f} does not match the expected pattern")
 
         groups = partition_match.groups()
-
         group_count = 0
-        grid_area = groups[group_count] if len(groups) > 0 else None
-        if CsvColumnNames.energy_supplier_id in partition_columns:
+
+        if (
+            CsvColumnNames.grid_area_code in partition_columns
+            or DataProductColumnNames.grid_area_code in partition_columns
+        ):
+            grid_area = groups[group_count]
             group_count += 1
+        else:
+            grid_area = None
+
+        if CsvColumnNames.energy_supplier_id in partition_columns:
             energy_supplier_id = groups[group_count]
+            group_count += 1
         else:
             energy_supplier_id = None
 

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -545,7 +545,7 @@ def test_write__when_energy_supplier_is_only_partition_for_energy_results__retur
     standard_wholesale_fixing_scenario_args: SettlementReportArgs,
 ):
     # Arrange
-    expected_file_count = 1  # corresponding to the number of grid areas in standard_wholesale_fixing_scenario
+    expected_file_count = 1
     expected_columns = [
         CsvColumnNames.grid_area_code,
         CsvColumnNames.calculation_type,

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -15,13 +15,26 @@ from settlement_report_job.domain import csv_writer
 
 from pyspark.sql import SparkSession, DataFrame
 import pyspark.sql.functions as F
+from settlement_report_job.domain.market_role import (
+    MarketRole,
+)
+from settlement_report_job.domain.energy_results.prepare_for_csv import (
+    prepare_for_csv,
+)
+from tests.data_seeding import (
+    standard_wholesale_fixing_scenario_data_generator,
+)
+from tests.test_factories.default_test_data_spec import (
+    create_energy_results_data_spec,
+)
 from tests.dbutils_fixture import DBUtilsFixture
 from functools import reduce
 import pytest
 from settlement_report_job.domain.report_data_type import ReportDataType
 
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
-import test_factories.time_series_csv_factory as factory
+import test_factories.time_series_csv_factory as time_series_factory
+import test_factories.energy_factory as energy_factory
 from settlement_report_job.domain.csv_column_names import (
     CsvColumnNames,
     EphemeralColumns,
@@ -64,12 +77,12 @@ def test_write__returns_files_corresponding_to_grid_area_codes(
         if resolution == MeteringPointResolutionDataProductValue.HOUR
         else ReportDataType.TimeSeriesQuarterly
     )
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         grid_area_codes=grid_area_codes,
         resolution=resolution,
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
 
     # Act
     result_files = csv_writer.write(
@@ -94,11 +107,11 @@ def test_write__when_higher_default_parallelism__number_of_files_is_unchanged(
     spark.conf.set("spark.default.parallelism", "10")
     report_data_type = ReportDataType.TimeSeriesHourly
     expected_file_count = 2
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         grid_area_codes=["804", "805"],
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
 
     # Act
     result_files = csv_writer.write(
@@ -133,11 +146,11 @@ def test_write__when_prevent_large_files_is_enabled__writes_expected_number_of_f
     # Arrange
     report_data_type = ReportDataType.TimeSeriesHourly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=number_of_rows,
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
 
     # Act
     result_files = csv_writer.write(
@@ -179,12 +192,12 @@ def test_write__files_have_correct_ordering_for_each_file(
     ]
     report_data_type = ReportDataType.TimeSeriesHourly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=number_of_metering_points,
         num_days_per_metering_point=number_of_days_for_each_mp,
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
     df_prepared_time_series = df_prepared_time_series.orderBy(F.rand())
 
     # Act
@@ -233,12 +246,12 @@ def test_write__files_have_correct_ordering_for_each_grid_area_code_file(
         CsvColumnNames.start_of_day,
     ]
     report_data_type = ReportDataType.TimeSeriesHourly
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         grid_area_codes=grid_area_codes,
         num_metering_points=number_of_rows,
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
     df_prepared_time_series = df_prepared_time_series.orderBy(F.rand())
 
     # Act
@@ -280,18 +293,22 @@ def test_write__files_have_correct_ordering_for_multiple_metering_point_types(
     report_data_type = ReportDataType.TimeSeriesQuarterly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
     standard_wholesale_fixing_scenario_args.locale = "en-gb"
-    test_spec_consumption = factory.TimeSeriesCsvTestDataSpec(
+    test_spec_consumption = time_series_factory.TimeSeriesCsvTestDataSpec(
         metering_point_type=MeteringPointTypeDataProductValue.CONSUMPTION,
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=10,
     )
-    test_spec_production = factory.TimeSeriesCsvTestDataSpec(
+    test_spec_production = time_series_factory.TimeSeriesCsvTestDataSpec(
         metering_point_type=MeteringPointTypeDataProductValue.PRODUCTION,
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=20,
     )
-    df_prepared_time_series_consumption = factory.create(spark, test_spec_consumption)
-    df_prepared_time_series_production = factory.create(spark, test_spec_production)
+    df_prepared_time_series_consumption = time_series_factory.create(
+        spark, test_spec_consumption
+    )
+    df_prepared_time_series_production = time_series_factory.create(
+        spark, test_spec_production
+    )
     df_prepared_time_series = df_prepared_time_series_consumption.union(
         df_prepared_time_series_production
     ).orderBy(F.rand())
@@ -349,11 +366,11 @@ def test_write__files_have_correct_sorting_across_multiple_files(
     ]
     report_data_type = ReportDataType.TimeSeriesHourly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
-    test_spec = factory.TimeSeriesCsvTestDataSpec(
+    test_spec = time_series_factory.TimeSeriesCsvTestDataSpec(
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=number_of_rows,
     )
-    df_prepared_time_series = factory.create(spark, test_spec)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec)
     df_prepared_time_series = df_prepared_time_series.orderBy(F.rand())
 
     # Act
@@ -391,12 +408,12 @@ def test_write__when_prevent_large_files__chunk_index_start_at_1(
     report_data_type = ReportDataType.TimeSeriesQuarterly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
     standard_wholesale_fixing_scenario_args.locale = "en-gb"
-    test_spec_consumption = factory.TimeSeriesCsvTestDataSpec(
+    test_spec_consumption = time_series_factory.TimeSeriesCsvTestDataSpec(
         metering_point_type=MeteringPointTypeDataProductValue.CONSUMPTION,
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=30,
     )
-    df_prepared_time_series = factory.create(spark, test_spec_consumption)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec_consumption)
 
     # Act
     result_files = csv_writer.write(
@@ -427,12 +444,12 @@ def test_write__when_prevent_large_files_but_too_few_rows__chunk_index_should_be
     report_data_type = ReportDataType.TimeSeriesQuarterly
     standard_wholesale_fixing_scenario_args.prevent_large_text_files = True
     standard_wholesale_fixing_scenario_args.locale = "en-gb"
-    test_spec_consumption = factory.TimeSeriesCsvTestDataSpec(
+    test_spec_consumption = time_series_factory.TimeSeriesCsvTestDataSpec(
         metering_point_type=MeteringPointTypeDataProductValue.CONSUMPTION,
         start_of_day=standard_wholesale_fixing_scenario_args.period_start,
         num_metering_points=30,
     )
-    df_prepared_time_series = factory.create(spark, test_spec_consumption)
+    df_prepared_time_series = time_series_factory.create(spark, test_spec_consumption)
 
     # Act
     result_files = csv_writer.write(
@@ -457,3 +474,133 @@ def test_write__when_prevent_large_files_but_too_few_rows__chunk_index_should_be
         ), "A valid integer indicating a present chunk index was found when not expected!"
     except ValueError:
         pass
+
+
+def test_write__when_energy_and_split_report_by_grid_area_is_false__returns_expected_number_of_files_and_content(
+    spark: SparkSession,
+    dbutils: DBUtilsFixture,
+    standard_wholesale_fixing_scenario_args: SettlementReportArgs,
+):
+    # Arrange
+    expected_file_count = 1  # corresponding to the number of grid areas in standard_wholesale_fixing_scenario
+    expected_columns = [
+        CsvColumnNames.grid_area_code,
+        CsvColumnNames.energy_supplier_id,
+        CsvColumnNames.calculation_type,
+        CsvColumnNames.time,
+        CsvColumnNames.resolution,
+        CsvColumnNames.metering_point_type,
+        CsvColumnNames.settlement_method,
+        CsvColumnNames.quantity,
+    ]
+
+    expected_file_names = [
+        "RESULTENERGY_804_02-01-2024_02-01-2024.csv",
+    ]
+
+    standard_wholesale_fixing_scenario_args.requesting_actor_market_role = (
+        MarketRole.DATAHUB_ADMINISTRATOR
+    )
+    standard_wholesale_fixing_scenario_args.calculation_id_by_grid_area = {
+        standard_wholesale_fixing_scenario_data_generator.GRID_AREAS[
+            0
+        ]: standard_wholesale_fixing_scenario_args.calculation_id_by_grid_area[
+            standard_wholesale_fixing_scenario_data_generator.GRID_AREAS[0]
+        ]
+    }
+    standard_wholesale_fixing_scenario_args.energy_supplier_ids = None
+    standard_wholesale_fixing_scenario_args.split_report_by_grid_area = True
+
+    df = prepare_for_csv(
+        energy_factory.create_energy_per_es_v1(
+            spark, create_energy_results_data_spec(grid_area_code="804")
+        ),
+        standard_wholesale_fixing_scenario_args.split_report_by_grid_area,
+    )
+
+    # Act
+    actual_files = csv_writer.write(
+        dbutils,
+        standard_wholesale_fixing_scenario_args,
+        df,
+        ReportDataType.EnergyResults,
+        10000,
+    )
+
+    # Assert
+    actual_file_names = [file.split("/")[-1] for file in actual_files]
+    for actual_file_name in actual_file_names:
+        assert actual_file_name in expected_file_names
+
+    assert len(actual_files) == expected_file_count
+    for file_path in actual_files:
+        df = spark.read.option("delimiter", ";").csv(file_path, header=True)
+        assert df.count() > 0
+        assert df.columns == expected_columns
+
+
+def test_write__when_energy_supplier_is_only_partition_for_energy_results__returns_correct_columns_and_files(
+    spark: SparkSession,
+    dbutils: DBUtilsFixture,
+    standard_wholesale_fixing_scenario_args: SettlementReportArgs,
+):
+    # Arrange
+    expected_file_count = 1  # corresponding to the number of grid areas in standard_wholesale_fixing_scenario
+    expected_columns = [
+        CsvColumnNames.grid_area_code,
+        CsvColumnNames.calculation_type,
+        CsvColumnNames.time,
+        CsvColumnNames.resolution,
+        CsvColumnNames.metering_point_type,
+        CsvColumnNames.settlement_method,
+        CsvColumnNames.quantity,
+    ]
+
+    expected_file_names = [
+        "RESULTENERGY_flere-net_1000000000000_DDQ_02-01-2024_02-01-2024.csv",
+    ]
+
+    standard_wholesale_fixing_scenario_args.requesting_actor_market_role = (
+        MarketRole.ENERGY_SUPPLIER
+    )
+    energy_supplier_id = "1000000000000"
+    standard_wholesale_fixing_scenario_args.requesting_actor_id = energy_supplier_id
+    standard_wholesale_fixing_scenario_args.energy_supplier_ids = [energy_supplier_id]
+    standard_wholesale_fixing_scenario_args.split_report_by_grid_area = False
+
+    df = prepare_for_csv(
+        energy_factory.create_energy_per_es_v1(
+            spark,
+            create_energy_results_data_spec(
+                grid_area_code="804", energy_supplier_id=energy_supplier_id
+            ),
+        ).union(
+            energy_factory.create_energy_per_es_v1(
+                spark,
+                create_energy_results_data_spec(
+                    grid_area_code="805", energy_supplier_id=energy_supplier_id
+                ),
+            )
+        )
+        # standard_wholesale_fixing_scenario_args.split_report_by_grid_area,
+    )
+
+    # Act
+    actual_files = csv_writer.write(
+        dbutils,
+        standard_wholesale_fixing_scenario_args,
+        df,
+        ReportDataType.EnergyResults,
+        10000,
+    )
+
+    # Assert
+    actual_file_names = [file.split("/")[-1] for file in actual_files]
+    for actual_file_name in actual_file_names:
+        assert actual_file_name in expected_file_names
+
+    assert len(actual_files) == expected_file_count
+    for file_path in actual_files:
+        df = spark.read.option("delimiter", ";").csv(file_path, header=True)
+        assert df.count() > 0
+        assert df.columns == expected_columns

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -536,7 +536,7 @@ def test_write__when_energy_and_split_report_by_grid_area_is_false__returns_expe
     for file_path in actual_files:
         df = spark.read.option("delimiter", ";").csv(file_path, header=True)
         assert df.count() > 0
-        assert df.columns == expected_columns 
+        assert df.columns == expected_columns
 
 
 def test_write__when_energy_supplier_is_only_partition_for_energy_results__returns_correct_columns_and_files(

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -539,7 +539,7 @@ def test_write__when_energy_and_split_report_by_grid_area_is_false__returns_expe
         assert df.columns == expected_columns
 
 
-def test_write__when_energy_supplier_is_only_partition_for_energy_results__returns_correct_columns_and_files(
+def test_write__when_energy_supplier_and_split_per_grid_area_is_false__returns_correct_columns_and_files(
     spark: SparkSession,
     dbutils: DBUtilsFixture,
     standard_wholesale_fixing_scenario_args: SettlementReportArgs,

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -581,8 +581,8 @@ def test_write__when_energy_supplier_is_only_partition_for_energy_results__retur
                     grid_area_code="805", energy_supplier_id=energy_supplier_id
                 ),
             )
-        )
-        # standard_wholesale_fixing_scenario_args.split_report_by_grid_area,
+        ),
+        standard_wholesale_fixing_scenario_args.split_report_by_grid_area,
     )
 
     # Act

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -539,7 +539,8 @@ def test_write__when_energy_and_split_report_by_grid_area_is_false__returns_expe
         assert df.columns == expected_columns
 
 
-def test_write__when_energy_supplier_and_split_per_grid_area_is_false__returns_correct_columns_and_files(
+def test_write__when_energy_supplier_and_split_per_grid_area_is_false__returns_correct_columns_and_files
+(
     spark: SparkSession,
     dbutils: DBUtilsFixture,
     standard_wholesale_fixing_scenario_args: SettlementReportArgs,

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -539,8 +539,7 @@ def test_write__when_energy_and_split_report_by_grid_area_is_false__returns_expe
         assert df.columns == expected_columns
 
 
-def test_write__when_energy_supplier_and_split_per_grid_area_is_false__returns_correct_columns_and_files
-(
+def test_write__when_energy_supplier_and_split_per_grid_area_is_false__returns_correct_columns_and_files(
     spark: SparkSession,
     dbutils: DBUtilsFixture,
     standard_wholesale_fixing_scenario_args: SettlementReportArgs,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

If a request is sent in, which would result in not having grid area be a partition column for energy results, but at the same time having energy_supplier_id (or chunk_index) being a partition column, then it would fail. This fixes it, by not always assuming grid area is a partition column.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
