### PR TITLE
fix: Added CHARGEOWNER conditionally in MonthlyAmounts orderby

### DIFF
--- a/source/databricks/settlement_report/settlement_report_job/domain/order_by_columns.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/order_by_columns.py
@@ -117,7 +117,7 @@ def _order_by_monthly_amounts(requesting_actor_market_role: MarketRole) -> list[
         CsvColumnNames.charge_code,
         CsvColumnNames.resolution,
     ]
-    
+
     if requesting_actor_market_role in [
         MarketRole.GRID_ACCESS_PROVIDER,
         MarketRole.SYSTEM_OPERATOR,

--- a/source/databricks/settlement_report/settlement_report_job/domain/order_by_columns.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/order_by_columns.py
@@ -22,7 +22,7 @@ def get_order_by_columns(
     elif report_data_type == ReportDataType.WholesaleResults:
         return _order_by_wholesale_results()
     elif report_data_type == ReportDataType.MonthlyAmounts:
-        return _order_by_monthly_amounts()
+        return _order_by_monthly_amounts(requesting_actor_market_role)
     else:
         raise ValueError(f"Unsupported report data type: {report_data_type}")
 
@@ -109,7 +109,7 @@ def _order_by_wholesale_results() -> list:
     ]
 
 
-def _order_by_monthly_amounts(existing_column_list: list[str]) -> list[str]:
+def _order_by_monthly_amounts(requesting_actor_market_role: MarketRole) -> list[str]:
     order_by_columns = [
         CsvColumnNames.grid_area_code,
         CsvColumnNames.energy_supplier_id,
@@ -118,7 +118,10 @@ def _order_by_monthly_amounts(existing_column_list: list[str]) -> list[str]:
         CsvColumnNames.resolution,
     ]
     
-    if CsvColumnNames.charge_owner_id in existing_column_list:
+    if requesting_actor_market_role in [
+        MarketRole.GRID_ACCESS_PROVIDER,
+        MarketRole.SYSTEM_OPERATOR,
+    ]:
         order_by_columns.insert(2, CsvColumnNames.charge_owner_id)
         
     return order_by_columns

--- a/source/databricks/settlement_report/settlement_report_job/domain/order_by_columns.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/order_by_columns.py
@@ -109,12 +109,16 @@ def _order_by_wholesale_results() -> list:
     ]
 
 
-def _order_by_monthly_amounts() -> list:
-    return [
+def _order_by_monthly_amounts(existing_column_list: list[str]) -> list[str]:
+    order_by_columns = [
         CsvColumnNames.grid_area_code,
         CsvColumnNames.energy_supplier_id,
-        CsvColumnNames.charge_owner_id,
         CsvColumnNames.charge_type,
         CsvColumnNames.charge_code,
         CsvColumnNames.resolution,
     ]
+    
+    if CsvColumnNames.charge_owner_id in existing_column_list:
+        order_by_columns.insert(2, CsvColumnNames.charge_owner_id)
+        
+    return order_by_columns

--- a/source/databricks/settlement_report/settlement_report_job/domain/order_by_columns.py
+++ b/source/databricks/settlement_report/settlement_report_job/domain/order_by_columns.py
@@ -123,5 +123,5 @@ def _order_by_monthly_amounts(requesting_actor_market_role: MarketRole) -> list[
         MarketRole.SYSTEM_OPERATOR,
     ]:
         order_by_columns.insert(2, CsvColumnNames.charge_owner_id)
-        
+
     return order_by_columns


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

The list of order by columns for monthly_amouints naïvely assumes that all columns are always present, even though CHARGEOWNER might be dropped if you are Grid Access Provider og System Operator. This PR fixes that, by adding it as an order by column on the condition that it is an existing column.

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
