### PR TITLE
fix: Don't use hard coded report id in test

### DIFF
--- a/source/dotnet/subsystem-tests/Features/SettlementReports/SettlementReportWholesaleCalculationsJobGeneratesZipScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/SettlementReports/SettlementReportWholesaleCalculationsJobGeneratesZipScenario.cs
@@ -56,7 +56,7 @@ public class SettlementReportWholesaleCalculationsJobGeneratesZipScenario : Subs
         // Expectations
         Fixture.ScenarioState.ExpectedJobTimeLimit = TimeSpan.FromMinutes(15);
         Fixture.ScenarioState.ExpectedRelativeOutputFilePath =
-            $"/wholesale_settlement_report_output/settlement_reports/3b0b3d20-59b3-4025-89e8-f45a18d8959d.zip";
+            $"/wholesale_settlement_report_output/settlement_reports/{Fixture.ScenarioState.ReportId}.zip";
     }
 
     [ScenarioStep(1)]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
