### PR TITLE
fix: Avoid large size on task values 

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
@@ -21,6 +21,7 @@ from settlement_report_job.domain.report_data_type import ReportDataType
 from settlement_report_job.domain.report_name_factory import FileNameFactory
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
 from settlement_report_job.domain.csv_column_names import EphemeralColumns
+from settlement_report_job.infrastructure.paths import get_report_output_path
 from settlement_report_job.utils import (
     write_files,
     get_new_files,
@@ -40,7 +41,7 @@ def write(
     rows_per_file: int = 1_000_000,
 ) -> list[str]:
 
-    report_output_path = f"{args.settlement_reports_output_path}/{args.report_id}"
+    report_output_path = get_report_output_path(args)
     spark_output_path = f"{report_output_path}/{_get_folder_name(report_data_type)}"
 
     partition_columns = []

--- a/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/csv_writer.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from typing import Any
 
 from pyspark.sql import DataFrame
@@ -64,12 +65,15 @@ def write(
         file_name_factory,
         partition_columns=partition_columns,
     )
-    files = merge_files(
+    files_paths = merge_files(
         dbutils=dbutils,
         new_files=new_files,
         headers=headers,
     )
-    return files
+
+    file_names = [os.path.basename(file_path) for file_path in files_paths]
+
+    return file_names
 
 
 def _get_folder_name(report_data_type: ReportDataType) -> str:

--- a/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
@@ -22,6 +22,7 @@ from settlement_report_job.domain.wholesale_results.wholesale_results_factory im
     create_wholesale_results,
 )
 from settlement_report_job.infrastructure.calculation_type import CalculationType
+from settlement_report_job.infrastructure.paths import get_report_output_path
 
 from settlement_report_job.utils import create_zip_file
 from settlement_report_job.logging import Logger
@@ -207,7 +208,7 @@ def execute_zip(spark: SparkSession, dbutils: Any, args: SettlementReportArgs) -
             file_names = dbutils.jobs.taskValues.get(taskKey=taskKey.value, key=key)
             files_to_zip.extend(
                 [
-                    f"{args.settlement_reports_output_path}/{file_name}"
+                    f"{get_report_output_path(args)}/{file_name}"
                     for file_name in file_names
                 ]
             )

--- a/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/report_generator.py
@@ -204,8 +204,12 @@ def execute_zip(spark: SparkSession, dbutils: Any, args: SettlementReportArgs) -
 
     for taskKey, key in task_types_to_zip.items():
         try:
+            file_names = dbutils.jobs.taskValues.get(taskKey=taskKey.value, key=key)
             files_to_zip.extend(
-                dbutils.jobs.taskValues.get(taskKey=taskKey.value, key=key)
+                [
+                    f"{args.settlement_reports_output_path}/{file_name}"
+                    for file_name in file_names
+                ]
             )
         except ValueError:
             log.info(

--- a/source/databricks/settlement_report/settlement_report_job/infrastructure/paths.py
+++ b/source/databricks/settlement_report/settlement_report_job/infrastructure/paths.py
@@ -1,2 +1,9 @@
+from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
+
+
 def get_settlement_reports_output_path(catalog_name: str) -> str:
     return f"/Volumes/{catalog_name}/wholesale_settlement_report_output/settlement_reports"  # noqa: E501
+
+
+def get_report_output_path(args: SettlementReportArgs) -> str:
+    return f"{args.settlement_reports_output_path}/{args.report_id}"

--- a/source/databricks/settlement_report/tests/domain/assertion.py
+++ b/source/databricks/settlement_report/tests/domain/assertion.py
@@ -1,7 +1,16 @@
-def assert_files(actual_files, expected_columns, expected_file_names, spark):
+from pyspark.sql import SparkSession
+
+
+def assert_files(
+    path: str,
+    actual_files: list[str],
+    expected_columns: list[str],
+    expected_file_names: list[str],
+    spark: SparkSession,
+):
     assert len(actual_files) == len(expected_file_names)
     for file_path in actual_files:
-        df = spark.read.csv(file_path, header=True)
+        df = spark.read.csv(f"{path}/{file_path}", header=True)
         assert df.count() > 0
         assert df.columns == expected_columns
         assert any(file_name in file_path for file_name in expected_file_names)

--- a/source/databricks/settlement_report/tests/domain/assertion.py
+++ b/source/databricks/settlement_report/tests/domain/assertion.py
@@ -1,16 +1,15 @@
 from pyspark.sql import SparkSession
 
 
-def assert_files(
+def assert_file_names_and_columns(
     path: str,
     actual_files: list[str],
     expected_columns: list[str],
     expected_file_names: list[str],
     spark: SparkSession,
 ):
-    assert len(actual_files) == len(expected_file_names)
-    for file_path in actual_files:
-        df = spark.read.csv(f"{path}/{file_path}", header=True)
+    assert set(actual_files) == set(expected_file_names)
+    for file_name in actual_files:
+        df = spark.read.csv(f"{path}/{file_name}", header=True)
         assert df.count() > 0
         assert df.columns == expected_columns
-        assert any(file_name in file_path for file_name in expected_file_names)

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -572,7 +572,6 @@ def test_write__when_energy_supplier_and_split_per_grid_area_is_false__returns_c
     standard_wholesale_fixing_scenario_args: SettlementReportArgs,
 ):
     # Arrange
-    expected_file_count = 1
     expected_columns = [
         CsvColumnNames.grid_area_code,
         CsvColumnNames.calculation_type,

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from domain.assertion import assert_file_names_and_columns
 from settlement_report_job.domain import csv_writer
 
 from pyspark.sql import SparkSession, DataFrame
@@ -52,21 +53,6 @@ def _read_csv_file(
 ) -> DataFrame:
     file_name = f"{directory}/{file_name}"
     return spark.read.csv(file_name, header=True)
-
-
-def _assert_file_names_and_columns(
-    actual_file_names,
-    expected_columns,
-    expected_file_names,
-    spark,
-    args,
-):
-    assert set(actual_file_names) == set(expected_file_names)
-    for file_name in actual_file_names:
-        file_path = f"{get_report_output_path(args)}/{file_name}"
-        df = spark.read.csv(file_path, header=True)
-        assert df.count() > 0
-        assert df.columns == expected_columns
 
 
 @pytest.mark.parametrize(
@@ -112,7 +98,6 @@ def test_write__returns_files_corresponding_to_grid_area_codes(
     )
 
     # Assert
-    assert len(result_files) > 0
     assert len(result_files) == expected_file_count
 
 
@@ -145,7 +130,6 @@ def test_write__when_higher_default_parallelism__number_of_files_is_unchanged(
     )
 
     # Assert
-    assert len(result_files) > 0
     assert len(result_files) == expected_file_count
 
 
@@ -190,7 +174,6 @@ def test_write__when_prevent_large_files_is_enabled__writes_expected_number_of_f
 
     # Assert
     assert df_prepared_time_series.count() == number_of_rows
-    assert len(result_files) > 0
     assert len(result_files) == expected_file_count
 
 
@@ -555,12 +538,12 @@ def test_write__when_energy_and_split_report_by_grid_area_is_false__returns_expe
     )
 
     # Assert
-    _assert_file_names_and_columns(
-        actual_file_names,
-        expected_columns,
-        expected_file_names,
-        spark,
-        standard_wholesale_fixing_scenario_args,
+    assert_file_names_and_columns(
+        path=get_report_output_path(standard_wholesale_fixing_scenario_args),
+        actual_files=actual_file_names,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
     )
 
 
@@ -624,12 +607,12 @@ def test_write__when_energy_supplier_and_split_per_grid_area_is_false__returns_c
     )
 
     # Assert
-    _assert_file_names_and_columns(
-        actual_file_names,
-        expected_columns,
-        expected_file_names,
-        spark,
-        standard_wholesale_fixing_scenario_args,
+    assert_file_names_and_columns(
+        path=get_report_output_path(standard_wholesale_fixing_scenario_args),
+        actual_files=actual_file_names,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
     )
 
 
@@ -696,10 +679,10 @@ def test_write__when_energy_and_prevent_large_files__returns_expected_number_of_
     )
 
     # Assert
-    _assert_file_names_and_columns(
-        actual_file_names,
-        expected_columns,
-        expected_file_names,
-        spark,
-        standard_wholesale_fixing_scenario_args,
+    assert_file_names_and_columns(
+        path=get_report_output_path(standard_wholesale_fixing_scenario_args),
+        actual_files=actual_file_names,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
     )

--- a/source/databricks/settlement_report/tests/domain/test_csv_writer.py
+++ b/source/databricks/settlement_report/tests/domain/test_csv_writer.py
@@ -356,8 +356,6 @@ def test_write__files_have_correct_ordering_for_multiple_metering_point_types(
         individual_dataframes.append(_read_csv_file(directory, file, spark))
     df_actual = reduce(DataFrame.unionByName, individual_dataframes)
     df_expected = df_actual.orderBy(expected_order_by)
-    print(df_actual.collect()[0], df_expected.collect()[0])
-    print(df_actual.collect()[-1], df_expected.collect()[-1])
     assert df_actual.collect() == df_expected.collect()
 
 

--- a/source/databricks/settlement_report/tests/domain/test_execute_charge_links.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_charge_links.py
@@ -13,6 +13,7 @@ from settlement_report_job.domain.settlement_report_args import SettlementReport
 from settlement_report_job.domain.csv_column_names import (
     CsvColumnNames,
 )
+from settlement_report_job.infrastructure.paths import get_report_output_path
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -51,7 +52,15 @@ def test_execute_charge_links__when_energy_supplier__returns_expected(
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get(key="charge_links_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(
+            standard_wholesale_fixing_scenario_energy_supplier_args
+        ),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 def test_execute_charge_links__when_grid_access_provider__returns_expected(
@@ -83,7 +92,15 @@ def test_execute_charge_links__when_grid_access_provider__returns_expected(
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("charge_links_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(
+            standard_wholesale_fixing_scenario_grid_access_provider_args
+        ),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 @pytest.mark.parametrize(
@@ -125,7 +142,13 @@ def test_execute_charge_links__when_system_operator_or_datahub_admin_with_one_en
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("charge_links_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 @pytest.mark.parametrize(
@@ -163,7 +186,13 @@ def test_execute_charge_links__when_system_operator_or_datahub_admin_with_none_e
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("charge_links_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 def test_execute_charge_links__when_include_basis_data_false__returns_no_file_paths(

--- a/source/databricks/settlement_report/tests/domain/test_execute_charge_links.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_charge_links.py
@@ -6,7 +6,7 @@ import pytest
 from tests.dbutils_fixture import DBUtilsFixture
 
 from data_seeding import standard_wholesale_fixing_scenario_data_generator
-from domain.assertion import assert_files
+from domain.assertion import assert_file_names_and_columns
 from settlement_report_job.domain.market_role import MarketRole
 from settlement_report_job.domain.report_generator import execute_charge_links
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
@@ -52,7 +52,7 @@ def test_execute_charge_links__when_energy_supplier__returns_expected(
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get(key="charge_links_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(
             standard_wholesale_fixing_scenario_energy_supplier_args
         ),
@@ -92,7 +92,7 @@ def test_execute_charge_links__when_grid_access_provider__returns_expected(
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("charge_links_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(
             standard_wholesale_fixing_scenario_grid_access_provider_args
         ),
@@ -142,7 +142,7 @@ def test_execute_charge_links__when_system_operator_or_datahub_admin_with_one_en
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("charge_links_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(args),
         actual_files=actual_files,
         expected_columns=expected_columns,
@@ -186,7 +186,7 @@ def test_execute_charge_links__when_system_operator_or_datahub_admin_with_none_e
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("charge_links_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(args),
         actual_files=actual_files,
         expected_columns=expected_columns,

--- a/source/databricks/settlement_report/tests/domain/test_execute_charge_links.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_charge_links.py
@@ -1,5 +1,3 @@
-import copy
-
 from pyspark.sql import SparkSession
 import pytest
 

--- a/source/databricks/settlement_report/tests/domain/test_execute_energy_results.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_energy_results.py
@@ -4,7 +4,7 @@ from pyspark.sql import SparkSession
 from tests.data_seeding import standard_wholesale_fixing_scenario_data_generator
 from tests.dbutils_fixture import DBUtilsFixture
 
-from domain.assertion import assert_files
+from domain.assertion import assert_file_names_and_columns
 from settlement_report_job.domain.report_generator import execute_energy_results
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
 from settlement_report_job.domain.csv_column_names import (
@@ -53,7 +53,7 @@ def test_execute_energy_results__when_standard_wholesale_fixing_scenario__return
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("energy_result_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(standard_wholesale_fixing_scenario_args),
         actual_files=actual_files,
         expected_columns=expected_columns,
@@ -101,7 +101,7 @@ def test_execute_energy_results__when_split_report_by_grid_area_is_false__return
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("energy_result_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(standard_wholesale_fixing_scenario_args),
         actual_files=actual_files,
         expected_columns=expected_columns,
@@ -142,7 +142,7 @@ def test_execute_energy_results__when_standard_wholesale_fixing_scenario_grid_ac
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("energy_result_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(standard_wholesale_fixing_scenario_args),
         actual_files=actual_files,
         expected_columns=expected_columns,
@@ -183,7 +183,7 @@ def test_execute_energy_results__when_standard_wholesale_fixing_scenario_energy_
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("energy_result_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(standard_wholesale_fixing_scenario_args),
         actual_files=actual_files,
         expected_columns=expected_columns,

--- a/source/databricks/settlement_report/tests/domain/test_execute_energy_results.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_energy_results.py
@@ -11,6 +11,7 @@ from settlement_report_job.domain.csv_column_names import (
     CsvColumnNames,
 )
 from settlement_report_job.domain.market_role import MarketRole
+from settlement_report_job.infrastructure.paths import get_report_output_path
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -52,7 +53,13 @@ def test_execute_energy_results__when_standard_wholesale_fixing_scenario__return
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("energy_result_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(standard_wholesale_fixing_scenario_args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 def test_execute_energy_results__when_split_report_by_grid_area_is_false__returns_expected_number_of_files_and_content(
@@ -94,7 +101,13 @@ def test_execute_energy_results__when_split_report_by_grid_area_is_false__return
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("energy_result_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(standard_wholesale_fixing_scenario_args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 def test_execute_energy_results__when_standard_wholesale_fixing_scenario_grid_access__returns_expected_number_of_files_and_content(
@@ -129,7 +142,13 @@ def test_execute_energy_results__when_standard_wholesale_fixing_scenario_grid_ac
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("energy_result_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(standard_wholesale_fixing_scenario_args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 def test_execute_energy_results__when_standard_wholesale_fixing_scenario_energy_supplier__returns_expected_number_of_files_and_content(
@@ -164,4 +183,10 @@ def test_execute_energy_results__when_standard_wholesale_fixing_scenario_energy_
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("energy_result_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(standard_wholesale_fixing_scenario_args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )

--- a/source/databricks/settlement_report/tests/domain/test_execute_hourly_time_series.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_hourly_time_series.py
@@ -9,6 +9,8 @@ from settlement_report_job.domain.settlement_report_args import SettlementReport
 from settlement_report_job.domain.csv_column_names import (
     CsvColumnNames,
 )
+from settlement_report_job.infrastructure.paths import get_report_output_path
+
 
 # NOTE: The tests in test_execute_quarterly_time_series.py should cover execute_hourly also, so we don't need to test
 # all the same things again here also.
@@ -44,4 +46,10 @@ def test_execute_hourly_time_series__when_standard_wholesale_fixing_scenario__re
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("hourly_time_series_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(standard_wholesale_fixing_scenario_args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )

--- a/source/databricks/settlement_report/tests/domain/test_execute_hourly_time_series.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_hourly_time_series.py
@@ -3,7 +3,7 @@ from pyspark.sql import SparkSession
 
 from tests.dbutils_fixture import DBUtilsFixture
 
-from domain.assertion import assert_files
+from domain.assertion import assert_file_names_and_columns
 from settlement_report_job.domain.report_generator import execute_hourly_time_series
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
 from settlement_report_job.domain.csv_column_names import (
@@ -46,7 +46,7 @@ def test_execute_hourly_time_series__when_standard_wholesale_fixing_scenario__re
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("hourly_time_series_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(standard_wholesale_fixing_scenario_args),
         actual_files=actual_files,
         expected_columns=expected_columns,

--- a/source/databricks/settlement_report/tests/domain/test_execute_quarterly_time_series.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_quarterly_time_series.py
@@ -172,7 +172,13 @@ def test_execute_quarterly_time_series__when_system_operator_or_datahub_admin_wi
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("quarterly_time_series_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 def test_execute_quarterly_time_series__when_include_basis_data_false__returns_no_file_paths(

--- a/source/databricks/settlement_report/tests/domain/test_execute_quarterly_time_series.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_quarterly_time_series.py
@@ -16,6 +16,7 @@ from settlement_report_job.domain.settlement_report_args import SettlementReport
 from settlement_report_job.domain.csv_column_names import (
     CsvColumnNames,
 )
+from settlement_report_job.infrastructure.paths import get_report_output_path
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -54,7 +55,13 @@ def test_execute_quarterly_time_series__when_energy_supplier__returns_expected(
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get(key="quarterly_time_series_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 def test_execute_quarterly_time_series__when_grid_access_provider__returns_expected(
@@ -82,7 +89,13 @@ def test_execute_quarterly_time_series__when_grid_access_provider__returns_expec
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("quarterly_time_series_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 @pytest.mark.parametrize(
@@ -119,7 +132,13 @@ def test_execute_quarterly_time_series__when_system_operator_or_datahub_admin_wi
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("quarterly_time_series_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 @pytest.mark.parametrize(
@@ -203,4 +222,10 @@ def test_execute_quarterly_time_series__when_energy_supplier_and_balance_fixing_
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get(key="quarterly_time_series_files")
-    assert_files(actual_files, expected_columns, expected_file_names, spark)
+    assert_files(
+        path=get_report_output_path(args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )

--- a/source/databricks/settlement_report/tests/domain/test_execute_quarterly_time_series.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_quarterly_time_series.py
@@ -9,7 +9,7 @@ from data_seeding import (
     standard_wholesale_fixing_scenario_data_generator,
     standard_balance_fixing_scenario_data_generator,
 )
-from domain.assertion import assert_files
+from domain.assertion import assert_file_names_and_columns
 from settlement_report_job.domain.market_role import MarketRole
 from settlement_report_job.domain.report_generator import execute_quarterly_time_series
 from settlement_report_job.domain.settlement_report_args import SettlementReportArgs
@@ -55,7 +55,7 @@ def test_execute_quarterly_time_series__when_energy_supplier__returns_expected(
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get(key="quarterly_time_series_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(args),
         actual_files=actual_files,
         expected_columns=expected_columns,
@@ -89,7 +89,7 @@ def test_execute_quarterly_time_series__when_grid_access_provider__returns_expec
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("quarterly_time_series_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(args),
         actual_files=actual_files,
         expected_columns=expected_columns,
@@ -132,7 +132,7 @@ def test_execute_quarterly_time_series__when_system_operator_or_datahub_admin_wi
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("quarterly_time_series_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(args),
         actual_files=actual_files,
         expected_columns=expected_columns,
@@ -172,7 +172,7 @@ def test_execute_quarterly_time_series__when_system_operator_or_datahub_admin_wi
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get("quarterly_time_series_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(args),
         actual_files=actual_files,
         expected_columns=expected_columns,
@@ -228,7 +228,7 @@ def test_execute_quarterly_time_series__when_energy_supplier_and_balance_fixing_
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get(key="quarterly_time_series_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(args),
         actual_files=actual_files,
         expected_columns=expected_columns,

--- a/source/databricks/settlement_report/tests/domain/test_execute_wholesale_results.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_wholesale_results.py
@@ -1,10 +1,6 @@
 from pyspark.sql import SparkSession
 import pytest
 
-
-from data_seeding import (
-    standard_wholesale_fixing_scenario_data_generator,
-)
 from dbutils_fixture import DBUtilsFixture
 from domain.assertion import assert_file_names_and_columns
 from settlement_report_job.domain.market_role import MarketRole

--- a/source/databricks/settlement_report/tests/domain/test_execute_wholesale_results.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_wholesale_results.py
@@ -6,6 +6,7 @@ from data_seeding import (
     standard_wholesale_fixing_scenario_data_generator,
 )
 from dbutils_fixture import DBUtilsFixture
+from domain.assertion import assert_files
 from settlement_report_job.domain.market_role import MarketRole
 from settlement_report_job.domain.report_generator import (
     execute_wholesale_results,
@@ -14,6 +15,7 @@ from settlement_report_job.domain.settlement_report_args import SettlementReport
 from settlement_report_job.domain.csv_column_names import (
     CsvColumnNames,
 )
+from settlement_report_job.infrastructure.paths import get_report_output_path
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -65,9 +67,10 @@ def test_execute_wholesale_results__when_energy_supplier_and_split_by_grid_area_
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get(key="wholesale_result_files")
-    assert len(actual_files) == len(expected_file_name)
-    for file_path in actual_files:
-        df = spark.read.csv(file_path, header=True)
-        assert df.count() > 0
-        assert df.columns == expected_columns
-        assert any(file_name in file_path for file_name in expected_file_name)
+    assert_files(
+        path=get_report_output_path(args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_name,
+        spark=spark,
+    )

--- a/source/databricks/settlement_report/tests/domain/test_execute_wholesale_results.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_wholesale_results.py
@@ -6,7 +6,7 @@ from data_seeding import (
     standard_wholesale_fixing_scenario_data_generator,
 )
 from dbutils_fixture import DBUtilsFixture
-from domain.assertion import assert_files
+from domain.assertion import assert_file_names_and_columns
 from settlement_report_job.domain.market_role import MarketRole
 from settlement_report_job.domain.report_generator import (
     execute_wholesale_results,
@@ -67,7 +67,7 @@ def test_execute_wholesale_results__when_energy_supplier_and_split_by_grid_area_
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get(key="wholesale_result_files")
-    assert_files(
+    assert_file_names_and_columns(
         path=get_report_output_path(args),
         actual_files=actual_files,
         expected_columns=expected_columns,

--- a/source/databricks/settlement_report/tests/domain/test_execute_wholesale_results.py
+++ b/source/databricks/settlement_report/tests/domain/test_execute_wholesale_results.py
@@ -46,7 +46,7 @@ def test_execute_wholesale_results__when_energy_supplier_and_split_by_grid_area_
 
     energy_supplier_id = args.energy_supplier_ids[0]
 
-    expected_file_name = [
+    expected_file_names = [
         f"RESULTWHOLESALE_flere-net_{energy_supplier_id}_{market_role_in_file_name}_{start_time}_{end_time}.csv",
     ]
     expected_columns = [
@@ -73,7 +73,13 @@ def test_execute_wholesale_results__when_energy_supplier_and_split_by_grid_area_
 
     # Assert
     actual_files = dbutils.jobs.taskValues.get(key="wholesale_result_files")
-    assert_files(actual_files, expected_columns, expected_file_name, spark)
+    assert_file_names_and_columns(
+        path=get_report_output_path(args),
+        actual_files=actual_files,
+        expected_columns=expected_columns,
+        expected_file_names=expected_file_names,
+        spark=spark,
+    )
 
 
 def test_execute_wholesale_results__when_energy_supplier_and_split_by_grid_area_is_true__returns_expected(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

Instead of storing full paths in tasks values we only store the file names. This reduces the size of the task values (there is a limit of 48 KiB 

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
