### PR TITLE
bug: Removed metering point type from measurements gold table

### DIFF
--- a/source/geh_wholesale/src/geh_wholesale/databases/migrations_wholesale/repository.py
+++ b/source/geh_wholesale/src/geh_wholesale/databases/migrations_wholesale/repository.py
@@ -79,11 +79,7 @@ class MigrationsWholesaleRepository:
             )
 
             # Later in the flow assert_schema will fails if the column "metering_point_type" is present.
-            # Therefore, it is dropped here.
-            if "metering_point_type" in df.columns:
-                df = df.drop("metering_point_type")
-
-            # Reorder the columns to match time series point schema.
+            # Therefore, it is dropped here. The columns are also reordered to match the schema.
             df = df.select(
                 Colname.metering_point_id,
                 Colname.quantity,

--- a/source/geh_wholesale/src/geh_wholesale/databases/migrations_wholesale/repository.py
+++ b/source/geh_wholesale/src/geh_wholesale/databases/migrations_wholesale/repository.py
@@ -4,6 +4,7 @@ from geh_common.data_products.measurements_core.measurements_gold.current_v1 imp
 )
 from pyspark.sql import DataFrame, SparkSession
 
+from geh_wholesale.constants import Colname
 from geh_wholesale.databases.feature_flag_manager import FeatureFlags
 from geh_wholesale.infrastructure.paths import (
     MeasurementsGoldDatabase,
@@ -69,13 +70,29 @@ class MigrationsWholesaleRepository:
         # If the flag is enabled time series points are fetched from measurements gold table,
         # otherwise from migrations table.
         if self._feature_manager.is_enabled(FeatureFlags.measuredata_measurements):  # type: ignore
-            return read_table(
+            df = read_table(
                 self._spark,
                 self._catalog_name,
                 self._measurements_gold_database_name,
                 self._measurements_current_v1_table_name,
                 measurements_current_v1_schmea,
             )
+
+            # Later in the flow assert_schema will fails if the column "metering_point_type" is present.
+            # Therefore, it is dropped here.
+            if "metering_point_type" in df.columns:
+                df = df.drop("metering_point_type")
+
+            # Reorder the columns to match time series point schema.
+            df = df.select(
+                Colname.metering_point_id,
+                Colname.quantity,
+                Colname.quality,
+                Colname.observation_time,
+            )
+
+            return df
+
         else:
             return read_table(
                 self._spark,

--- a/source/geh_wholesale/tests/databases/migrations_wholesale/repository/test_read_time_series_points.py
+++ b/source/geh_wholesale/tests/databases/migrations_wholesale/repository/test_read_time_series_points.py
@@ -10,13 +10,13 @@ from featuremanagement import FeatureManager
 from geh_common.data_products.measurements_core.measurements_gold import current_v1 as measurements_gold_current_v1
 from pyspark.sql import SparkSession
 
+from geh_wholesale.codelists import MeteringPointType
 from geh_wholesale.constants import Colname
 from geh_wholesale.databases.migrations_wholesale import MigrationsWholesaleRepository
-from geh_wholesale.databases.migrations_wholesale.repository import measurements_current_v1_schmea
 from geh_wholesale.databases.migrations_wholesale.schemas import time_series_points_schema
 from geh_wholesale.infrastructure.paths import MigrationsWholesaleDatabase
 from tests import SPARK_CATALOG_NAME
-from tests.helpers.data_frame_utils import assert_dataframes_equal
+from tests.helpers.data_frame_utils import assert_dataframes_equal, assert_schema
 from tests.helpers.delta_table_utils import write_dataframe_to_table
 
 
@@ -28,6 +28,18 @@ def _create_time_series_point_row(
         Colname.quantity: Decimal("1.123456"),
         Colname.quality: "foo",
         Colname.observation_time: datetime(2022, 6, 8, 22, 0, 0),
+    }
+
+
+def _create_current_v1_row(
+    metering_point_id: str = "some-metering-point-id",
+) -> dict:
+    return {
+        Colname.metering_point_id: metering_point_id,
+        Colname.quantity: Decimal("1.123456"),
+        Colname.quality: "foo",
+        Colname.observation_time: datetime(2022, 6, 8, 22, 0, 0),
+        "metering_point_type": MeteringPointType.CONSUMPTION.value,
     }
 
 
@@ -140,7 +152,7 @@ class TestFeatureFlagWhenToggling:
         mock_feature_manager_true: FeatureManager,
     ) -> None:
         # Arrange
-        reader = MigrationsWholesaleRepository(
+        repository = MigrationsWholesaleRepository(
             spark, mock_feature_manager_true, SPARK_CATALOG_NAME, "test_database", "test_database2"
         )
 
@@ -148,7 +160,7 @@ class TestFeatureFlagWhenToggling:
         with patch(
             "geh_wholesale.databases.migrations_wholesale.repository.read_table",
         ) as read_table_mock:
-            reader.read_time_series_points()
+            repository.read_time_series_points()
 
             # Assert
             read_table_mock.assert_called_once_with(
@@ -158,3 +170,24 @@ class TestFeatureFlagWhenToggling:
                 measurements_gold_current_v1.view_name,
                 measurements_current_v1_schmea,
             )
+
+    def test_dropping_column_when_reading_from_measurements_gold_table(
+        self,
+        spark: SparkSession,
+        mock_feature_manager_true: FeatureManager,
+    ) -> None:
+        # Arrange
+        row = _create_current_v1_row()
+        df = spark.createDataFrame(data=[row], schema=measurements_gold_current_v1.schema)
+
+        with mock.patch("geh_wholesale.databases.migrations_wholesale.repository.read_table", return_value=df):
+            repository = MigrationsWholesaleRepository(
+                spark, mock_feature_manager_true, SPARK_CATALOG_NAME, "test_database", "test_database2"
+            )
+
+            # Act
+            actual = repository.read_time_series_points()
+
+            # Assert
+            assert "metering_point_type" not in actual.columns
+            assert_schema(actual.schema, time_series_points_schema)

--- a/source/geh_wholesale/tests/databases/migrations_wholesale/repository/test_read_time_series_points.py
+++ b/source/geh_wholesale/tests/databases/migrations_wholesale/repository/test_read_time_series_points.py
@@ -150,7 +150,7 @@ class TestFeatureFlagWhenToggling:
                 SPARK_CATALOG_NAME,
                 "dummy_database_name2",
                 measurements_gold_current_v1.view_name,
-                measurements_current_v1_schmea,
+                measurements_gold_current_v1.schema,
             )
 
     def test_dropping_column_when_reading_from_measurements_gold_table(
@@ -174,7 +174,7 @@ class TestFeatureFlagWhenToggling:
             assert "metering_point_type" not in actual.columns
             assert_schema(actual.schema, time_series_points_schema)
 
-            
+
 def create_migration_wholesale_repository(
     spark: SparkSession = mock.Mock(),
     feature_manager_mock: FeatureManager = mock.Mock(),


### PR DESCRIPTION
Migration time series points table and measurements gold are not equal.
To make them equal, the metering point type is removed from the measurements gold table.

Test added too.
