### PR TITLE
Revert "fix: Use full checkpointing to combat indeterminate calculati…

### DIFF
--- a/source/databricks/calculation_engine/package/calculator_job.py
+++ b/source/databricks/calculation_engine/package/calculator_job.py
@@ -33,7 +33,7 @@ from package.calculator_job_args import (
 )
 from package.container import create_and_configure_container
 from package.databases import migrations_wholesale, wholesale_internal
-from package.infrastructure.spark_initializor import initialize_spark
+from package.infrastructure import initialize_spark
 from package.infrastructure.infrastructure_settings import InfrastructureSettings
 
 
@@ -84,7 +84,7 @@ def start_with_deps(
 
             args, infrastructure_settings = parse_job_args(command_line_args)
 
-            spark = initialize_spark(infrastructure_settings)
+            spark = initialize_spark()
             create_and_configure_container(spark, infrastructure_settings)
 
             prepared_data_reader = create_prepared_data_reader(

--- a/source/databricks/calculation_engine/package/databases/wholesale_results_internal/energy_results.py
+++ b/source/databricks/calculation_engine/package/databases/wholesale_results_internal/energy_results.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import fields
 import pyspark.sql.functions as f
 from dependency_injector.wiring import inject, Provide
-from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import DataFrame
 from pyspark.sql.types import StructType
 
 import package.databases.wholesale_results_internal.schemas as schemas
@@ -31,21 +30,10 @@ from package.infrastructure.paths import (
 
 
 @use_span("calculation.write.energy")
-@inject
-def write_energy_results(
-    energy_results_output: EnergyResultsOutput,
-    spark: SparkSession = Provide[Container.spark],
-) -> None:
+def write_energy_results(energy_results_output: EnergyResultsOutput) -> None:
     """Write each energy result to the output table."""
 
     print("Writing energy results to Unity Catalog")
-
-    # Checkpoint all calculations pre-writing, as down-scaling during this step leads to
-    # the "indeterminate result" issue from incident INC0409592.
-    for field in fields(energy_results_output):
-        field_value = getattr(energy_results_output, field.name)
-        if field_value is not None:
-            setattr(energy_results_output, field.name, field_value.cache().checkpoint())
 
     # Write exchange per neighbor grid area
     _write(

--- a/source/databricks/calculation_engine/package/infrastructure/spark_initializor.py
+++ b/source/databricks/calculation_engine/package/infrastructure/spark_initializor.py
@@ -15,22 +15,12 @@
 from pyspark import SparkConf
 from pyspark.sql.session import SparkSession
 
-from package.infrastructure.infrastructure_settings import InfrastructureSettings
 
-
-def initialize_spark(
-    infrastructure_settings: InfrastructureSettings | None = None,
-) -> SparkSession:
+def initialize_spark() -> SparkSession:
     # Set spark config with the session timezone so that datetimes are displayed consistently (in UTC)
     spark_conf = (
         SparkConf(loadDefaults=True)
         .set("spark.sql.session.timeZone", "UTC")
         .set("spark.databricks.io.cache.enabled", "True")
     )
-    spark_session = SparkSession.builder.config(conf=spark_conf).getOrCreate()
-    if infrastructure_settings:
-        spark_session.sparkContext.setCheckpointDir(
-            f"{infrastructure_settings.wholesale_container_path}/checkpoints/calculator_job"
-        )
-
-    return spark_session
+    return SparkSession.builder.config(conf=spark_conf).getOrCreate()

--- a/source/databricks/calculation_engine/tests/conftest.py
+++ b/source/databricks/calculation_engine/tests/conftest.py
@@ -67,7 +67,6 @@ def spark(
 ) -> SparkSession:
     warehouse_location = f"{tests_path}/__spark-warehouse__"
     metastore_path = f"{tests_path}/__metastore_db__"
-    checkpoint_path = f"{tests_path}/__checkpoints__"
 
     if (
         test_session_configuration.migrations.execute.value
@@ -79,9 +78,6 @@ def spark(
         if os.path.exists(metastore_path):
             print(f"Removing metastore before clean run (path={metastore_path})")
             shutil.rmtree(metastore_path)
-        if os.path.exists(checkpoint_path):
-            print(f"Removing checkpoints before clean run (path={checkpoint_path})")
-            shutil.rmtree(checkpoint_path)
 
     session = configure_spark_with_delta_pip(
         SparkSession.builder.config("spark.sql.warehouse.dir", warehouse_location)
@@ -124,7 +120,6 @@ def spark(
         .config("hive.metastore.schema.verification.record.version", "false")
         .enableHiveSupport()
     ).getOrCreate()
-    session.sparkContext.setCheckpointDir(checkpoint_path)
 
     yield session
     session.stop()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

This reverts commit 0089fae92edff6f76ff13243ab4028cb9be8979f.
Apparently it failed subsystem tests in Dev001, despite being tested on Dev002 previously...

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
