### PR TITLE
refac: Reduce time limit on sub system test

### DIFF
--- a/source/dotnet/subsystem-tests/Features/Calculations/BalanceFixingCalculationScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/BalanceFixingCalculationScenario.cs
@@ -113,8 +113,7 @@ public class BalanceFixingCalculationScenario : SubsystemTestsBase<CalculationSc
     [SubsystemFact]
     public void AndThen_CalculationDurationIsLessThanOrEqualToTimeLimit()
     {
-        // TODO JVM: Reduce time limit to 18 minutes, when only saving to unity catalog
-        var calculationTimeLimit = TimeSpan.FromMinutes(30);
+        var calculationTimeLimit = TimeSpan.FromMinutes(18);
         var actualCalculationDuration =
             Fixture.ScenarioState.Calculation!.ExecutionTimeEnd - Fixture.ScenarioState.Calculation.ExecutionTimeStart;
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

Since we no longer write to HIVE, the sub-system timeout has been lowered to 18 minutes.

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [x] Subsystem tests have been tested (by manually deploying to `dev_002`)
