### PR TITLE
fix: Added partitioning to chunk index

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/utils.py
+++ b/source/databricks/settlement_report/settlement_report_job/utils.py
@@ -124,7 +124,10 @@ def write_files(
         list[str]: Headers for the csv file.
     """
     if EphemeralColumns.chunk_index in partition_columns:
-        w = Window().orderBy(order_by)
+        partition_columns_without_chunk = [
+            col for col in partition_columns if col != EphemeralColumns.chunk_index
+        ]
+        w = Window().partitionBy(partition_columns_without_chunk).orderBy(order_by)
         chunk_index_col = F.ceil((F.row_number().over(w)) / F.lit(rows_per_file))
         df = df.withColumn(EphemeralColumns.chunk_index, chunk_index_col)
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description
Chunk indexes are calculated incorrectly.
Currently, the chunk_index uses the rownumber of the _entire dataframe_ to calculate a chunk. However, this means each chunk could be practically empty.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
