### PR TITLE
chore: Bump nuget dependabot

### DIFF
--- a/source/dotnet/subsystem-tests/SubsystemTests.csproj
+++ b/source/dotnet/subsystem-tests/SubsystemTests.csproj
@@ -35,7 +35,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Databricks.Client" Version="2.5.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />

--- a/source/dotnet/subsystem-tests/SubsystemTests.csproj
+++ b/source/dotnet/subsystem-tests/SubsystemTests.csproj
@@ -35,7 +35,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Databricks.Client" Version="2.5.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />

--- a/source/dotnet/subsystem-tests/SubsystemTests.csproj
+++ b/source/dotnet/subsystem-tests/SubsystemTests.csproj
@@ -39,8 +39,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.66.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Application/CalculationResults.Application.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Application/CalculationResults.Application.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Energinet.DataHub.Wholesale.CalculationResults.Application</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Application/CalculationResults.Application.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Application/CalculationResults.Application.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Energinet.DataHub.Wholesale.CalculationResults.Application</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Application/CalculationResults.Application.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Application/CalculationResults.Application.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Energinet.DataHub.Wholesale.CalculationResults.Application</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Infrastructure/CalculationResults.Infrastructure.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="NodaTime" Version="3.1.12" />
+    <PackageReference Include="NodaTime" Version="3.2.0" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="8.0.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.IntegrationTests/CalculationResults.IntegrationTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults.Interfaces.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.Interfaces/CalculationResults.Interfaces.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Energinet.DataHub.Wholesale.CalculationResults.Interfaces</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.1.12" />
+    <PackageReference Include="NodaTime" Version="3.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/CalculationResults/CalculationResults.UnitTests/CalculationResults.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Application/Calculations.Application.csproj
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Application/Calculations.Application.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NodaTime" Version="3.1.12" />
+    <PackageReference Include="NodaTime" Version="3.2.0" />
     <PackageReference Include="NodaTime.Serialization.Protobuf" Version="2.0.1" />
   </ItemGroup>
 

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Calculations.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Infrastructure/Calculations.Infrastructure.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="8.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.Databricks.Jobs" Version="11.2.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-    <PackageReference Include="NodaTime" Version="3.1.12" />
+    <PackageReference Include="NodaTime" Version="3.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Calculations/Calculations.IntegrationTests/Calculations.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.IntegrationTests/Calculations.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Calculations/Calculations.Interfaces/Calculations.Interfaces.csproj
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.Interfaces/Calculations.Interfaces.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Energinet.DataHub.Wholesale.Calculations.Interfaces</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.1.12" />
+    <PackageReference Include="NodaTime" Version="3.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Calculations.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Calculations/Calculations.UnitTests/Calculations.UnitTests.csproj
@@ -6,7 +6,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Common.Infrastructure/Common.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Common.Infrastructure/Common.Infrastructure.csproj
@@ -24,7 +24,7 @@ limitations under the License.
     <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.20.1" />
     <PackageReference Include="Energinet.DataHub.Core.Databricks.SqlStatementExecution" Version="11.2.4" />
     <PackageReference Include="Energinet.DataHub.Core.Databricks.Jobs" Version="11.2.4" />
-    <PackageReference Include="Energinet.DataHub.Core.App.Common.Abstractions" Version="13.2.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.Common.Abstractions" Version="14.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />

--- a/source/dotnet/wholesale-api/Common.Infrastructure/Common.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Common.Infrastructure/Common.Infrastructure.csproj
@@ -28,7 +28,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Common.Infrastructure/Common.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Common.Infrastructure/Common.Infrastructure.csproj
@@ -28,7 +28,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Common.Infrastructure/Common.Infrastructure.csproj
+++ b/source/dotnet/wholesale-api/Common.Infrastructure/Common.Infrastructure.csproj
@@ -28,7 +28,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="7.0.1" />
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Edi.UnitTests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="7.0.1" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/source/dotnet/wholesale-api/Events/Events.IntegrationTests/Events.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.IntegrationTests/Events.IntegrationTests.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Energinet.DataHub.Wholesale.Events.IntegrationTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Events/Events.UnitTests/Events.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/Events/Events.UnitTests/Events.UnitTests.csproj
@@ -6,7 +6,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/Orchestrations/Orchestrations.csproj
+++ b/source/dotnet/wholesale-api/Orchestrations/Orchestrations.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="13.2.0" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="6.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />

--- a/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
+++ b/source/dotnet/wholesale-api/Test.Core/Test.Core.csproj
@@ -21,7 +21,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="7.0.1" />
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
+++ b/source/dotnet/wholesale-api/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
@@ -27,7 +27,7 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi.UnitTests.csproj
+++ b/source/dotnet/wholesale-api/WebApi.UnitTests/WebApi.UnitTests.csproj
@@ -36,7 +36,7 @@ limitations under the License.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# Description
Bumps [Microsoft.Extensions.DependencyInjection.Abstractions](https://github.com/dotnet/runtime) from 8.0.1 to 9.0.0.
Bumps [Microsoft.Azure.Functions.Worker.ApplicationInsights](https://github.com/Azure/azure-functions-dotnet-worker) from 1.4.0 to 2.0.0
Bumps [FluentAssertions](https://github.com/fluentassertions/fluentassertions) from 6.12.1 to 6.12.2.
Bumps [Microsoft.Extensions.Configuration](https://github.com/dotnet/runtime) from 8.0.0 to 9.0.0.
Bumps [Energinet.DataHub.Core.App.Common.Abstractions](https://github.com/Energinet-DataHub/geh-core) from 13.2.0 to 14.0.0
Bumps [NodaTime](https://github.com/nodatime/nodatime) from 3.1.12 to 3.2.0

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
