### PR TITLE
doc: Remove 'exchange' from brp data product

### DIFF
--- a/source/databricks/calculation_engine/contracts/data_products/wholesale_results/energy_per_brp_v1.py
+++ b/source/databricks/calculation_engine/contracts/data_products/wholesale_results/energy_per_brp_v1.py
@@ -26,7 +26,7 @@ energy_per_brp_v1 = t.StructType(
         # EIC or GLN number
         t.StructField("balance_responsible_party_id", t.StringType(), not nullable),
         #
-        # 'consumption' | 'production' | 'exchange'
+        # 'consumption' | 'production'
         t.StructField("metering_point_type", t.StringType(), not nullable),
         #
         # 'flex' | 'non_profiled'


### PR DESCRIPTION
# Description

Exchange is not included in energy_per_brp, so the documentation had an error.

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
