### PR TITLE
fix: Added surplus production to meter type check

### DIFF
--- a/source/databricks/calculation_engine/package/datamigration/migration_scripts/202501061330_alter_tables__metering_point_type_constraints_added_surplus_production.sql
+++ b/source/databricks/calculation_engine/package/datamigration/migration_scripts/202501061330_alter_tables__metering_point_type_constraints_added_surplus_production.sql
@@ -1,0 +1,8 @@
+ALTER TABLE {CATALOG_NAME}.{WHOLESALE_RESULTS_INTERNAL_DATABASE_NAME}.amounts_per_charge
+DROP CONSTRAINT IF EXISTS metering_point_type_chk
+GO
+
+ALTER TABLE {CATALOG_NAME}.{WHOLESALE_RESULTS_INTERNAL_DATABASE_NAME}.amounts_per_charge
+ADD CONSTRAINT metering_point_type_chk
+    CHECK (metering_point_type IN ( 'production' , 'consumption' , 'exchange' , 've_production' , 'net_production' , 'supply_to_grid' , 'consumption_from_grid' , 'wholesale_services_information' , 'own_production' , 'net_from_grid' , 'net_to_grid' , 'total_consumption' , 'electrical_heating' , 'net_consumption' , 'capacity_settlement', 'surplus_production'))
+GO


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

This PR adds specifically "surplus_production" to the delta constraints for amounts_per_charge taken from migrations.


## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
