### PR TITLE
refac: Cleanup subsystem tests

### DIFF
--- a/source/dotnet/subsystem-tests/Features/Calculations/BalanceFixingCalculationJobScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/BalanceFixingCalculationJobScenario.cs
@@ -43,10 +43,10 @@ public class BalanceFixingCalculationJobScenario : SubsystemTestsBase<Calculatio
         var createdByUserId = Guid.Parse("DED7734B-DD56-43AD-9EE8-0D7EFDA6C783");
         Fixture.ScenarioState.CalculationJobInput = new Calculation(
             createdTime: createdTime,
-            calculationType: Common.Interfaces.Models.CalculationType.Aggregation,
-            gridAreaCodes: new List<GridAreaCode> { new("791") },
-            periodStart: Instant.FromDateTimeOffset(new DateTimeOffset(2022, 11, 30, 23, 0, 0, TimeSpan.Zero)),
-            periodEnd: Instant.FromDateTimeOffset(new DateTimeOffset(2022, 12, 11, 23, 0, 0, TimeSpan.Zero)),
+            calculationType: Common.Interfaces.Models.CalculationType.BalanceFixing,
+            gridAreaCodes: new List<GridAreaCode> { new("543") },
+            periodStart: Instant.FromDateTimeOffset(new DateTimeOffset(2022, 1, 11, 23, 0, 0, TimeSpan.Zero)),
+            periodEnd: Instant.FromDateTimeOffset(new DateTimeOffset(2022, 1, 12, 23, 0, 0, TimeSpan.Zero)),
             scheduledAt: createdTime, // Schedule to run immediately
             dateTimeZone: DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!,
             createdByUserId: createdByUserId,
@@ -75,25 +75,24 @@ public class BalanceFixingCalculationJobScenario : SubsystemTestsBase<Calculatio
     {
         var (isCompleted, run) = await Fixture.WaitForCalculationJobCompletedAsync(
             Fixture.ScenarioState.CalculationJobId,
-            waitTimeLimit: TimeSpan.FromMinutes(75));
+            waitTimeLimit: TimeSpan.FromMinutes(21));
 
         Fixture.ScenarioState.Run = run;
 
         // Assert
         using var assertionScope = new AssertionScope();
-        isCompleted.Should().BeTrue();
+        isCompleted.Should().BeTrue("because calculation job should complete within time limit.");
         run.Should().NotBeNull();
     }
 
     /// <summary>
     /// In this step we verify the 'duration' of the calculation job is within our 'performance goal'.
-    /// This 'duration' is the time we want to reduce during our performance workshop.
     /// </summary>
     [ScenarioStep(3)]
     [SubsystemFact]
     public void AndThen_CalculationJobDurationIsLessThanOrEqualToTimeLimit()
     {
-        var calculationJobTimeLimit = TimeSpan.FromMinutes(70);
+        var calculationJobTimeLimit = TimeSpan.FromMinutes(18);
 
         var actualCalculationJobDuration =
             Fixture.ScenarioState.Run.EndTime - Fixture.ScenarioState.Run.StartTime;

--- a/source/dotnet/subsystem-tests/Features/Calculations/BalanceFixingCalculationJobScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/BalanceFixingCalculationJobScenario.cs
@@ -1,0 +1,105 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Wholesale.Calculations.Application.Model;
+using Energinet.DataHub.Wholesale.Calculations.Application.Model.Calculations;
+using Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations.Fixtures;
+using Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.Attributes;
+using Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.LazyFixture;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NodaTime;
+using Xunit;
+
+namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations;
+
+[ExecutionContext(AzureEnvironment.AllDev)]
+[TestCaseOrderer(
+    ordererTypeName: "Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.Orderers.ScenarioStepOrderer",
+    ordererAssemblyName: "Energinet.DataHub.Wholesale.SubsystemTests")]
+public class BalanceFixingCalculationJobScenario : SubsystemTestsBase<CalculationJobScenarioFixture>
+{
+    public BalanceFixingCalculationJobScenario(LazyFixtureFactory<CalculationJobScenarioFixture> lazyFixtureFactory)
+        : base(lazyFixtureFactory)
+    {
+    }
+
+    [ScenarioStep(0)]
+    [SubsystemFact]
+    public void Given_CalculationJobInput()
+    {
+        var createdTime = SystemClock.Instance.GetCurrentInstant();
+        var createdByUserId = Guid.Parse("DED7734B-DD56-43AD-9EE8-0D7EFDA6C783");
+        Fixture.ScenarioState.CalculationJobInput = new Calculation(
+            createdTime: createdTime,
+            calculationType: Common.Interfaces.Models.CalculationType.Aggregation,
+            gridAreaCodes: new List<GridAreaCode> { new("791") },
+            periodStart: Instant.FromDateTimeOffset(new DateTimeOffset(2022, 11, 30, 23, 0, 0, TimeSpan.Zero)),
+            periodEnd: Instant.FromDateTimeOffset(new DateTimeOffset(2022, 12, 11, 23, 0, 0, TimeSpan.Zero)),
+            scheduledAt: createdTime, // Schedule to run immediately
+            dateTimeZone: DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!,
+            createdByUserId: createdByUserId,
+            version: createdTime.ToDateTimeUtc().Ticks,
+            false);
+    }
+
+    [ScenarioStep(1)]
+    [SubsystemFact]
+    public async Task When_CalculationJobIsStarted()
+    {
+        Fixture.ScenarioState.CalculationJobId = await Fixture.StartCalculationJobAsync(Fixture.ScenarioState.CalculationJobInput);
+
+        // Assert
+        Fixture.ScenarioState.CalculationJobId.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// In this step focus on completing the calculation with a certain 'wait time'.
+    /// This is not an exact time for how long it took to perform the calculation,
+    /// but the time it took for our retry loop to determine that the calculation has completed.
+    /// </summary>
+    [ScenarioStep(2)]
+    [SubsystemFact]
+    public async Task Then_CalculationJobIsCompletedWithinWaitTime()
+    {
+        var (isCompleted, run) = await Fixture.WaitForCalculationJobCompletedAsync(
+            Fixture.ScenarioState.CalculationJobId,
+            waitTimeLimit: TimeSpan.FromMinutes(75));
+
+        Fixture.ScenarioState.Run = run;
+
+        // Assert
+        using var assertionScope = new AssertionScope();
+        isCompleted.Should().BeTrue();
+        run.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// In this step we verify the 'duration' of the calculation job is within our 'performance goal'.
+    /// This 'duration' is the time we want to reduce during our performance workshop.
+    /// </summary>
+    [ScenarioStep(3)]
+    [SubsystemFact]
+    public void AndThen_CalculationJobDurationIsLessThanOrEqualToTimeLimit()
+    {
+        var calculationJobTimeLimit = TimeSpan.FromMinutes(70);
+
+        var actualCalculationJobDuration =
+            Fixture.ScenarioState.Run.EndTime - Fixture.ScenarioState.Run.StartTime;
+
+        // Assert
+        actualCalculationJobDuration.Should().BeGreaterThan(TimeSpan.Zero);
+        actualCalculationJobDuration.Should().BeLessThanOrEqualTo(calculationJobTimeLimit);
+    }
+}

--- a/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationJobScenarioConfiguration.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationJobScenarioConfiguration.cs
@@ -14,6 +14,7 @@
 
 using Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.Configuration;
 using Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.Extensions;
+using Microsoft.Extensions.Configuration;
 
 namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations.Fixtures;
 
@@ -29,10 +30,22 @@ public class CalculationJobScenarioConfiguration : SubsystemTestConfiguration
     {
         var secretsConfiguration = Root.BuildSecretsConfiguration();
         DatabricksWorkspace = DatabricksWorkspaceConfiguration.CreateFromConfiguration(secretsConfiguration);
+        LogAnalyticsWorkspaceId = secretsConfiguration.GetValue<string>("log-shared-workspace-id")!;
+        DatabricksCatalogName = Root.GetValue<string>("DATABRICKS_CATALOG_NAME")!;
     }
 
     /// <summary>
     /// Settings necessary to manage the Databricks workspace.
     /// </summary>
     public DatabricksWorkspaceConfiguration DatabricksWorkspace { get; }
+
+    /// <summary>
+    /// Setting necessary to use the shared Log Analytics workspace.
+    /// </summary>
+    public string LogAnalyticsWorkspaceId { get; }
+
+    /// <summary>
+    /// Setting necessary for specifying the Databricks test catalog.
+    /// </summary>
+    public string DatabricksCatalogName { get; }
 }

--- a/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationJobScenarioConfiguration.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationJobScenarioConfiguration.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.Configuration;
+using Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.Extensions;
+
+namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations.Fixtures;
+
+/// <summary>
+/// Responsible for retrieving settings necessary for performing performance tests of 'CalculationJob' in Databricks.
+///
+/// On developer machines we use the 'subsystemtest.local.settings.json' to set values.
+/// On hosted agents we must set these using environment variables.
+/// </summary>
+public class CalculationJobScenarioConfiguration : SubsystemTestConfiguration
+{
+    public CalculationJobScenarioConfiguration()
+    {
+        var secretsConfiguration = Root.BuildSecretsConfiguration();
+        DatabricksWorkspace = DatabricksWorkspaceConfiguration.CreateFromConfiguration(secretsConfiguration);
+    }
+
+    /// <summary>
+    /// Settings necessary to manage the Databricks workspace.
+    /// </summary>
+    public DatabricksWorkspaceConfiguration DatabricksWorkspace { get; }
+}

--- a/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationJobScenarioFixture.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationJobScenarioFixture.cs
@@ -50,10 +50,6 @@ public sealed class CalculationJobScenarioFixture : LazyFixtureBase
         var runParameters = new DatabricksCalculationParametersFactory()
             .CreateParameters(calculationJobInput);
 
-        runParameters.PythonParams.Add("--metering_point_periods_table_name=metering_point_periods_performance_test");
-        runParameters.PythonParams.Add("--time_series_points_table_name=time_series_points_for_performance_test");
-        runParameters.PythonParams.Add("--grid_loss_metering_points_table_name=grid_loss_responsible_performance_test");
-
         var runId = await DatabricksClient
             .Jobs
             .RunNow(calculatorJobId, runParameters);

--- a/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationJobScenarioFixture.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationJobScenarioFixture.cs
@@ -1,0 +1,130 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.TestCommon;
+using Energinet.DataHub.Wholesale.Calculations.Application.Model;
+using Energinet.DataHub.Wholesale.Calculations.Application.Model.Calculations;
+using Energinet.DataHub.Wholesale.Calculations.Infrastructure.Calculations;
+using Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations.States;
+using Energinet.DataHub.Wholesale.SubsystemTests.Fixtures;
+using Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.Extensions;
+using Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.LazyFixture;
+using Microsoft.Azure.Databricks.Client;
+using Microsoft.Azure.Databricks.Client.Models;
+using Xunit.Abstractions;
+
+namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations.Fixtures;
+
+public sealed class CalculationJobScenarioFixture : LazyFixtureBase
+{
+    public CalculationJobScenarioFixture(IMessageSink diagnosticMessageSink)
+        : base(diagnosticMessageSink)
+    {
+        Configuration = new CalculationJobScenarioConfiguration();
+        ScenarioState = new CalculationJobScenarioState();
+    }
+
+    public CalculationJobScenarioState ScenarioState { get; }
+
+    private CalculationJobScenarioConfiguration Configuration { get; }
+
+    /// <summary>
+    /// The actual client is not created until <see cref="OnInitializeAsync"/> has been called by the base class.
+    /// </summary>
+    private DatabricksClient DatabricksClient { get; set; } = null!;
+
+    public async Task<CalculationJobId> StartCalculationJobAsync(Calculation calculationJobInput)
+    {
+        var calculatorJobId = await DatabricksClient.GetCalculatorJobIdAsync();
+        var runParameters = new DatabricksCalculationParametersFactory()
+            .CreateParameters(calculationJobInput);
+
+        runParameters.PythonParams.Add("--metering_point_periods_table_name=metering_point_periods_performance_test");
+        runParameters.PythonParams.Add("--time_series_points_table_name=time_series_points_for_performance_test");
+        runParameters.PythonParams.Add("--grid_loss_metering_points_table_name=grid_loss_responsible_performance_test");
+
+        var runId = await DatabricksClient
+            .Jobs
+            .RunNow(calculatorJobId, runParameters);
+
+        DiagnosticMessageSink.WriteDiagnosticMessage($"'CalculatorJob' for {calculationJobInput.CalculationType} with id '{runId}' started.");
+
+        return new CalculationJobId(runId);
+    }
+
+    public async Task<(bool IsCompleted, Run? Run)> WaitForCalculationJobCompletedAsync(
+        CalculationJobId calculationJobId,
+        TimeSpan waitTimeLimit)
+    {
+        var delay = TimeSpan.FromMinutes(2);
+
+        (Run, RepairHistory) runState = default;
+        CalculationState? calculationState = CalculationState.Pending;
+        var isCondition = await Awaiter.TryWaitUntilConditionAsync(
+            async () =>
+            {
+                runState = await DatabricksClient.Jobs.RunsGet(calculationJobId.Id);
+                calculationState = ConvertToCalculationState(runState.Item1);
+
+                return
+                    calculationState is CalculationState.Completed
+                    or CalculationState.Failed
+                    or CalculationState.Canceled;
+            },
+            waitTimeLimit,
+            delay);
+
+        DiagnosticMessageSink.WriteDiagnosticMessage($"Wait for 'CalculatorJob' with id '{calculationJobId.Id}' completed with '{nameof(isCondition)}={isCondition}' and '{nameof(calculationState)}={calculationState}'.");
+
+        return (calculationState == CalculationState.Completed, runState.Item1);
+    }
+
+    protected override Task OnInitializeAsync()
+    {
+        DatabricksClient = DatabricksClient.CreateClient(Configuration.DatabricksWorkspace.BaseUrl, Configuration.DatabricksWorkspace.Token);
+
+        return Task.CompletedTask;
+    }
+
+    protected override Task OnDisposeAsync()
+    {
+        DatabricksClient.Dispose();
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Conversion rules was copied from "CalculationEngineClient".
+    /// </summary>
+    private static CalculationState ConvertToCalculationState(Run run)
+    {
+        return run.State.LifeCycleState switch
+        {
+            RunLifeCycleState.PENDING => CalculationState.Pending,
+            RunLifeCycleState.RUNNING => CalculationState.Running,
+            RunLifeCycleState.TERMINATING => CalculationState.Running,
+            RunLifeCycleState.SKIPPED => CalculationState.Canceled,
+            RunLifeCycleState.INTERNAL_ERROR => CalculationState.Failed,
+            RunLifeCycleState.TERMINATED => run.State.ResultState switch
+            {
+                RunResultState.SUCCESS => CalculationState.Completed,
+                RunResultState.FAILED => CalculationState.Failed,
+                RunResultState.CANCELED => CalculationState.Canceled,
+                RunResultState.TIMEDOUT => CalculationState.Canceled,
+                _ => throw new ArgumentOutOfRangeException(nameof(run.State)),
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(run.State)),
+        };
+    }
+}

--- a/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationJobScenarioFixture.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/Fixtures/CalculationJobScenarioFixture.cs
@@ -139,6 +139,51 @@ public sealed class CalculationJobScenarioFixture : LazyFixtureBase
         return results.ToList();
     }
 
+    public async Task<(long? CalculationVersion, string Message)> GetLatestCalculationVersionFromCalculationsAsync()
+    {
+        try
+        {
+            var statement = DatabricksStatement.FromRawSql(
+                $"SELECT calculation_version FROM {Configuration.DatabricksCatalogName}.wholesale_internal.calculations ORDER BY calculation_version DESC LIMIT 1");
+            var queryResult = DatabricksSqlWarehouseQueryExecutor.ExecuteStatementAsync(statement.Build());
+            var item = await queryResult.FirstAsync();
+
+            if (item.calculation_version != null)
+            {
+                return (item.calculation_version, "Calculation version retrieved successfully");
+            }
+
+            return (null, "No data found in the table");
+        }
+        catch (Exception e)
+        {
+            return (null, $"An error occurred: {e.Message}");
+        }
+    }
+
+    public async Task<(long? CalculationVersion, string Message)> GetCalculationVersionOfCalculationIdFromCalculationsAsync(
+        Guid calculationId)
+    {
+        try
+        {
+            var statement = DatabricksStatement.FromRawSql(
+                $"SELECT calculation_version FROM {Configuration.DatabricksCatalogName}.wholesale_internal.calculations WHERE calculation_id = '{calculationId}'");
+            var queryResult = DatabricksSqlWarehouseQueryExecutor.ExecuteStatementAsync(statement.Build());
+            var item = await queryResult.FirstAsync();
+
+            if (item.calculation_version != null)
+            {
+                return (item.calculation_version, "Calculation ID retrieved successfully");
+            }
+
+            return (null, "No data found in the table");
+        }
+        catch (Exception e)
+        {
+            return (null, $"An error occurred: {e.Message}");
+        }
+    }
+
     protected override Task OnInitializeAsync()
     {
         DatabricksClient = DatabricksClient.CreateClient(Configuration.DatabricksWorkspace.BaseUrl, Configuration.DatabricksWorkspace.Token);

--- a/source/dotnet/subsystem-tests/Features/Calculations/States/CalculationJobScenarioState.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/States/CalculationJobScenarioState.cs
@@ -21,6 +21,9 @@ namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations.State
 public class CalculationJobScenarioState
 {
     [NotNull]
+    public long? LatestCalculationVersion { get; set; }
+
+    [NotNull]
     public Calculation? CalculationJobInput { get; set; }
 
     [NotNull]

--- a/source/dotnet/subsystem-tests/Features/Calculations/States/CalculationJobScenarioState.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/States/CalculationJobScenarioState.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using Energinet.DataHub.Wholesale.Calculations.Application.Model.Calculations;
+using Microsoft.Azure.Databricks.Client.Models;
+
+namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations.States;
+
+public class CalculationJobScenarioState
+{
+    [NotNull]
+    public Calculation? CalculationJobInput { get; set; }
+
+    [NotNull]
+    public CalculationJobId? CalculationJobId { get; set; }
+
+    [NotNull]
+    public Run? Run { get; set; }
+}

--- a/source/dotnet/subsystem-tests/Features/Calculations/WholesaleFixingCalculationJobScenario.cs
+++ b/source/dotnet/subsystem-tests/Features/Calculations/WholesaleFixingCalculationJobScenario.cs
@@ -1,0 +1,104 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Wholesale.Calculations.Application.Model;
+using Energinet.DataHub.Wholesale.Calculations.Application.Model.Calculations;
+using Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations.Fixtures;
+using Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.Attributes;
+using Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.LazyFixture;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NodaTime;
+using Xunit;
+
+namespace Energinet.DataHub.Wholesale.SubsystemTests.Features.Calculations;
+
+[ExecutionContext(AzureEnvironment.AllDev)]
+[TestCaseOrderer(
+    ordererTypeName: "Energinet.DataHub.Wholesale.SubsystemTests.Fixtures.Orderers.ScenarioStepOrderer",
+    ordererAssemblyName: "Energinet.DataHub.Wholesale.SubsystemTests")]
+public class WholesaleFixingCalculationJobScenario : SubsystemTestsBase<CalculationJobScenarioFixture>
+{
+    public WholesaleFixingCalculationJobScenario(LazyFixtureFactory<CalculationJobScenarioFixture> lazyFixtureFactory)
+        : base(lazyFixtureFactory)
+    {
+    }
+
+    [ScenarioStep(0)]
+    [SubsystemFact]
+    public void Given_CalculationJobInput()
+    {
+        var createdTime = SystemClock.Instance.GetCurrentInstant();
+        var createdByUserId = Guid.Parse("DED7734B-DD56-43AD-9EE8-0D7EFDA6C783");
+        Fixture.ScenarioState.CalculationJobInput = new Calculation(
+            createdTime: createdTime,
+            calculationType: Common.Interfaces.Models.CalculationType.WholesaleFixing,
+            gridAreaCodes: new List<GridAreaCode> { new("804") },
+            periodStart: Instant.FromDateTimeOffset(new DateTimeOffset(2023, 1, 31, 23, 0, 0, TimeSpan.Zero)),
+            periodEnd: Instant.FromDateTimeOffset(new DateTimeOffset(2023, 2, 28, 23, 0, 0, TimeSpan.Zero)),
+            scheduledAt: createdTime, // Schedule to run immediately
+            dateTimeZone: DateTimeZoneProviders.Tzdb.GetZoneOrNull("Europe/Copenhagen")!,
+            createdByUserId: createdByUserId,
+            version: createdTime.ToDateTimeUtc().Ticks,
+            false);
+    }
+
+    [ScenarioStep(1)]
+    [SubsystemFact]
+    public async Task When_CalculationJobIsStarted()
+    {
+        Fixture.ScenarioState.CalculationJobId = await Fixture.StartCalculationJobAsync(Fixture.ScenarioState.CalculationJobInput);
+
+        // Assert
+        Fixture.ScenarioState.CalculationJobId.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// In this step focus on completing the calculation with a certain 'wait time'.
+    /// This is not an exact time for how long it took to perform the calculation,
+    /// but the time it took for our retry loop to determine that the calculation has completed.
+    /// </summary>
+    [ScenarioStep(2)]
+    [SubsystemFact]
+    public async Task Then_CalculationJobIsCompletedWithinWaitTime()
+    {
+        var (isCompleted, run) = await Fixture.WaitForCalculationJobCompletedAsync(
+            Fixture.ScenarioState.CalculationJobId,
+            waitTimeLimit: TimeSpan.FromMinutes(33));
+
+        Fixture.ScenarioState.Run = run;
+
+        // Assert
+        using var assertionScope = new AssertionScope();
+        isCompleted.Should().BeTrue("because calculation job should complete within time limit.");
+        run.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// In this step we verify the 'duration' of the calculation job is within our 'performance goal'.
+    /// </summary>
+    [ScenarioStep(3)]
+    [SubsystemFact]
+    public void AndThen_CalculationJobDurationIsLessThanOrEqualToTimeLimit()
+    {
+        var calculationJobTimeLimit = TimeSpan.FromMinutes(30);
+
+        var actualCalculationJobDuration =
+            Fixture.ScenarioState.Run.EndTime - Fixture.ScenarioState.Run.StartTime;
+
+        // Assert
+        actualCalculationJobDuration.Should().BeGreaterThan(TimeSpan.Zero);
+        actualCalculationJobDuration.Should().BeLessThanOrEqualTo(calculationJobTimeLimit);
+    }
+}


### PR DESCRIPTION
# Description

- [x] Add subsystem tests that test calculation job at the Databricks level, instead of using the Wholesale Web API and Durable Functions Orchestration

Tested in `dev_002`:
  - First attempt (verify job started and completed): https://github.com/Energinet-DataHub/dh3-environments/actions/runs/13636347750
  - Second attempt (+ verify telemetry and views/tables): https://github.com/Energinet-DataHub/dh3-environments/actions/runs/13636885871
  - Third attempt (+ verify version): https://github.com/Energinet-DataHub/dh3-environments/actions/runs/13647737375

## References

Part of: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/578
