### PR TITLE
Remove large runner reference

### DIFF
--- a/.github/workflows/ci-databricks.yml
+++ b/.github/workflows/ci-databricks.yml
@@ -170,7 +170,6 @@ jobs:
     if: ${{ inputs.has_calculator_job_changes }}
     uses: Energinet-DataHub/.github/.github/workflows/python-ci.yml@v14
     with:
-      operating_system: dh3-ubuntu-20.04-4core
       path_static_checks: ./source/databricks/calculation_engine
       # documented here: https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/databricks#styling-and-formatting
       ignore_errors_and_warning_flake8: E501,F401,E402,E203,W503
@@ -198,7 +197,6 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/python-ci.yml@v14
     with:
       job_name: ${{ matrix.tests_filter_expression.name }}
-      operating_system: dh3-ubuntu-20.04-4core
       path_static_checks: ./source/databricks/calculation_engine
       # documented here: https://github.com/Energinet-DataHub/opengeh-wholesale/tree/main/source/databricks#styling-and-formatting
       ignore_errors_and_warning_flake8: E501,F401,E402,E203,W503


### PR DESCRIPTION
# Description

Ubuntu-22.04 will be deprecated with brownouts starting March 1st

Ref: https://github.com/actions/runner-images/issues/11101