### PR TITLE
Make user id of github actions runner and docker image identical

### DIFF
--- a/.devcontainer/docker-compose-windows.yml
+++ b/.devcontainer/docker-compose-windows.yml
@@ -5,9 +5,10 @@ services:
       # Forwards the local Docker socket to the container.
       - /var/run/docker.sock:/var/run/docker-host.sock
       # Update this to wherever you want VS Code to mount the folder of your project
-      - ..:/workspaces/opengeh-wholesale:cached
+      - ..:${HOME}/work/opengeh-wholesale:cached
       # Map to Azure CLI token cache location (on Windows)
-      - "${USERPROFILE}/.azure:/home/joyvan/.azure"
+      - "${USERPROFILE}/.azure:/home/jovyan/.azure"
+    working_dir: ${HOME}/work/opengeh-wholesale
     environment:
       # Pass the environment variables from your shell straight through to your containers.
       # No warning is issued if the variable in the shell environment is not set.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,9 +5,10 @@ services:
       # Forwards the local Docker socket to the container.
       - /var/run/docker.sock:/var/run/docker-host.sock
       # Update this to wherever you want VS Code to mount the folder of your project
-      - ..:/workspaces/opengeh-wholesale:cached
+      - ..:${HOME}/work/opengeh-wholesale:cached
       # Map to Azure CLI token cache location (on Linux)
-      - "${HOME}/.azure:/home/joyvan/.azure"
+      - "${HOME}/.azure:/home/jovyan/.azure"
+    working_dir: ${HOME}/work/opengeh-wholesale
     environment:
       # Pass the environment variables from your shell straight through to your containers.
       # No warning is issued if the variable in the shell environment is not set.

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -51,6 +51,9 @@ ENV PATH=$SPARK_HOME/bin:$HADOOP_HOME/bin:$PATH \
 # Dynamically downloading spark dependencies from conf/spark-defaults.conf. This is done to save time in the build pipeline so that we don't need to download on every build.
 RUN spark-shell
 
-# Make $HOME owned by the root, which is the user used in the container
-# This is needed for e.g. commands that create files or folders in $HOME
-RUN sudo chown -R root:users $HOME
+# Change the username from jovyan to nayvoj and update the user id to 1001, as that is the user id used in the GitHub Actions runner
+RUN usermod -l nayvoj jovyan && \
+    usermod -u 1001 nayvoj && \
+    usermod -l jovyan nayvoj
+
+RUN usermod -u 1001 jovyan

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 
 # Copyright 2020 Energinet DataHub A/S
 #
@@ -21,7 +21,7 @@ echo "Tests folder path: '$1'"
 echo "Filter (paths): '$2'"
 
 # Configure Azure CLI to use token cache which must be mapped as volume from host machine
-export AZURE_CONFIG_DIR=/home/joyvan/.azure
+export AZURE_CONFIG_DIR=/home/jovyan/.azure
 
 # There env vars are important to ensure that the driver and worker nodes in spark are alligned
 export PYSPARK_PYTHON=/opt/conda/bin/python

--- a/.github/workflows/ci-databricks.yml
+++ b/.github/workflows/ci-databricks.yml
@@ -229,11 +229,6 @@ jobs:
         shell: bash
         id: test_count
         run: |
-          # Small hack to get the repository name
-          repository=${{ github.repository }}
-          repository_owner=${{ github.repository_owner }}
-          repository_name=${repository/$repository_owner\//}
-
           # IMPORTANT: When adding a new folder here, one must also add the folder
           # to one of the test jobs above! This is because this filter contains the sum of all folders
           # from test jobs.
@@ -255,7 +250,7 @@ jobs:
           optimize_job/
           datamigration/unity_catalog"
 
-          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -u root -w //workspaces/${repository_name} python-unit-test ./.devcontainer/check_test_count.sh $filter
+          IMAGE_TAG=${{ inputs.image_tag }} docker compose -f .devcontainer/docker-compose.yml run --rm -u root python-unit-test ./.devcontainer/check_test_count.sh $filter
 
   calculator_job_mypy_check:
     if: ${{ inputs.has_calculator_job_changes }}


### PR DESCRIPTION
This pull request includes several changes to configuration files and scripts to improve consistency and functionality across the project. The most important changes include updates to the Docker configuration files, modifications to user permissions in the Dockerfile, and adjustments to the entrypoint script and CI workflow.

This will make sure the user id for the github actions runner is the same as inside the container.

### Docker Configuration Updates:
* [`.devcontainer/docker-compose-windows.yml`](diffhunk://#diff-7da8718dba02e6f1fc48c79f17aa699ab5dec440ecc37d751a5480d3035fadcfL8-R11): Updated volume mounts and working directory to use `${HOME}` and corrected the Azure CLI token cache location.
* [`.devcontainer/docker-compose.yml`](diffhunk://#diff-67a4805fdcc6145d7b3ada2a6099a9b2e91c9d0fd108c22f95d2f01d219793d1L8-R11): Similar updates to volume mounts, working directory, and Azure CLI token cache location as the Windows configuration file.

### User Permissions and Environment Updates:
* [`.docker/Dockerfile`](diffhunk://#diff-38801fa32c4bd7bd97aa3c87c138be36e126e0337b22aacf27ab57365357dc20L54-R59): Changed the username from `jovyan` to `nayvoj` and updated the user ID to `1001` to match the GitHub Actions runner.
* [`.docker/entrypoint.sh`](diffhunk://#diff-d464f2255f2f24bca648f9c24fc26ecba642be2efd7afc78fb080232dee04524L1-R1): Removed the `-l` option from the bash shebang and updated the Azure CLI token cache location. [[1]](diffhunk://#diff-d464f2255f2f24bca648f9c24fc26ecba642be2efd7afc78fb080232dee04524L1-R1) [[2]](diffhunk://#diff-d464f2255f2f24bca648f9c24fc26ecba642be2efd7afc78fb080232dee04524L24-R24)

### CI Workflow Adjustments:
* [`.github/workflows/ci-databricks.yml`](diffhunk://#diff-e5b53e1912cce52237ab236856dd2ed1273a7a77ec6876cc74c5759f603ec2ccL232-L236): Removed unnecessary repository name extraction and adjusted the `docker compose` command to simplify the test count check. [[1]](diffhunk://#diff-e5b53e1912cce52237ab236856dd2ed1273a7a77ec6876cc74c5759f603ec2ccL232-L236) [[2]](diffhunk://#diff-e5b53e1912cce52237ab236856dd2ed1273a7a77ec6876cc74c5759f603ec2ccL258-R253)
