### PR TITLE
test: Increase settlemenent report download limit to 20 minutes in subsystem test

### DIFF
--- a/source/dotnet/subsystem-tests/Features/SettlementReports/SettlementReportBalanceFixingJobGeneratesZipScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/SettlementReports/SettlementReportBalanceFixingJobGeneratesZipScenario.cs
@@ -53,7 +53,7 @@ public class SettlementReportBalanceFixingJobGeneratesZipScenario : SubsystemTes
         };
 
         // Expectations
-        Fixture.ScenarioState.ExpectedJobTimeLimit = TimeSpan.FromMinutes(15);
+        Fixture.ScenarioState.ExpectedJobTimeLimit = TimeSpan.FromMinutes(20);
         Fixture.ScenarioState.ExpectedRelativeOutputFilePath =
             $"/wholesale_settlement_report_output/settlement_reports/{Fixture.ScenarioState.ReportId}.zip";
     }

--- a/source/dotnet/subsystem-tests/Features/SettlementReports/SettlementReportWholesaleCalculationsJobGeneratesZipScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/SettlementReports/SettlementReportWholesaleCalculationsJobGeneratesZipScenario.cs
@@ -54,7 +54,7 @@ public class SettlementReportWholesaleCalculationsJobGeneratesZipScenario : Subs
         };
 
         // Expectations
-        Fixture.ScenarioState.ExpectedJobTimeLimit = TimeSpan.FromMinutes(15);
+        Fixture.ScenarioState.ExpectedJobTimeLimit = TimeSpan.FromMinutes(20);
         Fixture.ScenarioState.ExpectedRelativeOutputFilePath =
             $"/wholesale_settlement_report_output/settlement_reports/{Fixture.ScenarioState.ReportId}.zip";
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
