### PR TITLE
project: add .gitattributes to ensure similar line endings on unix/windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,72 @@
+# Stolen from https://github.com/dotnet/runtime/blob/main/.gitattributes
 
-# Always use Windows line endings.
-# Otherwise lots of files will often show up as changes as we
-# work with the same files on both Windows (.NET development) 
-# and Linux (in Docker container).
-text eol=crlf
+# Set default behavior to automatically normalize line endings.
+* text=auto
 
-# Force bash scripts to always use LF line endings so that if a repo is accessed
+*.doc  diff=astextplain
+*.DOC	diff=astextplain
+*.docx	diff=astextplain
+*.DOCX	diff=astextplain
+*.dot	diff=astextplain
+*.DOT	diff=astextplain
+*.pdf	diff=astextplain
+*.PDF	diff=astextplain
+*.rtf	diff=astextplain
+*.RTF	diff=astextplain
+
+*.jpg  	binary
+*.png 	binary
+*.gif 	binary
+
+*.lss 	text
+
+# Force bash scripts to always use lf line endings so that if a repo is accessed
 # in Unix via a file share from Windows, the scripts will work.
+*.in text eol=lf
 *.sh text eol=lf
+*.tool-versions text eol=lf
+
+# Likewise, force cmd and batch scripts to always use crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+
+*.cs text diff=csharp
+*.vb text
+*.resx text
+*.c text
+*.cpp text
+*.cxx text
+*.h text
+*.hxx text
+*.py text
+*.rb text
+*.java text
+*.html text
+*.htm text
+*.css text
+*.scss text
+*.sass text
+*.less text
+*.js text
+*.lisp text
+*.clj text
+*.sql text
+*.php text
+*.lua text
+*.m text
+*.asm text
+*.erl text
+*.fs text
+*.fsx text
+*.hs text
+
+*.csproj text
+*.vbproj text
+*.fsproj text
+*.dbproj text
+*.sln text eol=crlf
+
+# Set linguist language for .h files explicitly based on
+# https://github.com/github/linguist/issues/1626#issuecomment-401442069
+# this only affects the repo's language statistics
+*.h linguist-language=C


### PR DESCRIPTION
# Description

<!-- INSERT DESCRIPTION HERE -->
Some programs do not work with CRLF line-endings. This file ensures consistency in line-endings based on file extensions. I choose to copy the one used in `dotnet`, as this is a system that is actively being developed on both windows and unix platforms and should therefore have experienced the same pains as we are.

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
