### PR TITLE
chore: logging settings does not take a tracer_name argument

### DIFF
--- a/source/databricks/calculation_engine/package/optimize_job/delta_optimization.py
+++ b/source/databricks/calculation_engine/package/optimize_job/delta_optimization.py
@@ -38,7 +38,7 @@ def optimize_tables(catalog_name: str | None = None) -> None:
     )
     logging_settings = config.LoggingSettings(
         cloud_role_name="dbr-optimize-tables",
-        tracer_name="optimize-tables-job",
+        subsystem="optimize-tables-job",
         applicationinsights_connection_string=applicationinsights_connection_string,
     )
     config.configure_logging(logging_settings=logging_settings)


### PR DESCRIPTION
# Description

<img width="787" alt="image" src="https://github.com/user-attachments/assets/6b79835e-0238-48ac-bf12-13ecac6e2885" />

Related: https://adb-1539466176548659.19.azuredatabricks.net/jobs/875821125385795/runs/355939263789729?o=1539466176548659

<!-- INSERT DESCRIPTION HERE -->

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
