### PR TITLE
fix: Wholesale requests spanning a change in years

### DIFF
--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/PeriodValidationRuleTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/PeriodValidationRuleTests.cs
@@ -267,7 +267,8 @@ public class PeriodValidationRuleTests
         var errors = await _sut.ValidateAsync(message);
 
         // Assert
-        errors.Should().ContainSingle().Subject.Should().Be(_invalidWinterMidnightFormat.WithPropertyName("Period Start"));
+        errors[0].Message.Should().Be(_invalidWinterMidnightFormat.WithPropertyName("Period Start").Message);
+        errors[1].Message.Should().Be(_invalidPeriodAcrossMonths.Message);
     }
 
     [Fact]

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/PeriodValidationRuleTests.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/PeriodValidationRuleTests.cs
@@ -474,6 +474,30 @@ public class PeriodValidationRuleTests
         errors.Should().ContainSingle().Subject.Should().Be(_invalidPeriodAcrossMonths);
     }
 
+    [Fact]
+    public async Task Validate_WhenPeriodIsBetweenTwoYears_ReturnsNoValidationError()
+    {
+        // Arrange
+        var periodStartDate = new LocalDateTime(2024, 12, 1, 0, 0, 0)
+            .InZoneStrictly(_dateTimeZone!)
+            .ToInstant();
+
+        var periodEndDate = new LocalDateTime(2025, 1, 1, 0, 0, 0)
+            .InZoneStrictly(_dateTimeZone!)
+            .ToInstant();
+
+        var message = new WholesaleServicesRequestBuilder()
+            .WithPeriodStart(periodStartDate.ToString())
+            .WithPeriodEnd(periodEndDate.ToString())
+            .Build();
+
+        // Act
+        var errors = await _sut.ValidateAsync(message);
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
     private sealed class MockClock(Func<Instant> getInstant) : IClock
     {
         public Instant GetCurrentInstant() => getInstant.Invoke();

--- a/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/PeriodValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/PeriodValidationRule.cs
@@ -131,8 +131,25 @@ public sealed class PeriodValidationRule(
             return;
         }
 
+        // Requests are only valid within a one-month period
         if (zonedEndDateTime.LocalDateTime.Month - zonedStartDateTime.LocalDateTime.Month != 1)
+        {
+            // If the request spans a year in local date time, we need to inspect that the start year and end year is only 1 year a part each other.
+            if (zonedEndDateTime.LocalDateTime.Year - zonedStartDateTime.LocalDateTime.Year == 1)
+            {
+                // Now the only valid month interval spanning a year change would be end month 1, and start month 12.
+                // Example:
+                // StartDate = 2024-12-01T23:00:00Z
+                // EndDate = 2025-01-01T23:00:00Z
+                if (zonedEndDateTime.LocalDateTime.Month - zonedStartDateTime.LocalDateTime.Month == -11)
+                {
+                    // In this case the request start and end would be over the course of yearly change, but would still be valid.
+                    return;
+                }
+            }
+
             errors.Add(_invalidPeriodAcrossMonths);
+        }
     }
 
     private void MustBeMidnight(Instant instant, string propertyName, ICollection<ValidationError> errors)

--- a/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/PeriodValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/PeriodValidationRule.cs
@@ -131,23 +131,8 @@ public sealed class PeriodValidationRule(
             return;
         }
 
-        // Requests are only valid within a one-month period
-        if (zonedEndDateTime.LocalDateTime.Month - zonedStartDateTime.LocalDateTime.Month != 1)
+        if ((zonedEndDateTime.LocalDateTime - zonedStartDateTime.LocalDateTime).Months != 1)
         {
-            // If the request spans a year in local date time, we need to inspect that the start year and end year is only 1 year a part each other.
-            if (zonedEndDateTime.LocalDateTime.Year - zonedStartDateTime.LocalDateTime.Year == 1)
-            {
-                // Now the only valid month interval spanning a year change would be end month 1, and start month 12.
-                // Example:
-                // StartDate = 2024-12-01T23:00:00Z
-                // EndDate = 2025-01-01T23:00:00Z
-                if (zonedEndDateTime.LocalDateTime.Month - zonedStartDateTime.LocalDateTime.Month == -11)
-                {
-                    // In this case the request start and end would be over the course of yearly change, but would still be valid.
-                    return;
-                }
-            }
-
             errors.Add(_invalidPeriodAcrossMonths);
         }
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description
This PR will allow requests for wholesale series which overlap a year on local date time. 
- `PeriodValidationRule` now inspects a if the month differ more than 1 from each other, and the year of start and end period is between each other (1), then the start and end of the month is allowed to be -11
  - Start: 2024-12-01T23:00:00Z, End: 2025-01-01T23:00:00Z

- Added a test to ensure the cased described is working as intended.
<!-- INSERT DESCRIPTION HERE -->

Reference: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/internal-repo/1535
## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
