### PR TITLE
Use ubuntu-latest instead of deprecated ubuntu-20.04

### DIFF
--- a/.github/workflows/ci-databricks.yml
+++ b/.github/workflows/ci-databricks.yml
@@ -155,7 +155,7 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/python-ci.yml@v14
     with:
       job_name: ${{ matrix.tests_filter_expression.name }}
-      operating_system: dh3-ubuntu-20.04-4core
+      operating_system: ubuntu-latest
       path_static_checks: ./source/databricks/calculation_engine
       # documented here: https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/databricks#styling-and-formatting
       ignore_errors_and_warning_flake8: E501,F401,E402,E203,W503

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -76,6 +76,7 @@ jobs:
               - '.docker/requirements.txt'
               - 'source/databricks/**'
             calculator_job:
+              - '.github/workflows/ci-databricks.yml'
               - 'source/databricks/calculation_engine/**'
             delta_migrations:
               - 'source/databricks/calculation_engine/package/datamigration/**'


### PR DESCRIPTION
# Description

ubuntu-20.04 is deprecated, brownouts will happen from March 1st

Ref: https://github.com/actions/runner-images/issues/11101