### PR TITLE
fix: Reallign DataHubNames with EDI

### DIFF
--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/RequestedByActorRoleValidationRuleTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/RequestedByActorRoleValidationRuleTest.cs
@@ -59,7 +59,7 @@ public sealed class RequestedByActorRoleValidationRuleTest
     public async Task ValidateAsync_WhenRequestingWithDdmActorRole_ReturnsDdmShouldRequestAsMdrErrorAsync()
     {
         // Arrange
-        var request = new DataHub.Edi.Requests.AggregatedTimeSeriesRequest { RequestedForActorRole = "GridOperator" };
+        var request = new DataHub.Edi.Requests.AggregatedTimeSeriesRequest { RequestedForActorRole = DataHubNames.ActorRole.GridAccessProvider };
         var rule = new RequestedByActorRoleValidationRule();
 
         // Act

--- a/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/GridAreaValidatorTest.cs
+++ b/source/dotnet/wholesale-api/Edi.UnitTests/Validators/WholesaleServicesRequest/GridAreaValidatorTest.cs
@@ -54,7 +54,7 @@ public class GridAreaValidatorTest
 
         var message = new WholesaleServicesRequestBuilder()
             .WithRequestedByActorId(ValidGlnNumber)
-            .WithRequestedByActorRole(DataHubNames.ActorRole.GridOperator)
+            .WithRequestedByActorRole(DataHubNames.ActorRole.GridAccessProvider)
             .WithGridAreaCode(gridAreaCode)
             .Build();
 
@@ -85,7 +85,7 @@ public class GridAreaValidatorTest
 
         var message = new WholesaleServicesRequestBuilder()
             .WithRequestedByActorId(ValidGlnNumber)
-            .WithRequestedByActorRole(DataHubNames.ActorRole.GridOperator)
+            .WithRequestedByActorRole(DataHubNames.ActorRole.GridAccessProvider)
             .WithGridAreaCode(gridAreaCode)
             .Build();
 
@@ -109,7 +109,7 @@ public class GridAreaValidatorTest
         // Arrange
         var message = new WholesaleServicesRequestBuilder()
             .WithRequestedByActorId(ValidGlnNumber)
-            .WithRequestedByActorRole(DataHubNames.ActorRole.GridOperator)
+            .WithRequestedByActorRole(DataHubNames.ActorRole.GridAccessProvider)
             .WithGridAreaCode(null!)
             .Build();
 
@@ -139,7 +139,7 @@ public class GridAreaValidatorTest
 
         var message = new WholesaleServicesRequestBuilder()
             .WithRequestedByActorId(ValidGlnNumber)
-            .WithRequestedByActorRole(DataHubNames.ActorRole.GridOperator)
+            .WithRequestedByActorRole(DataHubNames.ActorRole.GridAccessProvider)
             .WithGridAreaCode(notExistingGridAreaCode)
             .Build();
 

--- a/source/dotnet/wholesale-api/Edi/Contracts/DataHubNames.cs
+++ b/source/dotnet/wholesale-api/Edi/Contracts/DataHubNames.cs
@@ -17,7 +17,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Energinet.DataHub.Wholesale.Edi.Contracts;
 
 /// <summary>
-/// These domain names are shared between the EDI and Wholesale subsystems
+/// These DataHub domain names are shared between the EDI and Wholesale subsystems
 /// When updating these, you need to manually update the classes in the other subsystem
 /// Files to manually keep in sync:
 /// - EDI: BuildingBlocks.Domain/DataHub/DataHubNames.cs
@@ -34,6 +34,8 @@ public static class DataHubNames
         public const string PreliminaryAggregation = "PreliminaryAggregation";
         public const string WholesaleFixing = "WholesaleFixing";
         public const string Correction = "Correction";
+        public const string PeriodicMetering = "PeriodicMetering";
+        public const string PeriodicFlexMetering = "PeriodicFlexMetering";
     }
 
     public static class ChargeType
@@ -88,11 +90,12 @@ public static class DataHubNames
         public const string MeteredDataResponsible = "MeteredDataResponsible";
         public const string EnergySupplier = "EnergySupplier";
         public const string BalanceResponsibleParty = "BalanceResponsibleParty";
-        public const string GridOperator = "GridOperator";
+        public const string GridAccessProvider = "GridAccessProvider";
         public const string MeteredDataAdministrator = "MeteredDataAdministrator";
         public const string ImbalanceSettlementResponsible = "ImbalanceSettlementResponsible";
         public const string SystemOperator = "SystemOperator";
         public const string DanishEnergyAgency = "DanishEnergyAgency";
         public const string Delegated = "Delegated";
+        public const string DataHubAdministrator = "DataHubAdministrator";
     }
 }

--- a/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSeriesRequest/Rules/RequestedByActorRoleValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/AggregatedTimeSeriesRequest/Rules/RequestedByActorRoleValidationRule.cs
@@ -25,7 +25,7 @@ public sealed class RequestedByActorRoleValidationRule : IValidationRule<DataHub
             DataHubNames.ActorRole.MeteredDataResponsible => new List<ValidationError>(),
             DataHubNames.ActorRole.BalanceResponsibleParty => new List<ValidationError>(),
             DataHubNames.ActorRole.EnergySupplier => new List<ValidationError>(),
-            DataHubNames.ActorRole.GridOperator => new List<ValidationError>
+            DataHubNames.ActorRole.GridAccessProvider => new List<ValidationError>
             {
                 new(
                     "Rollen skal være MDR når der anmodes om beregnede energitidsserier / Role must be MDR when requesting aggregated measure data",

--- a/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/GridAreaValidationRule.cs
+++ b/source/dotnet/wholesale-api/Edi/Validation/WholesaleServicesRequest/Rules/GridAreaValidationRule.cs
@@ -31,7 +31,7 @@ public class GridAreaValidationRule : IValidationRule<DataHub.Edi.Requests.Whole
 
     public async Task<IList<ValidationError>> ValidateAsync(DataHub.Edi.Requests.WholesaleServicesRequest subject)
     {
-        if (subject.RequestedForActorRole != DataHubNames.ActorRole.GridOperator) return NoError;
+        if (subject.RequestedForActorRole != DataHubNames.ActorRole.GridAccessProvider) return NoError;
 
         if (subject.GridAreaCodes.Count == 0)
             return MissingGridAreaCodeError;

--- a/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/WholesaleInboxTriggerTests.cs
+++ b/source/dotnet/wholesale-api/Orchestrations.IntegrationTests/Functions/WholesaleInboxTriggerTests.cs
@@ -111,7 +111,7 @@ public class WholesaleInboxTriggerTests : IAsyncLifetime
             BusinessReason = DataHubNames.BusinessReason.WholesaleFixing,
             GridAreaCodes = { "804" },
             RequestedForActorNumber = "1234567890123",
-            RequestedForActorRole = DataHubNames.ActorRole.GridOperator,
+            RequestedForActorRole = DataHubNames.ActorRole.GridAccessProvider,
             Resolution = DataHubNames.Resolution.Hourly,
         };
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description
This PR will update constants described in the `DataHubNames` in Wholesale to sync them with the ones in EDI.
Wholesale: https://github.com/Energinet-DataHub/opengeh-wholesale/blob/main/source/dotnet/wholesale-api/Edi/Contracts/DataHubNames.cs
EDI: https://github.com/Energinet-DataHub/opengeh-edi/blob/main/source/BuildingBlocks.Domain/DataHub/DataHubNames.cs
<!-- INSERT DESCRIPTION HERE -->

Reference: 
## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
